### PR TITLE
bugfix: ignore Keysight mainframe dB calculation error 

### DIFF
--- a/LabExT/Instruments/LaserMainframeKeysight.py
+++ b/LabExT/Instruments/LaserMainframeKeysight.py
@@ -43,7 +43,7 @@ class LaserMainframeKeysight(Instrument):
 
     """
 
-    ignored_SCPI_error_numbers = [0, -420, -231]
+    ignored_SCPI_error_numbers = [0, -420, -231, -261]
 
     def __init__(self, *args, **kwargs):
         # call Instrument constructor, creates VISA instrument

--- a/LabExT/Instruments/PowerMeterGenericKeysight.py
+++ b/LabExT/Instruments/PowerMeterGenericKeysight.py
@@ -40,7 +40,7 @@ class PowerMeterGenericKeysight(Instrument):
 
     """
 
-    ignored_SCPI_error_numbers = [0, -410, -420, -231, -213]
+    ignored_SCPI_error_numbers = [0, -410, -420, -231, -213, -261]
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
Apparently, on older mainframe (816xB) firmwares a -261:StatUnitCalculationError will appear on very low optical input powers. For the explanation, see this excerpt of the 8164B Programming Guide: 

![image](https://user-images.githubusercontent.com/3842684/148963267-e1e439c3-9aee-43ac-9f8b-9b65fd666177.png)

In this PR, we simply ignore the error, as its annoying and interrupts live viewing and measurements. We can savely ignore it, as too low optical powers get recorded as NaN anyhow. (Except on the N77xx models, which report a -200dBm value for too low powers.)