### PR TITLE
Github workflow for LabExT

### DIFF
--- a/.github/workflows/labext-ci.yml
+++ b/.github/workflows/labext-ci.yml
@@ -1,0 +1,23 @@
+name: LabExT CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Running tests
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py38, mypy
+
+[gh-actions]
+python =
+    3.8: py38, mypy
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
# Goal
Setup of a CI for LabExT to run tests automatically for each push. This can also be used for linters later.

# Approach
Use of a Github action, which is triggered for every push. In addition, Tox is used, which is a wrapper for pytest. Tox first generates a package from the code and then calls pytest to run all tests (files with * _test.py).
Further information can be found at: https://github.com/tox-dev/tox

# Compatibility
This PR does not introduce any new functions in LabExT, but only sets up GitHub for CI. Nevertheless, all runs will fail because pytest has not yet found any tests and so exits with status code 1. 