### PR TITLE
[Movement] (1/3) MovementWizard: Manage connection to stages

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -18,6 +18,7 @@ from LabExT.Experiments.StandardExperiment import StandardExperiment
 from LabExT.Instruments.InstrumentAPI import InstrumentAPI
 from LabExT.Instruments.ReusingResourceManager import ReusingResourceManager
 from LabExT.Movement.Mover import Mover
+from LabExT.Movement.MoverNew import MoverNew
 from LabExT.SearchForPeak.PeakSearcher import PeakSearcher
 from LabExT.Utils import DeprecatedException, get_configuration_file_path, get_visa_lib_string
 from LabExT.View.Controls.KeyboardShortcutButtonPress import callback_if_btn_enabled
@@ -65,6 +66,7 @@ class ExperimentManager:
         self.addon_settings = None
         self.chip = chip
         self.mover = Mover(self)
+        self.mover_new = MoverNew(self)
         self.peak_searcher = PeakSearcher(None, self, mover=self.mover, parent=self.root)
         self.instrument_api = InstrumentAPI(self)
         self.docu = None

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import logging
+from typing import Type, List
+from functools import wraps
+
+from LabExT.Movement.Stage import Stage
+
+
+def assert_connected_stages(func):
+    """
+    Use this decorator to assert that the mover has at least one connected stage,
+    when calling methods, which require connected stages.
+    """
+
+    @wraps(func)
+    def wrapper(mover, *args, **kwargs):
+        if mover.all_disconnected:
+            raise MoverError(
+                "Function {} needs at least one connected stage. Please use the connection functions beforehand".format(
+                    func.__name__))
+
+        return func(mover, *args, **kwargs)
+    return wrapper
+
+
+class MoverError(RuntimeError):
+    pass
+
+
+class MoverNew:
+    DEFAULT_SPEED_XY = 200
+    DEFAULT_SPPED_Z = 20
+    DEFAULT_Z_LIFT = 20
+
+    def __init__(self, experiment_manager):
+        """Constructor.
+
+        Parameters
+        ----------
+        experiment_manager : ExperimentManager
+            Current instance of ExperimentManager.
+        """
+        self.experiment_manager = experiment_manager
+        self.logger = logging.getLogger()
+
+        self._stages: List[Type[Stage]] = Stage.discovery()
+
+        self._speed_xy = self.DEFAULT_SPEED_XY
+        self._speed_z = self.DEFAULT_SPPED_Z
+        self._z_lift = self.DEFAULT_Z_LIFT
+
+    def __del__(self):
+        """Collects all settings and stores them in a file"""
+        pass
+
+    @property
+    def stages(self):
+        return self._stages
+
+    @property
+    def connected_stages(self):
+        return list(filter(lambda s: s.connected, self.stages))
+
+    @property
+    def disconnected_stages(self):
+        return list(filter(lambda s: not s.connected, self.stages))
+
+    @property
+    def all_connected(self):
+        if len(self.stages) == 0:
+            return False
+        return len(self.connected_stages) == len(self.stages)
+
+    @property
+    def all_disconnected(self):
+        if len(self.stages) == 0:
+            return True
+        return len(self.disconnected_stages) == len(self.stages)
+
+    #
+    #   Connectivity methods
+    #
+
+    def connect(self):
+        if not self.stages:
+            raise MoverError(
+                "No stages found to connect. Please check your devices.")
+
+        for stage in self.stages:
+            stage.connect()
+
+    def connect_stage_by_index(self, stage_idx: int):
+        if not self.stages:
+            raise MoverError(
+                "No stages found to connect. Please check your devices.")
+
+        self.stages[stage_idx].connect()
+
+    @assert_connected_stages
+    def disconnect(self):
+        for stage in self.connected_stages:
+            stage.disconnect()
+
+    @assert_connected_stages
+    def disconnect_stage_by_index(self, stage_idx: int):
+        if not self.stages[stage_idx].connected:
+            return
+
+        self.stages[stage_idx].disconnect()

--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -39,6 +39,16 @@ class Stage(ABC):
     _logger = logging.getLogger()
     driver_loaded = False
 
+    _META_DESCRIPTION = ''
+    _META_CONNECTION_TYPE = ''
+
+    @classmethod
+    def discovery(cls):
+        stages = []
+        for stage_class in cls.__subclasses__():
+            stages += stage_class.find_stages()
+        return stages
+
     @classmethod
     def find_stages(cls):
         raise NotImplementedError
@@ -49,7 +59,8 @@ class Stage(ABC):
         self.connected = False
 
     def __del__(self):
-        self.disconnect()
+        if self.connected:
+            self.disconnect()
 
     @abstractmethod
     def connect(self) -> bool:

--- a/LabExT/Movement/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stage3DSmarAct.py
@@ -341,6 +341,11 @@ class Stage3DSmarAct(Stage):
     # Find SmarAct system
     @classmethod
     def find_stages(cls):
+        stages = []
+
+        if not cls.driver_loaded:
+            return stages
+
         out_buffer = ct.create_string_buffer(4096)
         buffer_size = ct.c_ulong(4096)
         if cls._exit_if_error(
@@ -349,8 +354,12 @@ class Stage3DSmarAct(Stage):
                 out_buffer,
                 buffer_size)):
             if buffer_size != ct.c_ulong(0):
-                return out_buffer.value.decode().split()
-        return []
+                stages += [
+                    Stage3DSmarAct(address.encode('utf-8'))
+                    for address in out_buffer.value.decode().split()
+                ]
+
+        return stages
 
     # Setup and initialization
 

--- a/LabExT/Tests/Movement/Mover_test.py
+++ b/LabExT/Tests/Movement/Mover_test.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from LabExT.Movement.MoverNew import MoverNew, MoverError, assert_connected_stages
+from LabExT.Movement.Stage import Stage
+
+
+class MoverBaseCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expermiment_manager = Mock()
+        cls.connected_stage = Mock(connected=True)
+        cls.disconnected_stage = Mock(connected=False)
+        with patch.object(Stage, 'discovery', return_value=[cls.connected_stage, cls.disconnected_stage]):
+            cls.mover = MoverNew(cls.expermiment_manager)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        del cls.expermiment_manager
+
+    def tearDown(self) -> None:
+        self.connected_stage.reset_mock()
+        self.disconnected_stage.reset_mock()
+
+    #
+    #   Testing Decorators
+    #
+
+    def test_assert_connected_stages_calls_function(self):
+        func = Mock()
+        func.__name__ = 'Dummy Function'
+        assert_connected_stages(func)(self.mover)
+        func.assert_called_once()
+
+    #
+    #   Testing Mover Properties
+    #
+
+    def test_stage_filtering(self):
+        self.assertListEqual(
+            self.mover.connected_stages, [
+                self.connected_stage])
+        self.assertListEqual(
+            self.mover.disconnected_stages, [
+                self.disconnected_stage])
+
+    def test_all_connected(self):
+        self.assertFalse(self.mover.all_connected)
+
+    def test_all_disconnected(self):
+        self.assertFalse(self.mover.all_disconnected)
+
+    
+    #
+    #   Testing Stage Connection
+    #
+
+    def test_connect_to_all(self):
+        self.mover.connect()
+
+        self.connected_stage.connect.assert_called_once()
+        self.disconnected_stage.connect.assert_called_once()
+
+    def test_connect_to_stage_by_index(self):
+        self.mover.connect_stage_by_index(1)
+
+        self.connected_stage.connect.assert_not_called()
+        self.disconnected_stage.connect.assert_called_once()
+
+    def test_disconnect_to_all(self):
+        self.mover.disconnect()
+
+        self.connected_stage.disconnect.assert_called_once()
+        self.disconnected_stage.disconnect.assert_not_called()
+
+    def test_connect_to_stage_by_index(self):
+        self.mover.disconnect_stage_by_index(0)
+
+        self.connected_stage.disconnect.assert_called_once()
+        self.disconnected_stage.disconnect.assert_not_called()
+
+class EmptyStagePoolCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expermiment_manager = Mock()
+        with patch.object(Stage, 'discovery', return_value=[]):
+            cls.mover = MoverNew(cls.expermiment_manager)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        del cls.expermiment_manager
+
+    #
+    #   Testing Decorators
+    #
+
+    def test_assert_connected_stages_calls_function(self):
+        func = Mock()
+        func.__name__ = 'Dummy Function'
+
+        with self.assertRaises(MoverError):
+            assert_connected_stages(func)(self.mover)
+
+        func.assert_not_called()
+
+    #
+    #   Testing Mover Properties
+    #
+
+    def test_stage_filtering(self):
+        self.assertListEqual(self.mover.connected_stages, [])
+        self.assertListEqual(self.mover.disconnected_stages, [])
+
+    def test_all_connected(self):
+        self.assertFalse(self.mover.all_connected)
+
+    def test_all_disconnected(self):
+        self.assertTrue(self.mover.all_disconnected)
+
+    #
+    #   Testing Stage Connection
+    #
+
+    def test_connect_to_all_raises_error(self):
+        with self.assertRaises(MoverError):
+            self.mover.connect()
+
+    def test_connect_to_stage_by_index_raises_error(self):
+        with self.assertRaises(MoverError):
+            self.mover.connect_stage_by_index(0)
+
+
+class AllConnectedPoolCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expermiment_manager = Mock()
+        cls.connected_stage = Mock(connected=True)
+        with patch.object(Stage, 'discovery', return_value=[cls.connected_stage]):
+            cls.mover = MoverNew(cls.expermiment_manager)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        del cls.expermiment_manager
+
+    def tearDown(self) -> None:
+        self.connected_stage.reset_mock()
+
+    #
+    #   Testing Decorators
+    #
+
+    def test_assert_connected_stages_calls_function(self):
+        func = Mock()
+        func.__name__ = 'Dummy Function'
+
+        assert_connected_stages(func)(self.mover)
+
+        func.assert_called_once()
+
+    #
+    #   Testing Mover Properties
+    #
+
+    def test_stage_filtering(self):
+        self.assertListEqual(
+            self.mover.connected_stages, [
+                self.connected_stage])
+        self.assertListEqual(self.mover.disconnected_stages, [])
+
+    def test_all_connected(self):
+        self.assertTrue(self.mover.all_connected)
+
+    def test_all_disconnected(self):
+        self.assertFalse(self.mover.all_disconnected)
+
+
+class AllDisconnectedPoolCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expermiment_manager = Mock()
+        cls.disconnected_stage = Mock(connected=False)
+        with patch.object(Stage, 'discovery', return_value=[cls.disconnected_stage]):
+            cls.mover = MoverNew(cls.expermiment_manager)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        del cls.expermiment_manager
+
+    def tearDown(self) -> None:
+        self.disconnected_stage.reset_mock()
+
+    #
+    #   Testing Decorators
+    #
+
+    def test_assert_connected_stages_raises_error(self):
+        func = Mock()
+        func.__name__ = 'Dummy Function'
+
+        with self.assertRaises(MoverError):
+            assert_connected_stages(func)(self.mover)
+
+        func.assert_not_called()
+
+    #
+    #   Testing Mover Properties
+    #
+
+    def test_stage_filtering(self):
+        self.assertListEqual(self.mover.connected_stages, [])
+        self.assertListEqual(
+            self.mover.disconnected_stages, [
+                self.disconnected_stage])
+
+    def test_all_connected(self):
+        self.assertFalse(self.mover.all_connected)
+
+    def test_all_disconnected(self):
+        self.assertTrue(self.mover.all_disconnected)

--- a/LabExT/Tests/Movement/Stage3DSmarAct/SmarActTestCase.py
+++ b/LabExT/Tests/Movement/Stage3DSmarAct/SmarActTestCase.py
@@ -8,6 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import ctypes as ct
 import json
 import unittest
+from importlib import reload
 from unittest.mock import Mock, patch, DEFAULT, mock_open
 
 from LabExT.Utils import get_configuration_file_path

--- a/LabExT/View/ApplicationController.py
+++ b/LabExT/View/ApplicationController.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ApplicationController(ABC):
+    @abstractmethod
+    def __init__(self, parent, experiment_manager) -> None:
+        self.parent = parent
+        self.experiment_manager = experiment_manager

--- a/LabExT/View/ApplicationView.py
+++ b/LabExT/View/ApplicationView.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import messagebox
+
+
+class ApplicationView:
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def error(self):
+        pass
+
+    @error.setter
+    def error(self, message):
+        messagebox.showerror(title="An error has occurred", message=message)
+
+    @property
+    def info(self):
+        pass
+
+    @info.setter
+    def info(self, message):
+        messagebox.showinfo(title="Information", message=message)

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -31,12 +31,14 @@ class MainWindowContextMenu(Menu):
         Menu.__init__(self, self.parent)
         self._file = Menu(self, tearoff=0)
         self._movement = Menu(self, tearoff=0)
+        self._movement_new = Menu(self, tearoff=0)
         self._view = Menu(self, tearoff=0)
         self._settings = Menu(self, tearoff=0)
         self._help = Menu(self, tearoff=0)
 
         self.add_cascade(label="File", menu=self._file)
         self.add_cascade(label="Movement", menu=self._movement)
+        self.add_cascade(label="Movement [Beta]", menu=self._movement_new)
         self.add_cascade(label="View", menu=self._view)
         self.add_cascade(label="Settings", menu=self._settings)
         self.add_cascade(label="Help", menu=self._help)
@@ -71,6 +73,10 @@ class MainWindowContextMenu(Menu):
         self._movement.add_command(
             label="Search for Peak",
             command=self._menu_listener.client_search_for_peak)
+
+        self._movement_new.add_command(
+            label="Open Stage Configuration",
+            command=self._menu_listener.client_movement_wizard)
 
         self._view.add_command(
             label="Open Extra Plots",

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -23,6 +23,7 @@ from LabExT.View.ExtraPlots import ExtraPlots
 from LabExT.View.InstrumentConnectionDebugger import InstrumentConnectionDebugger
 from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
 from LabExT.View.MoveDeviceWindow import MoveDeviceWindow
+from LabExT.View.MovementWizard.MovementWizardController import MovementWizardController
 from LabExT.View.ProgressBar.ProgressBar import ProgressBar
 from LabExT.View.SearchForPeakPlotsWindow import SearchForPeakPlotsWindow
 from LabExT.View.StageDriverSettingsDialog import StageDriverSettingsDialog
@@ -190,6 +191,10 @@ class MListener:
         new_window = Toplevel(self._root)
         new_window.lift()
         ConfigureStageWindow(new_window, self._experiment_manager)
+
+    def client_movement_wizard(self):
+        self._movement_wizard = MovementWizardController(self._root, self._experiment_manager)
+        self._movement_wizard.new()
 
     def client_move_stages(self):
         """Called when the user wants to move the stages manually.

--- a/LabExT/View/MovementWizard/MovementWizardController.py
+++ b/LabExT/View/MovementWizard/MovementWizardController.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from typing import Type
+from tkinter import Tk
+
+from LabExT.Movement.Stage import StageError, Stage
+from LabExT.View.ApplicationController import ApplicationController
+from LabExT.View.MovementWizard.MovementWizardView import MovementWizardView
+from LabExT.Movement.MoverNew import MoverNew
+
+
+class MovementWizardController(ApplicationController):
+    def __init__(self, parent: Type[Tk], experiment_manager) -> None:
+        super().__init__(parent, experiment_manager)
+        self.mover: Type[MoverNew] = experiment_manager.mover_new
+        self.view = MovementWizardView(parent, self, self.mover)
+
+    #
+    # View Controller methods
+    #
+
+    def new(self):
+        """
+        Creates View to configure stages
+        """
+        self.view.connection_frame()
+
+    #
+    # Stage Management methods
+    #
+
+    def connect_to_all_stages(self):
+        try:
+            self.mover.connect()
+            self.view.info = "Successfully connected to {} stages.".format(
+                len(self.mover.stages))
+        except StageError as exce:
+            self.view.error = """Connection establishment to the stages failed: \n {} \n
+							     Please check if all drivers are loaded and all stages are connected correctly.
+							  """.format(exce)
+        finally:
+            self.new()
+
+    def connect_to_single_stage_by_poll_index(self, stage_idx: int):
+        try:
+            self.mover.connect_stage_by_index(stage_idx)
+            self.view.info = "Successfully connected to stage {}.".format(
+                stage_idx)
+        except (StageError, KeyError) as exce:
+            self.view.error = """Connection establishment to stage {} failed: \n {} \n
+							     Please check if all drivers are loaded and all stages are connected correctly.
+							  """.format(stage_idx, exce)
+        finally:
+            self.new()
+
+    def disconnect_to_all_stages(self):
+        try:
+            self.mover.disconnect()
+            self.view.info = "Successfully disconnected {} stages.".format(
+                len(self.mover.stages))
+        except StageError as exce:
+            self.view.error = """Connection teardown for stages failed: \n {} \n
+							     Please check if all drivers are loaded and all stages are connected correctly.
+							  """.format(exce)
+        finally:
+            self.new()
+
+    def disconnect_to_single_stage_by_poll_index(self, stage_idx: int):
+        try:
+            self.mover.disconnect_stage_by_index(stage_idx)
+            self.view.info = "Successfully disconnected stage {}.".format(
+                stage_idx)
+        except (StageError, KeyError) as exce:
+            self.view.error = """Connection teardown for stage {} failed: \n {} \n
+							     Please check if all drivers are loaded and all stages are connected correctly.
+							  """.format(stage_idx, exce)
+        finally:
+            self.new()

--- a/LabExT/View/MovementWizard/MovementWizardView.py
+++ b/LabExT/View/MovementWizard/MovementWizardView.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Button, Toplevel, DISABLED, NORMAL
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.CustomTable import CustomTable
+from LabExT.View.ApplicationView import ApplicationView
+
+class MovementWizardView(ApplicationView):
+    def __init__(self, parent, controller, mover) -> None:
+        self.parent = parent
+        self.controller = controller
+        self.mover = mover
+
+        self.main_window = Toplevel(self.parent)
+        self.main_window.title("Movement Wizard")
+        self.main_window.rowconfigure(2, weight=1)
+        self.main_window.columnconfigure(0, weight=1)
+        self.main_window.focus_force()
+
+        self._selection_table = None
+
+    def connection_frame(self, row=1) -> None:
+        connection_frame = CustomFrame(self.main_window)
+        connection_frame.title = "Stage Connection Manager"
+        connection_frame.grid(row=row, column=0, columnspan=2, padx=5, pady=5, sticky='nswe')
+        connection_frame.columnconfigure(1, weight=1)
+
+        available_stages_frame = CustomFrame(connection_frame)
+        available_stages_frame.title = "Available Stages"
+        available_stages_frame.grid(row=2, column=0, columnspan=4, padx=5, pady=5, sticky='nswe')
+        available_stages_frame.columnconfigure(0, weight=1)
+        available_stages_frame.rowconfigure(0, weight=1)
+
+        self._selection_table = CustomTable(
+            parent=available_stages_frame,
+            columns=('ID', 'Stage Description', 'Stage Class', 'Connection Type', 'Connection Address', 'Connected', 'Status'),
+            rows=[(
+                id,
+                s.__class__._META_DESCRIPTION,
+                s.__class__.__name__,
+                s.__class__._META_CONNECTION_TYPE,
+                s.address.encode('utf-8'),
+                s.connected,
+                s.get_status() if s.connected else '-- NO STATUS --'
+            ) for id, s in enumerate(self.mover.stages)],
+            selectmode='extended'
+        )
+
+        Button(
+            connection_frame,
+            text="Connect to all", 
+            state=NORMAL if not self.mover.all_connected else DISABLED,
+            command=self.controller.connect_to_all_stages,
+            width=15
+        ).grid(row=3, column=0, padx=5, pady=5, sticky='w')
+
+        Button(
+            connection_frame,
+            text="Connect to selected",
+            state=NORMAL if not self.mover.all_connected else DISABLED,
+            command=self._on_selected_connect,
+            width=15
+        ).grid(row=3, column=1, padx=5, pady=5, sticky='w')
+
+        Button(
+            connection_frame,
+            text="Disconnect to all",
+            state=NORMAL if not self.mover.all_disconnected else DISABLED,
+            command=self.controller.disconnect_to_all_stages,
+            width=15
+        ).grid(row=3, column=2, padx=5, pady=5, sticky='w')
+
+        Button(
+            connection_frame,
+            text="Disconnect to selected",
+            state=NORMAL if not self.mover.all_disconnected else DISABLED,
+            command=self._on_selected_disconnect,
+            width=15
+        ).grid(row=3, column=3, padx=5, pady=5, sticky='w')
+
+    #
+    # Callbacks
+    #        
+
+    def _on_selected_connect(self):
+        for iid in self._get_selected_stage():
+            self.controller.connect_to_single_stage_by_poll_index(int(self._selection_table.get_tree().set(iid, 0)))
+
+    def _on_selected_disconnect(self):
+        for iid in self._get_selected_stage():
+            self.controller.disconnect_to_single_stage_by_poll_index(int(self._selection_table.get_tree().set(iid, 0)))
+
+    #
+    # Helpers
+    #
+
+    def _get_selected_stage(self):
+        iids = self._selection_table.get_tree().selection()
+        if not iids:
+            self.error = "Please select at least one stage."
+            return []
+        return iids


### PR DESCRIPTION
# Goal
Add a new MovementWizard and Mover implementation.
This PullRequest focuses on establish connections to stages.

# Approach and Implementation
- MoverClass: Added a new class named MoverNew. So that for the time being we can use both movers at the same time. This class manages a list of stages, which are currently plugged in but not necessarily connected. These stages will be found by a find_stages method. Each stage implementation in LabExT (e.g Stage3DSmarAct) should provide this function and should return all available stages of its kind.
The Mover provides function to disconnect and connect to all or to selected stages.

- MoverTest: I added tests to test the Mover functions. The tests assume that we have a correct Stage implementation, so the test mock the out and performs based on the cases: No available stages, only connected stages, only disconnected stages and partial connected stages.

- MovementWizardController: Handles everything to connect and disconnect stages and to find all available stages
- MovementWizardView: Handles representation of model (MoverClass) and interacts with controller MovementWizardController


# Compatibility
This PR does introduce new code which is not actively used.