### PR TITLE
Add quickaccess for coupling tools

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -20,7 +20,6 @@ from LabExT.Instruments.ReusingResourceManager import ReusingResourceManager
 from LabExT.Movement.Mover import Mover
 from LabExT.SearchForPeak.PeakSearcher import PeakSearcher
 from LabExT.Utils import DeprecatedException, get_configuration_file_path, get_visa_lib_string
-from LabExT.View.Controls.KeyboardShortcutButtonPress import callback_if_btn_enabled
 from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
 from LabExT.View.MainWindow.MainWindowController import MainWindowController
 from LabExT.View.ProgressBar.ProgressBar import ProgressBar
@@ -125,24 +124,6 @@ class ExperimentManager:
         self.main_window.model.status_mover_driver_enabled.set(self.mover.mover_enabled)
         self.main_window.model.status_transformation_enabled.set(self.mover.trafo_enabled)
         self.main_window.model.status_sfp_initialized.set(self.peak_searcher.initialized)
-
-        # Keyboard Shortcuts
-        self.root.bind("<F1>", self.show_documentation)
-        self.root.bind("<F5>",
-                       callback_if_btn_enabled(lambda event: self.main_window.start(),
-                                               self.main_window.model.commands[0].button_handle))
-        self.root.bind("<Escape>",
-                       callback_if_btn_enabled(lambda event: self.main_window.stop(),
-                                               self.main_window.model.commands[1].button_handle))
-        self.root.bind("<Control-r>",
-                       callback_if_btn_enabled(lambda event: self.main_window.repeat_last_exec_measurement(),
-                                               self.main_window.view.frame.buttons_frame.repeat_meas_button))
-        self.root.bind("<Control-n>",
-                       callback_if_btn_enabled(lambda event: self.main_window.new_single_measurement(),
-                                               self.main_window.view.frame.buttons_frame.new_meas_button))
-        self.root.bind("<Delete>",
-                       callback_if_btn_enabled(lambda event: self.main_window.todo_delete(),
-                                               self.main_window.view.frame.to_do_frame.delete_todo_meas))
 
         # inform user about mover status
         if not self.mover.mover_enabled:

--- a/LabExT/View/Controls/ControlPanel.py
+++ b/LabExT/View/Controls/ControlPanel.py
@@ -117,17 +117,23 @@ class ControlPanel(CustomFrame):
         if self._command_source is None:
             return
 
-        r = 0
-        for command in self._command_source:
+        for cidx, command in enumerate(self._command_source):
+
+            # only x-pad first and last button
+            if cidx == 0:
+                padx = (5, 0)
+            elif cidx == len(self._command_source) - 1:
+                padx = (0, 5)
+            else:
+                padx = (0, 0)
+
             command.button_handle = self.add_widget(
                 Button(
                     self, textvariable=command.name, command=command.command),
-                column=r,
-                row=0, sticky='nswe')
+                column=cidx,
+                row=0, sticky='nswe', padx=padx, pady=5)
 
             if self._button_width is not None:
                 command.button_handle.config(width=self._button_width)
                 command.button_handle.rowconfigure(0, weight=1)
-                command.button_handle.columnconfigure(r, weight=1)
-
-            r += 1
+                command.button_handle.columnconfigure(cidx, weight=1)

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -16,6 +16,7 @@ from LabExT.View.EditMeasurementWizard.EditMeasurementWizardController import Ed
 from LabExT.View.MainWindow.MainWindowModel import MainWindowModel
 from LabExT.View.MainWindow.MainWindowView import MainWindowView
 from LabExT.View.SettingsWindow import SettingsWindow
+from LabExT.View.Controls.KeyboardShortcutButtonPress import callback_if_btn_enabled
 
 
 class MainWindowController:
@@ -59,6 +60,8 @@ class MainWindowController:
         self.view.set_up_main_window()  # setup the main window content
 
         self._axis_being_changed = False
+
+        self._register_keyboard_shortcuts()
 
     def on_window_close(self):
         """Called when user closes the application. Save experiment
@@ -539,3 +542,28 @@ class MainWindowController:
         self.experiment_manager.docu.cleanup()
 
         self.root.destroy()
+
+    def _register_keyboard_shortcuts(self):
+        self.root.bind("<F1>",
+                       self.experiment_manager.show_documentation)
+        self.root.bind("<F5>",
+                       callback_if_btn_enabled(lambda event: self.start(),
+                                               self.model.commands[0].button_handle))
+        self.root.bind("<Escape>",
+                       callback_if_btn_enabled(lambda event: self.stop(),
+                                               self.model.commands[1].button_handle))
+        self.root.bind("<Control-r>",
+                       callback_if_btn_enabled(lambda event: self.repeat_last_exec_measurement(),
+                                               self.view.frame.buttons_frame.repeat_meas_button))
+        self.root.bind("<Control-n>",
+                       callback_if_btn_enabled(lambda event: self.new_single_measurement(),
+                                               self.view.frame.buttons_frame.new_meas_button))
+        self.root.bind("<Delete>",
+                       callback_if_btn_enabled(lambda event: self.todo_delete(),
+                                               self.view.frame.to_do_frame.delete_todo_meas))
+        self.root.bind("<Control-l>",
+                       callback_if_btn_enabled(lambda event: self.open_live_viewer(),
+                                               self.view.frame.coupling_tools_panel.live_viewer_btn))
+        self.root.bind("<Control-s>",
+                       callback_if_btn_enabled(lambda event: self.open_peak_searcher(),
+                                               self.view.frame.coupling_tools_panel.peak_searcher_btn))

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -480,7 +480,7 @@ class MainWindowController:
     def offer_chip_reload_possibility(self):
         chip_name = self.model.chip_parameters['Chip name'].value
         chip_path = self.model.chip_parameters['Chip path'].value
-        # chip_path is is only set if the user did the "load chip" functionality
+        # chip_path is only set if the user did the "load chip" functionality
         # so to offer to re-load the same chip, its sufficient to check if chip_path was set to anything
         if not chip_path:
             # there was no chip loaded on last use of LabExT, do not offer reloading
@@ -492,6 +492,14 @@ class MainWindowController:
         if not user_wants_chip_reload:
             return
         self.experiment_manager.import_chip(chip_path, chip_name)
+
+    def open_live_viewer(self):
+        """ opens live-viewer window by calling appropriate menu listener function """
+        self.view.menu_listener.client_live_view()
+
+    def open_peak_searcher(self):
+        """ opens search for peak window by calling appropriate menu listener function """
+        self.view.menu_listener.client_search_for_peak()
 
     def start(self):
         """Calls the experiment handler to start the experiment.

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -69,14 +69,14 @@ class MainWindowContextMenu(Menu):
             label="Move Stages to Device",
             command=self._menu_listener.client_move_device)
         self._movement.add_command(
-            label="Search for Peak",
+            label="Search for Peak (Ctrl+S)",
             command=self._menu_listener.client_search_for_peak)
 
         self._view.add_command(
             label="Open Extra Plots",
             command=self._menu_listener.client_extra_plots)
         self._view.add_command(
-            label="Start Live Instrument View",
+            label="Start Live Instrument View (Ctrl+L)",
             command=self._menu_listener.client_live_view)
 
         self._settings.add_command(
@@ -138,8 +138,8 @@ class MainWindowControlPanel(ControlPanel):
         # control buttons
         #
         self.logger.debug('Adding control buttons..')
-        self.grid(row=4, column=0, sticky='we')
-        self.title = 'Experiment Control'
+        self.grid(row=5, column=0, sticky='we')
+        self.title = 'Execute ToDos'
         self.button_width = 15
         self.command_source = self.model.commands
 
@@ -180,6 +180,30 @@ class MainWindowControlPanel(ControlPanel):
         self.columnconfigure(2, weight=1)
 
 
+class MainWindowCouplingTools(LabelFrame):
+    """
+    Buttons for quick-accessing the auxiliary tools.
+    """
+
+    def __init__(self, parent, controller):
+        self.parent = parent
+        self.controller = controller
+        LabelFrame.__init__(self, self.parent, text='Couple Light to SiP Chip')
+        self.grid(row=3, column=0, sticky='we')
+        self.rowconfigure(0, weight=1)
+        self.rowconfigure(1, weight=1)
+        self.columnconfigure(0, weight=1)
+
+        self.live_viewer_btn = Button(self,
+                                      text='Open Live Viewer (Ctrl+L)',
+                                      command=self.controller.open_live_viewer)
+        self.live_viewer_btn.grid(row=0, column=0, sticky='we', padx=5, pady=5)
+        self.peak_searcher_btn = Button(self,
+                                        text='Peak Searcher (Ctrl+S)',
+                                        command=self.controller.open_peak_searcher)
+        self.peak_searcher_btn.grid(row=1, column=0, sticky='we', padx=5, pady=5)
+
+
 class MainWindowButtonsFrame(LabelFrame):
     """
     The buttons frame. Has buttons to add measurements.
@@ -188,8 +212,8 @@ class MainWindowButtonsFrame(LabelFrame):
         self.main_frame = main_frame
         self.parent = parent
         self.controller = controller
-        LabelFrame.__init__(self, self.parent, text='Start New Experiment')
-        self.grid(row=3, column=0, sticky='we')
+        LabelFrame.__init__(self, self.parent, text='Create new ToDos')
+        self.grid(row=4, column=0, sticky='we')
         self.rowconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
         self.columnconfigure(0, weight=1)
@@ -254,9 +278,9 @@ class MainWindowAxesFrame(LabelFrame):
         self.parent = parent
         self.root = root
         self.controller = controller
-        LabelFrame.__init__(self, self.parent)
+        LabelFrame.__init__(self, self.parent, text='Choose Axes to Display')
 
-        self.grid(row=5, column=0, sticky='we')
+        self.grid(row=6, column=0, sticky='we')
         self.rowconfigure(2, weight=1)
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
@@ -439,6 +463,7 @@ class MainWindowFrame(Frame):
         self.control_frame = None
         self.parameter_frame = None
         self.buttons_frame = None
+        self.coupling_tools_panel = None
         self.control_panel = None
 
         self.selec_plot = None
@@ -467,6 +492,7 @@ class MainWindowFrame(Frame):
         self.parameter_frame = MainWindowParameterFrame(self.control_frame, self.model)
         self.buttons_frame = MainWindowButtonsFrame(self.control_frame, self, self.controller)
         self.control_panel = MainWindowControlPanel(self.control_frame, self.model)
+        self.coupling_tools_panel = MainWindowCouplingTools(self.control_frame, self.controller)
         self.axes_frame = MainWindowAxesFrame(self.control_frame, self.root, self.controller)
 
         self.selec_plot = PlotControl(self, add_toolbar=True, figsize=(5, 5), add_legend=True,


### PR DESCRIPTION
An often wished for feature: The live-viewer (and the search-for-peak window) should be available via shortcuts and prominently placed buttons.

This PR introduces the buttons in the Main Window to quickly open live-viewer and search-for-peak. The live-viewer is now available by pressing Ctrl+L, the SfP window by Ctrl+S.

This PR also contains two "beautifying" additions:
* The horizontal control buttons are now properly padded.
* The Label-Frames in the MainWindow have more telling titles and are ordered according to their usage in a classical measurement scenario.

This PR also contains the following refactoring:
* Registering the main-window's keyboard shortcuts is now done in `MainWindowController` instead of in the very unfitting `ExperimentManager`.