### PR TITLE
Fix: Use sys.exit after pytest

### DIFF
--- a/LabExT/Tests/runtests.py
+++ b/LabExT/Tests/runtests.py
@@ -25,4 +25,4 @@ if __name__ == "__main__":
     if options.laboratory_tests:
         sys.argv.remove('--laboratory_tests')
 
-    pytest.main()
+    sys.exit(pytest.main())


### PR DESCRIPTION
Use pytest return code to tell tox if the run has passed or not.