### PR TITLE
[View] Dialog for Driver Path

### DIFF
--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -5,6 +5,24 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+import _tkinter
+import tkinter
+from unittest import TestCase
+
+class TKinterTestCase(TestCase):
+    def setUp(self):
+        self.root=tkinter.Tk()
+        self.pump_events()
+
+    def tearDown(self):
+        if self.root:
+            self.root.destroy()
+            self.pump_events()
+
+    def pump_events(self):
+        while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
+            pass
+
 
 import _tkinter
 import tkinter

--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -5,24 +5,6 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-import _tkinter
-import tkinter
-from unittest import TestCase
-
-class TKinterTestCase(TestCase):
-    def setUp(self):
-        self.root=tkinter.Tk()
-        self.pump_events()
-
-    def tearDown(self):
-        if self.root:
-            self.root.destroy()
-            self.pump_events()
-
-    def pump_events(self):
-        while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
-            pass
-
 
 import _tkinter
 import tkinter

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import json
+from unittest.mock import patch, mock_open
+
+from LabExT.Tests.Utils import TKinterTestCase
+from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
+
+
+class DriverPathDialogTest(TKinterTestCase):
+
+    def test_dialog_initial_state(self):
+        settings_file_path = 'my_path_file.txt'
+        current_driver_path = '/path/to/control/module.py'
+
+        with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path') as config_path:
+            with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
+
+                dialog = DriverPathDialog(self.root, settings_file_path)
+
+                config_path.assert_called_once_with(settings_file_path)
+
+                self.assertEqual(
+                    str(dialog._driver_path_entry.get()),
+                    current_driver_path
+                )
+
+    def test_save_without_change(self):
+        settings_file_path = 'my_path_file.txt'
+        current_driver_path = '/path/to/control/module.py'
+
+        with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
+            with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
+                dialog = DriverPathDialog(self.root, settings_file_path)
+
+                with patch('LabExT.View.Controls.DriverPathDialog.messagebox.showinfo') as messagebox_mock:
+                    dialog._save_button.invoke()
+
+                messagebox_mock.assert_called_once()
+                self.assertEqual(dialog.driver_path, current_driver_path)
+                self.assertFalse(dialog.path_has_changed)
+
+    def test_save_with_change(self):
+        settings_file_path = 'my_path_file.txt'
+        current_driver_path = '/path/to/control/module.py'
+        new_driver_path = '/my/new/path.py'
+
+        with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
+            with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
+                dialog = DriverPathDialog(self.root, settings_file_path)
+
+                with patch('LabExT.View.Controls.DriverPathDialog.messagebox.showinfo') as messagebox_mock:
+                    dialog._driver_path_entry.delete(0, "end")
+                    dialog._driver_path_entry.insert(0, new_driver_path)
+                    dialog._save_button.invoke()
+
+                messagebox_mock.assert_called_once()
+                self.assertEqual(dialog.driver_path, new_driver_path)
+                self.assertTrue(dialog.path_has_changed)

--- a/LabExT/View/Controls/DriverPathDialog.py
+++ b/LabExT/View/Controls/DriverPathDialog.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import json
+from pathlib import Path
+from tkinter import Toplevel, Label, Button, Entry, messagebox
+
+from LabExT.Utils import get_configuration_file_path
+from LabExT.View.Controls.CustomFrame import CustomFrame
+
+
+class DriverPathDialog(Toplevel):
+    """
+    Dialog to change a driver path to be saved in a specified file.
+    """
+
+    def __init__(
+            self,
+            parent,
+            settings_file_path,
+            title=None,
+            label=None,
+            hint=None):
+        """
+        Constructor.
+
+        settings_file_path must be relative to the LabExT settings folder.
+        """
+        Toplevel.__init__(self, parent)
+        self.title(title)
+
+        self._label = label
+        self._hint = hint
+        self._settings_file_path = get_configuration_file_path(
+            settings_file_path)
+        self._driver_path = None
+        self._path_has_changed = False
+
+        self._driver_path_entry = None
+
+        self.__setup__()
+
+    def __setup__(self):
+        """
+        Builds Dialog.
+        """
+        self.rowconfigure(1, weight=1)
+        self.columnconfigure(0, weight=1)
+
+        path_frame = CustomFrame(self)
+        path_frame.title = self._label
+        path_frame.grid(row=1, column=0, padx=5, pady=5, sticky='nswe')
+        path_frame.columnconfigure(0, weight=1)
+        path_frame.rowconfigure(0, weight=1)
+
+        Label(
+            path_frame,
+            text=self._hint
+        ).grid(row=0, column=0, padx=5, pady=5, sticky='nswe')
+
+        self._driver_path_entry = Entry(path_frame)
+        self._driver_path_entry.insert(
+            0, self.driver_path if self.driver_path else "/path/to/module")
+        self._driver_path_entry.grid(
+            row=1, column=0, padx=5, pady=5, sticky='nswe')
+
+        self._cancel_button = Button(
+            self,
+            text="Discard and Close",
+            command=self.destroy,
+            width=30,
+            height=1
+        )
+        self._cancel_button.grid(row=2, column=0, padx=5, pady=5, sticky='sw')
+
+        self._save_button = Button(
+            self,
+            text="Save and Close",
+            command=self._save,
+            width=30,
+            height=1
+        )
+        self._save_button.grid(row=2, column=0, padx=5, pady=5, sticky='se')
+
+    def _save(self):
+        """
+        Callback, when user wants to save the Path.
+        """
+        if not self._driver_path_entry:
+            return
+
+        user_given_path = str(self._driver_path_entry.get())
+        self.driver_path = str(Path(user_given_path.strip()))
+        messagebox.showinfo(
+            parent=self,
+            title='Success',
+            message='Driver path saved. Modules will be reloaded.',
+        )
+
+        self.destroy()
+
+    @property
+    def driver_path(self):
+        """
+        Returns current driver path.
+
+        If None, the path is read from the settings file.
+        """
+        if not self._driver_path:
+            self._driver_path = self._get_driver_path_from_file()
+
+        return self._driver_path
+
+    @property
+    def path_has_changed(self):
+        """
+        Returns True, if driver path has changed and False otherwise
+        """
+        return self._path_has_changed
+
+    @driver_path.setter
+    def driver_path(self, path):
+        """
+        Saves the given driver path in the settings file if it is not equal to the current path.
+        """
+        if path == self.driver_path:
+            return
+
+        try:
+            with open(self._settings_file_path, 'w') as f:
+                json.dump(path, f)
+            self._path_has_changed = True
+            self._driver_path = path
+        except Exception as e:
+            messagebox.showerror(
+                "Error", "Could not save driver path: {}".format(e))
+
+    def _get_driver_path_from_file(self):
+        """
+        Reads the current driver path from settings path.
+        """
+        try:
+            with open(self._settings_file_path, 'r') as f:
+                try:
+                    return json.load(f)
+                except ValueError:
+                    raise ValueError(
+                        '{} is not valid JSON.'.format(
+                            self._settings_file_path))
+        except IOError:
+            raise IOError(
+                '{} does not exist.'.format(
+                    self._settings_file_path))


### PR DESCRIPTION
**Needs #33 merged before!**

This pull request adds a widget to store driver paths in a general way. It has the same functionality as StageDriverSettingsDialog, except that DriverPathDialog is built in a general way.  Tests have been added to test functionality (e.g. button clicks) rather than appearance. 

**The code does not break any existing code. It simply adds code that is not already in use.**

## Example usage for `Stage3DSmarAct`
```python
def load_driver(cls, parent=None) -> bool:
    """
    Loads driver for SmarAct by open a dialog to specifiy the driver path.
    """
    driver_path_dialog = DriverPathDialog(
        parent,
        settings_file_path="mcsc_module_path.txt",
        title="Stage Driver Settings",
        label="SmarAct MCSControl driver module path",
        hint="Specify the directory where the module MCSControl_PythonWrapper is found.\nThis is external software,"
                 "provided by SmarAct GmbH and is available from them. See https://smaract.com."
    )
    parent.wait_window(driver_path_dialog)
    return driver_path_dialog.path_has_changed
```
Based on the return value  of `load_driver`, we can reload the modules without restarting LabExT.