### PR TITLE
[Movement] Stop method for SmarAct stages

### DIFF
--- a/LabExT/Movement/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stage3DSmarAct.py
@@ -251,6 +251,16 @@ class Stage3DSmarAct(Stage):
                 raise ValueError("Invalid movement mode {}".format(str(mode)))
             self._movement_mode = mode
 
+        # Channel control
+
+        def stop(self) -> None:
+            """Stops all movement of this channel"""
+            self._stage._exit_if_error(
+                MCSC.SA_Stop_S(
+                    self._stage.handle,
+                    self._handle
+                ))
+
         # Movement
 
         def move(
@@ -588,6 +598,12 @@ class Stage3DSmarAct(Stage):
             diff=pos[0], mode=MovementType.ABSOLUTE)
         self.channels[Axis.Y].move(
             diff=pos[1], mode=MovementType.ABSOLUTE)
+
+    # Stage control
+
+    def stop(self):
+        for channel in self.channels.values():
+            channel.stop()
 
     # Helper methods
 

--- a/LabExT/Tests/Movement/Stage3DSmarAct/Channel_test.py
+++ b/LabExT/Tests/Movement/Stage3DSmarAct/Channel_test.py
@@ -367,3 +367,15 @@ class ChannelTest(SmarActTestCase):
 
         self.mcsc_mock.SA_FindReferenceMark_S.assert_called_once_with(
             self.stage.handle, self.channel._handle, 1, 0, 1)
+
+    # Testing channel control
+
+    def test_channel_stop(self):
+        self.mcsc_mock.SA_Stop_S = Mock(return_value=self.MCSC_STATUS_OK)
+
+        self.channel.stop()
+
+        self.mcsc_mock.SA_Stop_S.assert_called_once_with(
+            self.stage.handle,
+            self.channel._handle
+        )


### PR DESCRIPTION
**Don't merge before https://github.com/LabExT/LabExT/pull/11**

# Goal
Add a "kill-switch" for stages.

# Approach
By invoking the driver method `SA_Stop_S`, all stage movement will be stopped. We can later introduce a keyboard shortcut that automatically stops all movements in case the user detects dangerous movements of the stages.

# Compatibility
This will not break anything.