### PR TITLE
[Movement] (3/5): Single Point für safe absolute (approx) movement

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -10,6 +10,7 @@ import numpy as np
 from typing import Type
 from enum import Enum, auto
 
+from LabExT.Movement.Transformations import SinglePointFixation
 from LabExT.Movement.Stage import StageError
 
 
@@ -145,6 +146,7 @@ class Calibration:
         self._device_port = device_port
 
         self._axes_rotation = None
+        self._single_point_fixation = None
 
     #
     #   Representation
@@ -215,6 +217,18 @@ class Calibration:
 
         self._axes_rotation = axes_rotation
         self._state = State.COORDINATE_SYSTEM_FIXED
+
+        return True
+
+    def fix_single_point(
+            self,
+            single_point_fixation: Type[SinglePointFixation]):
+        if not single_point_fixation.is_valid:
+            raise CalibrationError(
+                "The given fixation is no valid. ")
+
+        self._single_point_fixation = single_point_fixation
+        self._state = State.SINGLE_POINT_FIXED
 
         return True
 

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from abc import ABC, abstractmethod
+from typing import NamedTuple, Type
+import numpy as np
+
+
+class Transformation(ABC):
+    """
+    Abstract interface for transformations.
+    """
+
+    @abstractmethod
+    def __init__(self) -> None:
+        pass
+
+    @property
+    @abstractmethod
+    def is_valid(self):
+        """
+        Returns True if the transformation is valid.
+        """
+        pass
+
+    @abstractmethod
+    def chip_to_stage(self, chip_coordinate):
+        """
+        Transforms a coordinate in chip space to stage space.
+        """
+        pass
+
+    @abstractmethod
+    def stage_to_chip(self, stage_coordinate):
+        """
+        Transforms a coordinate in stage space to chip space.
+        """
+        pass
+
+
+class CoordinatePairing(NamedTuple):
+    calibration: object
+    stage_coordinate: list
+    device: object
+    chip_coordinate: list
+
+
+class SinglePointFixation(Transformation):
+    """
+    Performs a translation based on a fixed single point.
+    """
+
+    def __init__(self) -> None:
+        self._chip_coordinate = None
+        self._stage_coordinate = None
+        self._offset = None
+
+    def __str__(self) -> str:
+        if self._offset is None:
+            return "No single point fixed"
+
+        return "Stage-Coordinate {} fixed with Chip-Coordinate {}".format(
+            self._stage_coordinate, self._chip_coordinate)
+
+    @property
+    def is_valid(self):
+        """
+        Returns True if single point transformation is defined.
+        """
+        return self._offset is not None
+
+    def update(self, pairing: Type[CoordinatePairing]):
+        """
+        Updates the offset based on a coordinate pairing.
+        """
+        if pairing.chip_coordinate is None or pairing.stage_coordinate is None:
+            raise ValueError("Incomplete Pairing")
+
+        self._chip_coordinate = np.array(pairing.chip_coordinate)
+        self._stage_coordinate = np.array(pairing.stage_coordinate)
+
+        self._offset = self._stage_coordinate - self._chip_coordinate
+
+    def chip_to_stage(self, chip_coordinate):
+        """
+        Translates chip coordinate to stage coordinate
+        """
+        if not self.is_valid:
+            raise RuntimeError("Cannot translate with invalid fixation. ")
+
+        return np.array(chip_coordinate) + self._offset
+
+    def stage_to_chip(self, stage_coordinate):
+        """
+        Translates stage coordinate to chip coordinate
+        """
+        if not self.is_valid:
+            raise RuntimeError("Cannot translate with invalid fixation. ")
+
+        return np.array(stage_coordinate) + self._offset

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -101,4 +101,4 @@ class SinglePointFixation(Transformation):
         if not self.is_valid:
             raise RuntimeError("Cannot translate with invalid fixation. ")
 
-        return np.array(stage_coordinate) + self._offset
+        return np.array(stage_coordinate) - self._offset

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import call, patch
 import numpy as np
 
+from LabExT.Movement.Transformations import CoordinatePairing, SinglePointFixation
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Stages.DummyStage import DummyStage
@@ -199,3 +200,25 @@ class CalibrationTest(unittest.TestCase):
         self.assertEqual(
             self.calibration._state,
             State.COORDINATE_SYSTEM_FIXED)
+
+    def test_fix_single_point_accepts_only_valid_fixations(self):
+        fixation = SinglePointFixation()
+
+        with self.assertRaises(CalibrationError):
+            self.calibration.fix_single_point(fixation)
+
+    def test_fix_single_point_accepts_saves_fixations(self):
+        fixation = SinglePointFixation()
+        fixation.update(CoordinatePairing(
+            calibration=None,
+            stage_coordinate=[0, 0],
+            device=None,
+            chip_coordinate=[1, 1]
+        ))
+
+        self.calibration.fix_single_point(fixation)
+
+        self.assertEqual(self.calibration._single_point_fixation, fixation)
+        self.assertEqual(
+            self.calibration._state,
+            State.SINGLE_POINT_FIXED)

--- a/LabExT/Tests/Movement/Transformations_test.py
+++ b/LabExT/Tests/Movement/Transformations_test.py
@@ -91,5 +91,18 @@ class SinglePointFixationTest(unittest.TestCase):
 
         self.assertTrue(
             (self.fixation.stage_to_chip([5, 6]) ==
-             np.array([5, 6]) + expected_offset).all()
+             np.array([5, 6]) - expected_offset).all()
         )
+
+    def test_chip_to_stage_and_stage_to_chip_are_inversed(self):
+        self.fixation.update(CoordinatePairing(
+            None, [7, 1], None, [4, 2]
+        ))
+
+        chip_input_coordinate = [2, 3]
+        self.assertTrue((chip_input_coordinate == self.fixation.stage_to_chip(
+            self.fixation.chip_to_stage(chip_input_coordinate))).all())
+
+        stage_input_coordinate = [2, 3]
+        self.assertTrue((stage_input_coordinate == self.fixation.chip_to_stage(
+            self.fixation.stage_to_chip(stage_input_coordinate))).all())

--- a/LabExT/Tests/Movement/Transformations_test.py
+++ b/LabExT/Tests/Movement/Transformations_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import unittest
+import numpy as np
+
+from LabExT.Movement.Transformations import CoordinatePairing, SinglePointFixation
+
+
+class SinglePointFixationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixation = SinglePointFixation()
+
+    def test_is_valid_for_no_offset(self):
+        self.assertFalse(self.fixation.is_valid)
+
+    def test_update_missing_chip_coordinate(self):
+        pairing = CoordinatePairing(
+            calibration=None,
+            stage_coordinate=[1, 2],
+            device=None,
+            chip_coordinate=None
+        )
+
+        with self.assertRaises(ValueError):
+            self.fixation.update(pairing)
+
+        self.assertFalse(self.fixation.is_valid)
+
+    def test_update_missing_stage_coordinate(self):
+        pairing = CoordinatePairing(
+            calibration=None,
+            stage_coordinate=None,
+            device=None,
+            chip_coordinate=[1, 2]
+        )
+
+        with self.assertRaises(ValueError):
+            self.fixation.update(pairing)
+
+        self.assertFalse(self.fixation.is_valid)
+
+    def test_update(self):
+        pairing = CoordinatePairing(
+            calibration=None,
+            stage_coordinate=[2, 4],
+            device=None,
+            chip_coordinate=[1, 5]
+        )
+
+        self.fixation.update(pairing)
+
+        self.assertTrue(self.fixation.is_valid)
+
+    def test_chip_to_stage_when_invalid(self):
+        with self.assertRaises(RuntimeError):
+            self.fixation.chip_to_stage([1, 2])
+
+    def test_stage_to_chip_when_invalid(self):
+        with self.assertRaises(RuntimeError):
+            self.fixation.stage_to_chip([1, 2])
+
+    def test_chip_to_stage_translates_chip_coordinate(self):
+        stage_coordinate = [2, 4]
+        chip_coordinate = [1, 5]
+        expected_offset = np.array(stage_coordinate) - \
+            np.array(chip_coordinate)
+
+        self.fixation.update(CoordinatePairing(
+            None, stage_coordinate, None, chip_coordinate
+        ))
+
+        self.assertTrue(
+            (self.fixation.chip_to_stage([5, 6]) ==
+             np.array([5, 6]) + expected_offset).all()
+        )
+
+    def test_stage_to_chip_translates_chip_coordinate(self):
+        stage_coordinate = [2, 4]
+        chip_coordinate = [1, 5]
+        expected_offset = np.array(stage_coordinate) - \
+            np.array(chip_coordinate)
+
+        self.fixation.update(CoordinatePairing(
+            None, stage_coordinate, None, chip_coordinate
+        ))
+
+        self.assertTrue(
+            (self.fixation.stage_to_chip([5, 6]) ==
+             np.array([5, 6]) + expected_offset).all()
+        )

--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -8,6 +8,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import _tkinter
 import tkinter
+from unittest.mock import patch
+from LabExT.Movement.Stage import Stage
 import pytest
 from unittest import TestCase
 
@@ -26,6 +28,16 @@ class TKinterTestCase(TestCase):
         while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
             pass
 
+def with_stage_discovery_patch(func):
+    """
+    Patches the Stage classmethods `find_available_stages` and `find_stage_classes`.
+    Reason: When the mover is initialized, it automatically searches for all stage classes and for all attached stages.
+    The search for stages requires loaded drivers, which we do not want to call in test mode.
+    """
+    patch_stage_class_search = patch.object(Stage, "find_stage_classes")
+    patch_stage_discovery = patch.object(Stage, "find_available_stages")
+
+    return patch_stage_class_search(patch_stage_discovery(func))
 
 def mark_as_laboratory_test(cls):
     """

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -16,7 +16,7 @@ from LabExT.View.Movement.CoordinatePairingsWindow import CoordinatePairingsWind
 from LabExT.Wafer.Device import Device
 
 
-class Foo(TKinterTestCase):
+class CoordinatePairingsWindowTest(TKinterTestCase):
     @with_stage_discovery_patch
     def setUp(self, available_stages_mock, stage_classes_mock) -> None:
         super().setUp()

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from unittest.mock import Mock, patch
+from LabExT.Movement.Calibration import Calibration, DevicePort, Orientation
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.Movement.Stage import Stage
+from LabExT.Movement.Transformations import CoordinatePairing
+from LabExT.Tests.Utils import TKinterTestCase, with_stage_discovery_patch
+from LabExT.View.Movement.CoordinatePairingsWindow import CoordinatePairingsWindow
+
+from LabExT.Wafer.Device import Device
+
+
+class Foo(TKinterTestCase):
+    @with_stage_discovery_patch
+    def setUp(self, available_stages_mock, stage_classes_mock) -> None:
+        super().setUp()
+        available_stages_mock.return_value = []
+        stage_classes_mock.return_value = []
+
+        self.devices = {
+            0: Device(0, [0, 0], [1, 1], "My Device 1")
+        }
+
+        self.experiment_manager = Mock()
+
+        self.mover = MoverNew(self.experiment_manager)
+
+        self.stage_1 = Mock(spec=Stage)
+        self.stage_2 = Mock(spec=Stage)
+        self.stage_1.connected = True
+        self.stage_2.connected = True
+
+        self.in_calibration = Calibration(
+            self.mover,
+            self.stage_1,
+            Orientation.LEFT,
+            DevicePort.INPUT)
+        self.out_calibration = Calibration(
+            self.mover,
+            self.stage_2,
+            Orientation.RIGHT,
+            DevicePort.OUTPUT)
+
+    def test_raises_error_if_no_calibration_is_given(self):
+        with self.assertRaises(ValueError):
+            CoordinatePairingsWindow(self.experiment_manager, self.root)
+
+    def test_raises_error_if_no_chip_is_imported(self):
+        self.experiment_manager.chip = None
+        with self.assertRaises(ValueError):
+            CoordinatePairingsWindow(self.experiment_manager, self.root)
+
+    def test_pairings_returns_an_empty_list_for_no_device(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager,
+            self.root,
+            self.in_calibration,
+            self.out_calibration)
+
+        self.assertEqual([], window.pairings)
+
+    def test_pairings_returns_an_empty_list_if_no_stage_cooridnates(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager,
+            self.root,
+            self.in_calibration,
+            self.out_calibration)
+
+        window._device_table.set_selected_device(0)
+        window._select_device_button.invoke()
+
+        self.assertEqual([], window.pairings)
+
+    def test_reset_device_selection(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager,
+            self.root,
+            self.in_calibration,
+            self.out_calibration)
+
+        window._device_table.set_selected_device(0)
+        window._select_device_button.invoke()
+
+        self.assertEqual(window._device, self.devices.get(0))
+
+        window._clear_device_button.invoke()
+
+        self.assertIsNone(window._device)
+
+    def test_pairings_for_input_calibration(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager, self.root, self.in_calibration)
+
+        window._device_table.set_selected_device(0)
+        window._select_device_button.invoke()
+
+        self.in_calibration.stage.get_current_position.return_value = [3, 9]
+
+        window._finish_button.invoke()
+
+        expected_pairings = CoordinatePairing(
+            calibration=self.in_calibration,
+            stage_coordinate=[3, 9],
+            device=self.devices.get(0),
+            chip_coordinate=[0, 0]
+        )
+
+        self.assertEqual(window.pairings, [expected_pairings])
+
+    def test_pairings_for_output_calibration(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager,
+            self.root,
+            out_calibration=self.out_calibration)
+
+        window._device_table.set_selected_device(0)
+        window._select_device_button.invoke()
+
+        self.out_calibration.stage.get_current_position.return_value = [4, 8]
+
+        window._finish_button.invoke()
+
+        expected_pairings = CoordinatePairing(
+            calibration=self.out_calibration,
+            stage_coordinate=[4, 8],
+            device=self.devices.get(0),
+            chip_coordinate=[1, 1]
+        )
+
+        self.assertEqual(window.pairings, [expected_pairings])
+
+    def test_pairings_for_input_and_output_calibration(self):
+        self.experiment_manager.chip._devices = self.devices
+        window = CoordinatePairingsWindow(
+            self.experiment_manager,
+            self.root,
+            in_calibration=self.in_calibration,
+            out_calibration=self.out_calibration)
+
+        window._device_table.set_selected_device(0)
+        window._select_device_button.invoke()
+
+        self.in_calibration.stage.get_current_position.return_value = [4, 8]
+        self.out_calibration.stage.get_current_position.return_value = [3, 9]
+
+        window._finish_button.invoke()
+
+        expected_pairing_1 = CoordinatePairing(
+            calibration=self.in_calibration,
+            stage_coordinate=[4, 8],
+            device=self.devices.get(0),
+            chip_coordinate=[0, 0]
+        )
+
+        expected_pairing_2 = CoordinatePairing(
+            calibration=self.out_calibration,
+            stage_coordinate=[3, 9],
+            device=self.devices.get(0),
+            chip_coordinate=[1, 1]
+        )
+
+        self.assertEqual(
+            window.pairings, [
+                expected_pairing_1, expected_pairing_2])

--- a/LabExT/View/Controls/CoordinateWidget.py
+++ b/LabExT/View/Controls/CoordinateWidget.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import LEFT, SUNKEN, Frame, Label
+from LabExT.Movement.Calibration import Axis
+
+
+class CoordinateWidget(Frame):
+    """
+    Simple Widget to display a coordinate
+    """
+
+    def __init__(self, parent, coordinate):
+        super(CoordinateWidget, self).__init__(parent)
+        self._coordinate = coordinate[:3]  # Use only first 3 values
+
+        self.__setup__()
+
+    def __setup__(self):
+        for idx, value in enumerate(self._coordinate):
+            Label(self, text="{}:".format(Axis(idx).name)).pack(side=LEFT)
+            Label(
+                self, text=value, borderwidth=1, relief=SUNKEN
+            ).pack(side=LEFT, ipadx=5, padx=(0, 5))
+
+    @property
+    def coordinate(self):
+        self._coordinate
+
+    @coordinate.setter
+    def coordinate(self, coordinate):
+        """
+        Rerenders the the frame to display
+        """
+        self._coordinate = coordinate[:3]
+
+        for c in self.winfo_children():
+            c.forget()
+        self.__setup__()

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.DeviceTable import DeviceTable
+
+from LabExT.Movement.Stage import StageError
+import LabExT.Movement.Transformations as Transformations
+
+
+class CoordinatePairingsWindow(Toplevel):
+    """
+    Window to pair a stage and chip coordinate.
+    """
+
+    def __init__(
+            self,
+            experiment_manager,
+            parent,
+            in_calibration=None,
+            out_calibration=None):
+        if in_calibration is None and out_calibration is None:
+            raise ValueError(
+                "At least one calibration is needed to create a coordinate pairing. ")
+
+        if experiment_manager.chip is None:
+            raise ValueError("Cannot create pairing without chip imported. ")
+
+        self.experiment_manager = experiment_manager
+        self._in_calibration = in_calibration
+        self._out_calibration = out_calibration
+
+        super(CoordinatePairingsWindow, self).__init__(parent)
+
+        self._device = None
+        self._in_stage_coordinate = None
+        self._out_stage_coordinate = None
+
+        # Set up window
+        self.title("New Chip-Stage-Coordinates Pairings")
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1000, 600, 200, 200))
+        self.protocol('WM_DELETE_WINDOW', self._cancel)
+
+        # Build window
+        self._main_frame = Frame(self, borderwidth=0, relief=FLAT)
+        self._main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
+
+        self._buttons_frame = Frame(
+            self,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0)
+        self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
+
+        hint = "Press Finish when you have reached an optimal coupling and want to save the pairings."
+        finish_hint = Label(self._buttons_frame, text=hint)
+        finish_hint.pack(side=LEFT)
+
+        self._finish_button = Button(
+            self._buttons_frame,
+            text="Save and Close",
+            width=15,
+            state=DISABLED,
+            command=self._finish)
+        self._finish_button.pack(
+            side=RIGHT, fill=Y, expand=0)
+
+        self.__setup__()
+
+    def __setup__(self):
+        """
+        Builds all widgets based on current state.
+        """
+        hint = "In this window, a coordinate pairing between stages and chip devices can be created.\n" \
+               "Please select a device first and then move the stages to the input or output port of the device."
+        top_hint = Label(self._main_frame, text=hint)
+        top_hint.pack(side=TOP, fill=X)
+
+        self._select_device_frame()
+        self._current_pairings_frame()
+
+    def __reload__(self):
+        """
+        Reloads window.
+        """
+        for child in self._main_frame.winfo_children():
+            child.forget()
+
+        self._finish_button.config(state=NORMAL if self._device else DISABLED)
+
+        self.__setup__()
+        self.update_idletasks()
+
+    @property
+    def pairings(self):
+        """
+        Returns a list of coordinate pairings if device and stage coordinate is defined, otherwise empty list.
+        """
+        pairings = []
+        if not self._device:
+            return pairings
+
+        if not self._out_stage_coordinate and not self._in_stage_coordinate:
+            return pairings
+
+        if self._in_calibration and self._in_stage_coordinate:
+            pairings.append(Transformations.CoordinatePairing(
+                self._in_calibration,
+                self._in_stage_coordinate,
+                self._device,
+                self._device._in_position
+            ))
+
+        if self._out_calibration and self._out_stage_coordinate:
+            pairings.append(Transformations.CoordinatePairing(
+                self._out_calibration,
+                self._out_stage_coordinate,
+                self._device,
+                self._device._out_position
+            ))
+
+        return pairings
+
+    #
+    #   Frames
+    #
+
+    def _current_pairings_frame(self):
+        """
+        Renders a frame to show the current pairings
+        """
+        frame = CustomFrame(self._main_frame)
+        frame.pack(side=TOP, fill=X, pady=5)
+
+        step_hint = Label(frame, text=self._get_coupling_hint())
+        step_hint.pack(side=TOP, fill=X)
+
+        if self._in_calibration:
+            self._calibration_pairing_widget(
+                frame, self._in_calibration).pack(
+                side=TOP, fill=X)
+
+        if self._out_calibration:
+            self._calibration_pairing_widget(
+                frame, self._out_calibration).pack(
+                side=TOP, fill=X)
+
+    def _select_device_frame(self):
+        """
+        Renders a frame to select a device.
+        """
+        frame = CustomFrame(self._main_frame)
+        frame.title = "Device Selection"
+        frame.pack(side=TOP, fill=X, pady=5)
+
+        if not self._device:
+            self._device_table = DeviceTable(frame, self.experiment_manager)
+            self._device_table.pack(side=TOP, fill=X, expand=True)
+
+            self._select_device_button = Button(
+                frame,
+                text="Select marked device",
+                command=self._on_device_selection
+            )
+            self._select_device_button.pack(side=LEFT, pady=2)
+        else:
+            Label(
+                frame,
+                text=self._device.short_str(),
+                font='Helvetica 12 bold'
+            ).pack(side=LEFT, fill=X)
+
+            self._clear_device_button = Button(
+                frame,
+                text="Clear selection",
+                command=self._on_device_selection_clear
+            )
+            self._clear_device_button.pack(side=LEFT, padx=5)
+
+    #
+    #   Callbacks
+    #
+
+    def _finish(self):
+        try:
+            if self._in_calibration:
+                self._in_stage_coordinate = self._in_calibration.stage.get_current_position()
+            if self._out_calibration:
+                self._out_stage_coordinate = self._out_calibration.stage.get_current_position()
+
+            self.destroy()
+        except StageError as e:
+            messagebox.showerror(
+                "Error", "Could not get current position: {}".format(e))
+
+    def _cancel(self):
+        self._in_stage_coordinate = None
+        self._out_stage_coordinate = None
+        self._device = None
+        self.destroy()
+
+    def _on_device_selection(self):
+        """
+        Callback, when user hits "Select marked device" button.
+        """
+        self._device = self._device_table.get_selected_device()
+        if self._device is None:
+            messagebox.showwarning(
+                'Selection Needed',
+                'Please select one device.',
+                parent=self)
+            return
+
+        self.__reload__()
+
+    def _on_device_selection_clear(self):
+        """
+        Callback, when user wants to clear the current device selection.
+        """
+        self._device = None
+        self.__reload__()
+
+    #
+    #   Helpers
+    #
+
+    def _calibration_pairing_widget(self, parent, calibration):
+        pairing_frame = CustomFrame(parent)
+        pairing_frame.title = calibration.short_str
+        pairing_frame.pack(side=TOP, fill=X, pady=5)
+
+        Label(
+            pairing_frame,
+            text="Paired with chip coordinate:"
+        ).pack(side=LEFT, fill=X)
+
+        if self._device:
+            Label(
+                pairing_frame,
+                text=self._device._in_position if calibration.is_input_stage else self._device._out_position,
+                borderwidth=2,
+                relief='sunken').pack(
+                side=LEFT,
+                padx=5)
+        else:
+            Label(
+                pairing_frame,
+                text="No device selected",
+                foreground="#FF3333"
+            ).pack(side=LEFT, padx=5)
+
+        return pairing_frame
+
+    def _get_coupling_hint(self):
+        if self._in_calibration and self._out_calibration:
+            return "You have selected two stages to create a pairing:\n" \
+                   "{} must be moved to the input port.\n" \
+                   "{} must be moved to the output port.".format(self._in_calibration, self._out_calibration)
+
+        if self._in_calibration:
+            return "You have selected one stages to create a pairing:\n" \
+                   "{} must be moved to the input port".format(self._in_calibration)
+
+        if self._out_calibration:
+            return "You have selected one stages to create a pairing:\n" \
+                   "{} must be moved to the output port".format(self._out_calibration)

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -6,11 +6,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y
+from LabExT.View.Controls.CoordinateWidget import CoordinateWidget
 from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.DeviceTable import DeviceTable
 
 from LabExT.Movement.Stage import StageError
 import LabExT.Movement.Transformations as Transformations
+from LabExT.View.Movement.StagePositionWidget import StagePositionWidget
 
 
 class CoordinatePairingsWindow(Toplevel):
@@ -234,25 +236,32 @@ class CoordinatePairingsWindow(Toplevel):
         pairing_frame.title = calibration.short_str
         pairing_frame.pack(side=TOP, fill=X, pady=5)
 
-        Label(
-            pairing_frame,
-            text="Paired with chip coordinate:"
-        ).pack(side=LEFT, fill=X)
-
         if self._device:
             Label(
                 pairing_frame,
-                text=self._device._in_position if calibration.is_input_stage else self._device._out_position,
-                borderwidth=2,
-                relief='sunken').pack(
-                side=LEFT,
-                padx=5)
+                text="Chip coordinate:"
+            ).pack(side=LEFT)
+
+            CoordinateWidget(
+                pairing_frame,
+                coordinate=self._device._in_position if calibration.is_input_stage else self._device._out_position
+            ).pack(side=LEFT)
+
+            Label(
+                pairing_frame,
+                text="will be paired with Stage coordinate:"
+            ).pack(side=LEFT)
+
+            StagePositionWidget(
+                pairing_frame,
+                stage=calibration.stage
+            ).pack(side=LEFT)
         else:
             Label(
                 pairing_frame,
                 text="No device selected",
                 foreground="#FF3333"
-            ).pack(side=LEFT, padx=5)
+            ).pack(side=LEFT)
 
         return pairing_frame
 

--- a/LabExT/View/Movement/StagePositionWidget.py
+++ b/LabExT/View/Movement/StagePositionWidget.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from typing import Type
+from LabExT.Movement.Stage import Stage
+from LabExT.View.Controls.CoordinateWidget import CoordinateWidget
+
+
+class StagePositionWidget(CoordinateWidget):
+    """
+    Widget, which display the current position of a stage. Updates automatically.
+    """
+
+    REFRESHING_RATE = 1000  # [ms]
+
+    def __init__(self, parent, stage: Type[Stage]):
+        self.stage = stage
+
+        super().__init__(parent, self.stage.get_current_position())
+
+        self._update_pos_job = self.after(
+            self.REFRESHING_RATE, self._refresh_position)
+
+    def __del__(self):
+        if self._update_pos_job:
+            self.after_cancel(self._update_pos_job)
+
+    def _refresh_position(self):
+        """
+        Refreshes Stage Position.
+
+        Kills update job, if an error occurred.
+        """
+        try:
+            self.coordinate = self.stage.get_current_position()
+        except Exception as exc:
+            self.after_cancel(self._update_pos_job)
+            raise RuntimeError(exc)
+
+        self.after(self.REFRESHING_RATE, self._refresh_position)

--- a/LabExT/View/StageCalibration/StageCalibrationController.py
+++ b/LabExT/View/StageCalibration/StageCalibrationController.py
@@ -6,7 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from LabExT.View.StageCalibration.StageCalibrationView import StageCalibrationView
-from LabExT.Movement.Calibration import CalibrationError
+from LabExT.Movement.Calibration import CalibrationError, DevicePort, Orientation
 
 
 class StageCalibrationController:
@@ -30,6 +30,26 @@ class StageCalibrationController:
         for calibration, axes_rotation in axes_rotations.items():
             try:
                 calibration.fix_coordinate_system(axes_rotation)
+            except CalibrationError as e:
+                errors.update({calibration: e})
+
+        if errors:
+            raise CalibrationError(errors)
+
+        if self.experiment_manager:
+            self.experiment_manager.main_window.refresh_context_menu()
+
+        return True
+
+    def save_single_point_fixation(self, fixations):
+        """
+        Saves for each calibration the single point fixation.
+        """
+        errors = {}
+
+        for calibration, fixation in fixations.items():
+            try:
+                calibration.fix_single_point(fixation)
             except CalibrationError as e:
                 errors.update({calibration: e})
 

--- a/LabExT/View/StageCalibration/StageCalibrationView.py
+++ b/LabExT/View/StageCalibration/StageCalibrationView.py
@@ -8,11 +8,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from tkinter import W, Frame, Label, OptionMenu, StringVar, Button, messagebox, NORMAL, DISABLED, LEFT, RIGHT, TOP, X
 from functools import partial
 from itertools import product
+from LabExT.Movement.Transformations import SinglePointFixation
+from LabExT.View.Movement.CoordinatePairingsWindow import CoordinatePairingsWindow
 from bidict import bidict
 from typing import Type
 
 from LabExT.Movement.Calibration import AxesRotation, Calibration, Axis, CalibrationError, Direction
-from LabExT.Utils import run_with_wait_window
+from LabExT.Utils import run_with_wait_window, try_to_lift_window
 from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.Wizard import Wizard
 
@@ -65,6 +67,23 @@ class StageCalibrationView(Wizard):
 
             self._axis_calibration_vars[calibration] = axes_vars
 
+        # -- 2. STEP: FIX SINGLE POINT --
+        self.fix_single_point_step = self.add_step(
+            self._fix_single_point_step_builder,
+            title="Fix Single Point",
+            on_reload=self._check_single_point_fixations,
+            on_next=self._on_save_single_point_fixations)
+        # Step state and variables
+        self._current_single_point_fixations = {
+            c: SinglePointFixation() for c in self.mover.calibrations.values()}
+
+        # Global state
+        self._coordinate_pairing_window = None
+
+        # Connect steps
+        self.fix_coordinate_system_step.next_step = self.fix_single_point_step
+        self.fix_single_point_step.previous_step = self.fix_coordinate_system_step
+
         # Start Wizard by setting the current step
         self.current_step = self.fix_coordinate_system_step
 
@@ -115,6 +134,37 @@ class StageCalibrationView(Wizard):
                 self._axis_wiggle_buttons.setdefault(
                     calibration, {})[chip_axis] = wiggle_button
 
+    def _fix_single_point_step_builder(self, frame):
+        """
+        Step builder to fix a single point.
+        """
+        frame.title = "Fix Single Point"
+
+        step_description = Label(
+            frame,
+            text="To move the stage absolute to chip coordinates, a stage coordinate is fixed with a chip coordinate and the translation of the two coordinate systems is calculated. \n" +
+            "Note: It is assumed that the chip and stage coordinate axes are parallel, which is not necessarily the case. Therefore this is only an approximation.")
+        step_description.pack(side=TOP, fill=X)
+
+        for calibration in self.mover.calibrations.values():
+            single_point_fixation_frame = CustomFrame(frame)
+            single_point_fixation_frame.title = str(calibration)
+            single_point_fixation_frame.pack(side=TOP, fill=X, pady=2)
+
+            current_fixation = self._current_single_point_fixations[calibration]
+
+            Label(
+                single_point_fixation_frame,
+                text=str(current_fixation),
+                foreground='#4BB543' if current_fixation.is_valid else "#FF3333",
+            ).pack(
+                side=LEFT)
+
+            Button(
+                single_point_fixation_frame,
+                text="Update Pairing ...",
+                command=partial(self._on_single_point_fixation, calibration)
+            ).pack(side=RIGHT)
     #
     #   Callback
     #
@@ -130,7 +180,6 @@ class StageCalibrationView(Wizard):
         """
         selection = self._axis_calibration_vars[calibration][chip_axis].get()
         direction, stage_axis = self.STAGE_AXIS_OPTIONS.inverse[selection]
-
         self._current_axes_rotations[calibration].update(
             chip_axis=chip_axis, stage_axis=stage_axis, direction=direction
         )
@@ -195,3 +244,69 @@ class StageCalibrationView(Wizard):
             self._performing_wiggle = False
 
         self.lift()
+
+    def _on_single_point_fixation(self, calibration):
+        """
+        Callback, when user wants to update the single point fixation
+        """
+        if self._force_only_one_coordinate_window():
+            self._coordinate_pairing_window = CoordinatePairingsWindow(
+                self.experiment_manager,
+                parent=self,
+                in_calibration=calibration if calibration.is_input_stage else None,
+                out_calibration=calibration if calibration.is_output_stage else None)
+            self.wait_window(self._coordinate_pairing_window)
+            pairings = self._coordinate_pairing_window.pairings
+            if(len(pairings) > 0):
+                self._current_single_point_fixations[calibration].update(
+                    pairings[0])
+
+            self._coordinate_pairing_window = None
+            self.__reload__()
+
+    def _check_single_point_fixations(self):
+        """
+        Callback, when single point fixation step gets reloaded.
+
+        Checks, if the current fixations are valid.
+        """
+        if all(f.is_valid for f in self._current_single_point_fixations.values()):
+            self.current_step.next_step_enabled = True
+            self.set_error("")
+        else:
+            self.current_step.next_step_enabled = False
+            self.set_error("Please define a point to fix for all stages.")
+
+    def _on_save_single_point_fixations(self):
+        """
+        Callback, when user finishes single point fixation.
+        """
+        try:
+            self.controller.save_single_point_fixation(
+                self._check_single_point_fixations)
+        except CalibrationError as exec:
+            messagebox.showerror("Error", str(exec))
+            return False
+
+        return True
+
+    #
+    #   Helper
+    #
+
+    def _force_only_one_coordinate_window(self) -> bool:
+        """
+        Ensures that only one window exists to create a new coordinate pair.
+
+        Returns True if it is ok, to create a new window.
+        """
+        if self._coordinate_pairing_window is None:
+            return True
+
+        if messagebox.askyesno(
+            "New Coordinate-Pairing",
+                "You have an unfinished coordinate pairing creation. Do you want to cancel it and create a new one?"):
+            self._coordinate_pairing_window._cancel()
+            return True
+        else:
+            return not try_to_lift_window(self._coordinate_pairing_window)

--- a/LabExT/View/StageCalibration/StageCalibrationView.py
+++ b/LabExT/View/StageCalibration/StageCalibrationView.py
@@ -283,7 +283,7 @@ class StageCalibrationView(Wizard):
         """
         try:
             self.controller.save_single_point_fixation(
-                self._check_single_point_fixations)
+                self._current_single_point_fixations)
         except CalibrationError as exec:
             messagebox.showerror("Error", str(exec))
             return False


### PR DESCRIPTION
# Movement Update: Single Point Fixation
This PR adds another step to the calibration of the stages. For each stage a coordinate pair of chip and stage coordinate is defined, which can be used to calculate a translation. Together with the axis-calibration it is possible to move approximate absolute in chip-coordinates.

## All changes in detail:
- `Transformation`: Is an abstract base class, so this cannot be initialised directly and provides an interface for all transformations in LabExT. This requires that the functions `chip_to_stage`, `stage_to_chip` and `is_valid` are defined.
- `CoordinatePairing`: `NamedTuple`. Quadruple of calibration (aka stage), stage coordinate (list), device and chip coordinate.
- `SinglePointFixation` is a transformation. It stores a chip and stage cooridnate and calculates an offset from these. This is added to the coordinate at `chip_to_stage` and `stage_to_chip`.
- `CoordinatePairingsWindow` is a simple window that can be passed one or two calibrations, where one must be an input and the other an output stage. After selecting a device and asking to move the stages to the ports, 1 or 2 pairings are created (depending on how many calibrations have been passed).
- `StageCalibrationView` and `StageCalibrationController` have been adapted for the new step
- Tests for all new methods
<img width="1204" alt="Screenshot 2022-02-21 at 10 57 15" src="https://user-images.githubusercontent.com/14354617/154931843-590aa84f-7433-4ac3-beb3-a55f4cfaae77.png">
<img width="998" alt="Screenshot 2022-02-21 at 10 57 31" src="https://user-images.githubusercontent.com/14354617/154931856-7adfd141-e53c-4639-8c2b-525943a94e4d.png">
<img width="998" alt="Screenshot 2022-02-21 at 10 57 39" src="https://user-images.githubusercontent.com/14354617/154931858-d1d188d7-a0bf-4d10-8874-0b3a37ed1247.png">
<img width="1200" alt="Screenshot 2022-02-21 at 10 57 52" src="https://user-images.githubusercontent.com/14354617/154931860-5a9f2b7a-3025-4ba1-8236-d6983c5ebae4.png">
