### PR TITLE
Add method to refresh main window context menu

### DIFF
--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -92,6 +92,12 @@ class MainWindowController:
         self.root.config(cursor='')
         self.logger.debug('Done updating tables')
 
+    def refresh_context_menu(self):
+        """
+        Refreshes context menu.
+        """
+        self.view.set_up_context_menu() 
+
     def set_selec_plot_title(self, title):
         """ set the title of the selected measurements plot """
         self.view.frame.selec_plot.title = title

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -452,12 +452,12 @@ class MainWindowFrame(Frame):
         self.to_do_frame = None
         self.finished_meas_frame = None
 
-    def set_up_menu(self, menu_listener):
+    def set_up_menu(self):
         """
         Sets up the menu bar up top.
         """
-        self.menu_listener = menu_listener
-        self.menu = MainWindowContextMenu(self, menu_listener)
+        self.menu_listener = MListener(self.experiment_manager, self.root)
+        self.menu = MainWindowContextMenu(self, self.menu_listener)
 
     def set_up_control_frame(self):
         """
@@ -517,7 +517,6 @@ class MainWindowView:
         self.logger = logging.getLogger()
 
         self.frame = None
-        self.menu_listener = None
 
     def set_up_root_window(self):
         """
@@ -545,21 +544,23 @@ class MainWindowView:
         """
         Setup main window
         """
-        self.menu_listener = MListener(self.experiment_manager, self.root)
-
         #
         # add menu bar
         #
-        self.frame.set_up_menu(self.menu_listener)
-
-        self.logger.debug('Adding menu bar..')
-        self.root.config(menu=self.frame.menu)
+        self.set_up_context_menu()
 
         self.frame.set_up_control_frame()
-
+        
         self.frame.set_up_logging_frame()
         #
         # active and finished measurement tables
         #
 
         self.frame.set_up_auxiliary_tables()
+
+    def set_up_context_menu(self):
+        """
+        Setup main window context menu and menu listener
+        """
+        self.frame.set_up_menu()
+        self.root.config(menu=self.frame.menu)


### PR DESCRIPTION
Allows to refresh the context menu when the application state has changed, by using:
```python
self.experiment_manager.main_window.refresh_context_menu()
```

Is useful when a menu item is disabled first and is available through a state change. Then this function can be called after the update and reload the context menu.