### PR TITLE
Feature: Limit y-axis scaling in live viewer

### DIFF
--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -154,6 +154,11 @@ class LiveViewerController:
         parameters :
             List of new parameters
         """
+
+        #
+        # update x axis length
+        #
+
         # load the number of points kept
         nopk = parameters['number of points kept'].value
         # find the difference in plot size
@@ -182,6 +187,14 @@ class LiveViewerController:
 
         # set the number of point kepts in the model structure
         self.model.plot_size = nopk
+
+        #
+        # update min y span
+        #
+
+        min_y = parameters['minimum y-axis span'].value
+        self.model.live_plot.min_y_axis_span = min_y
+        self.model.min_y_span = min_y
 
     def remove_card(self, index):
         """ Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -5,7 +5,7 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from LabExT.Measurements.MeasAPI import MeasParamInt
+from LabExT.Measurements.MeasAPI import MeasParamInt, MeasParamFloat
 
 from LabExT.ViewModel.Utilities.ObservableList import ObservableList
 
@@ -26,7 +26,8 @@ class LiveViewerModel:
         # these are the general settings
         self.general_settings = {
             # number of points kept
-            'number of points kept': MeasParamInt(value=100)
+            'number of points kept': MeasParamInt(value=100),
+            'minimum y-axis span': MeasParamFloat(value=4.0),
         }
 
         # the plot collection, which is used for the plotting frame
@@ -47,3 +48,6 @@ class LiveViewerModel:
 
         # the number of points kept
         self.plot_size = 100
+
+        # the minimum y span
+        self.min_y_span = 4.0

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -225,7 +225,8 @@ class PlotWidget (PlotControl):
                              add_toolbar=True,
                              figsize=(12, 6),
                              autoscale_axis=True,
-                             no_x_autoscale=True
+                             no_x_autoscale=True,
+                             min_y_axis_span=None
                              )
 
         self.parent = parent
@@ -237,9 +238,11 @@ class PlotWidget (PlotControl):
         self.show_grid = True
         self.data_source = self.model.plot_collection
 
-        self.ax.set_xlim([0, 99])
+        current_nopk = self.model.general_settings['number of points kept'].value
+        current_y_min = self.model.general_settings['minimum y-axis span'].value
 
-        self.model.live_plot = self
+        self.ax.set_xlim([0, current_nopk])
+        self.min_y_axis_span = current_y_min
 
     def destroy(self):
         # this is a workaround for the LiveViewer thread


### PR DESCRIPTION
# Goal
Add live-viewer feature: limit y-axis scaling to minimum.

When using the live viewer, the y-axis currently is scaled to always show the total y-axis range + 20%. This could mean that the y-axis spans about 0.2 dB during optical coupling, which is too small to make sense. Ideally, we want to lower-limit to 1 to 2 dB y axis range.

# Approach
Adding the property `min_y_axis_span` to PlotControl plus the scale limiting in `__handle_scaling__`. Further, the LiveViewer controller sets the attribute on clicking the apply settings button.

# Compatibility
No compatibility issues expected, its just a small added feature to PlotControl which is disabled by default.