### PR TITLE
Adding a full click-through unittest of running an InsertionLoss measurement with simulated instruments

### DIFF
--- a/.github/workflows/labext-ci.yml
+++ b/.github/workflows/labext-ci.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install -r requirements_testing.txt
     - name: Running tests
       run: tox

--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -75,9 +75,8 @@ class ExperimentManager:
 
         # create global unique resource manager
         global RESOURCE_MANAGER
-        if RESOURCE_MANAGER is not None:
-            raise RuntimeError("ExperimentManager must only be instantiated once!")
-        RESOURCE_MANAGER = ReusingResourceManager(get_visa_lib_string())
+        if RESOURCE_MANAGER is None:
+            RESOURCE_MANAGER = ReusingResourceManager(get_visa_lib_string())
         self.resource_manager = RESOURCE_MANAGER
 
         # create a new StandardExperiment

--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -45,7 +45,7 @@ class ExperimentManager:
         Takes care of all movement related actions.
     """
 
-    def __init__(self, root, log_file_path, chip=None):
+    def __init__(self, root, log_file_path, chip=None, skip_setup=False):
         """Constructor.
 
         Parameters
@@ -84,41 +84,44 @@ class ExperimentManager:
         self.exp = StandardExperiment(self, root, chip, self.mover)
         self.peak_searcher.set_experiment(self.exp)
 
-        # load addon settings from settings file
-        self.load_addon_settings()
+        if not skip_setup:  # only True in case of testing
 
-        # here we start fully loading LabExT. Its also where we start the Progressbar.
-        # Although Tkinter is technically thread - safe(assuming Tk is built with --enable - threads), practically
-        # speaking there are still problems when used in multithreaded Python applications. The problems stem from
-        # the fact that the _tkinter module attempts to gain control of the main thread via a polling technique
-        # when processing calls from other threads.
-        # This is why we need to put all the setting up into a different thread (yayy)
-        # since we are working in a diffrent thread, we need a variable to signal the end of the process
-        self.setup_done = False
-        # here we set up the progress bar
-        self.pgb = ProgressBar(root, 'Welcome to LabExt\nWe are setting everything up for you!')
-        # this is needed, since tk automatically opens a root window, which we do not want. The withdraw
-        # command hides that window
-        root.withdraw()
+            # load addon settings from settings file
+            self.load_addon_settings()
 
-        # now we can start the setup thread, we pass the text variable as an argument, so we can send updates
-        # to the window
-        Thread(target=self.setup_runner).start()
+            # here we start fully loading LabExT. Its also where we start the Progressbar.
+            # Although Tkinter is technically thread - safe(assuming Tk is built with --enable - threads), practically
+            # speaking there are still problems when used in multithreaded Python applications. The problems stem from
+            # the fact that the _tkinter module attempts to gain control of the main thread via a polling technique
+            # when processing calls from other threads.
+            # This is why we need to put all the setting up into a different thread (yayy)
+            # since we are working in a diffrent thread, we need a variable to signal the end of the process
+            self.setup_done = False
+            # here we set up the progress bar
+            self.pgb = ProgressBar(root, 'Welcome to LabExt\nWe are setting everything up for you!')
+            # this is needed, since tk automatically opens a root window, which we do not want. The withdraw
+            # command hides that window
+            root.withdraw()
 
-        # this little loop here updates the progress bar
-        while not self.setup_done:
-            self.pgb.update_idletasks()
-            self.pgb.update()
+            # now we can start the setup thread, we pass the text variable as an argument, so we can send updates
+            # to the window
+            Thread(target=self.setup_runner).start()
 
-        # finally, we can destroy the progress bar window and continue with setting up the main window
-        self.pgb.destroy()
+            # this little loop here updates the progress bar
+            while not self.setup_done:
+                self.pgb.update_idletasks()
+                self.pgb.update()
 
-        # recall the root window since we hid it during progress bar loading
-        root.deiconify()
+            # finally, we can destroy the progress bar window and continue with setting up the main window
+            self.pgb.destroy()
+
+            # recall the root window since we hid it during progress bar loading
+            root.deiconify()
 
         # create and open main window GUI
         self.main_window = MainWindowController(self._root, self)
-        self.main_window.offer_chip_reload_possibility()
+        if not skip_setup:
+            self.main_window.offer_chip_reload_possibility()
 
         # update status the first time
         self.main_window.model.status_mover_driver_enabled.set(self.mover.mover_enabled)

--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -10,6 +10,8 @@ import _tkinter
 import tkinter
 import pytest
 from unittest import TestCase
+import random
+import string
 
 
 class TKinterTestCase(TestCase):
@@ -70,3 +72,8 @@ def ask_user_yes_no(ask_string="Is one kg of feathers lighter than one kg of iro
             raise RuntimeError("User aborted yes-no-question.")
         else:
             continue
+
+
+def randomword(length):
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for _ in range(length))

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -7,6 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 from unittest.mock import patch, mock_open
+from pathlib import Path
 
 from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
@@ -32,7 +33,7 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_without_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
@@ -47,8 +48,8 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_with_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
-        new_driver_path = '/my/new/path.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
+        new_driver_path = str(Path('/my/new/path.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -28,8 +28,8 @@ def simulator_only_instruments_descriptions(name):
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):
-        with patch('ExperimentManager.get_visa_lib_string', lambda: "@py"):
-            with patch('ExperimentManager.setup_instruments_config', lambda: False):
+        with patch('LabExT.ExperimentManager.get_visa_lib_string', lambda: "@py"):
+            with patch('LabExT.ExperimentManager.setup_instruments_config', lambda: False):
                 self.expm = ExperimentManager(self.root, "", skip_setup=True)
                 self.expm.exp.measurements_classes['InsertionLossSweep'] = InsertionLossSweep
                 self.expm.instrument_api.instruments['LaserSimulator'] = LaserSimulator

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -168,7 +168,7 @@ class MainWindowTest(TKinterTestCase):
                     self.pump_events()
 
             # wait for the simulated measurement to complete
-            sleep(10)  # maximum real-life test time is about 5s with above given params
+            self.mwm.experiment_handler._experiment_thread.join()
             self.pump_events()
 
             # check if provided values are actually saved to the objects in LabExT

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -171,7 +171,7 @@ class MainWindowTest(TKinterTestCase):
             sleep(10)  # maximum real-life test time is about 5s with above given params
             self.pump_events()
 
-            # check if provided values are actually saved in the dictionary
+            # check if provided values are actually saved to the objects in LabExT
             self.assertEqual(len(self.expm.exp.to_do_list), 0)
             self.assertEqual(len(self.expm.exp.measurements), 1)
             executed_measurement = self.expm.exp.measurements[0]
@@ -194,8 +194,7 @@ class MainWindowTest(TKinterTestCase):
                                  {'wavelength start', 'wavelength stop', 'wavelength step', 'sweep speed', 'laser power',
                                   'powermeter range', 'users comment'})
 
-            # check content
-            # check metadata in the saved dictionary
+            # check content in the dictionary saved in the executed measurements
             check_meas_dict_meta_data(executed_measurement)
             # for checking the simulated data, we can re-use the checker function from the measurement's test
             check_ILsweep_data_output(test_inst=self, data_dict=executed_measurement, params_dict=ps)

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+from time import sleep
+from unittest.mock import patch
+
+from LabExT.ExperimentManager import ExperimentManager
+from LabExT.Instruments.LaserSimulator import LaserSimulator
+from LabExT.Instruments.PowerMeterSimulator import PowerMeterSimulator
+from LabExT.Measurements.InsertionLossSweep import InsertionLossSweep
+from LabExT.Tests.Utils import TKinterTestCase
+
+
+def simulator_only_instruments_descriptions(name):
+    if name[0:5] == 'Laser':
+        return [{"visa": "None", "class": "LaserSimulator", "channels": [0, 1, 2, 3, 4] }]
+    elif name[0:10] == 'PowerMeter':
+        return [{"visa": "None", "class": "PowerMeterSimulator", "channels": [1, 2, 3, 4] }]
+    elif name[0:3] == 'OSA':
+        return [{"visa": "None", "class": "OpticalSpectrumAnalyzerSimulator", "channels": []}]
+    else:
+        raise ValueError('Unknown name for simulator descriptions:' + str(name))
+
+
+class MainWindowTest(TKinterTestCase):
+
+    def main_window_setup(self):
+
+        # TODO: the patching does not work all cases!
+        with patch('LabExT.Utils.get_visa_lib_string', lambda: "@py"):
+            self.expm = ExperimentManager(self.root, "", skip_setup=True)
+            self.expm.exp.measurements_classes['InsertionLossSweep'] = InsertionLossSweep
+            self.expm.instrument_api.instruments['LaserSimulator'] = LaserSimulator
+            self.expm.instrument_api.instruments['PowerMeterSimulator'] = PowerMeterSimulator
+            self.mwc = self.expm.main_window
+            self.mwm = self.mwc.model
+            self.mwv = self.mwc.view
+
+    def test_mainwindow_initial_state(self):
+
+        self.main_window_setup()
+
+        # full transformation and sfp need initialization before usage
+        self.assertFalse(self.mwm.status_transformation_enabled.get())
+        self.assertFalse(self.mwm.status_sfp_initialized.get())
+
+        # no ToDos and now loaded measurements at beginning
+        self.assertEqual(len(self.expm.exp.to_do_list), 0)
+        self.assertEqual(len(self.expm.exp.measurements), 0)
+
+        # assert no devices loaded
+        self.assertIsNone(self.expm.chip)
+
+    def test_mainwindow_single_IL_sweep(self):
+
+        # TODO: the patching does not work all cases!
+        with patch('LabExT.Utils.get_visa_address', simulator_only_instruments_descriptions):
+
+            self.main_window_setup()
+
+            # open new measurement wizard
+            self.mwv.frame.buttons_frame.new_meas_button.invoke()
+            self.pump_events()
+            new_meas_wizard_c = self.mwm.last_opened_new_meas_wizard_controller
+
+            # stage 0: ad-hoc device
+            new_meas_wizard_c.view.s0_adhoc_frame._entry_id.delete(0, "end")
+            new_meas_wizard_c.view.s0_adhoc_frame._entry_id.insert(0, '999')
+            new_meas_wizard_c.view.s0_adhoc_frame._entry_type.delete(0, "end")
+            new_meas_wizard_c.view.s0_adhoc_frame._entry_type.insert(0, 'MZM')
+            new_meas_wizard_c.view.section_frames[0].continue_button.invoke()
+            self.pump_events()
+
+            # stage 1: meas selection
+            new_meas_wizard_c.view.s1_meas_name.set('InsertionLossSweep')
+            new_meas_wizard_c.view.section_frames[1].continue_button.invoke()
+            self.pump_events()
+
+            # stage 2: instrument selection - modify saved roles
+            laser_role = new_meas_wizard_c.view.s2_instrument_selector.instrument_source['Laser']
+            opm_role = new_meas_wizard_c.view.s2_instrument_selector.instrument_source['Power Meter']
+            lsim = [l for l in laser_role.choices_human_readable_desc if "LaserSimulator" in l][0]
+            pmsim = [l for l in opm_role.choices_human_readable_desc if "PowerMeterSimulator" in l][0]
+            laser_role.selected_instr.set(lsim)
+            laser_role.selected_channel.set("0")
+            opm_role.selected_instr.set(pmsim)
+            opm_role.selected_channel.set("1")
+
+            new_meas_wizard_c.view.section_frames[2].continue_button.invoke()
+            self.pump_events()
+
+            # stage 3: parameter selection
+            ps = new_meas_wizard_c.view.s3_measurement_param_table._parameter_source
+            ps['wavelength start'].value = 1500
+            ps['wavelength stop'].value = 1600
+            ps['wavelength step'].value = 10.0
+            ps['sweep speed'].value = 50.0
+            ps['laser power'].value = -10.0
+            ps['powermeter range'].value = -80.0
+            ps['users comment'].value = 'automated testing'
+
+            # TODO: use this patch to not save to file when testing
+            #with patch('LabExT.View.Controls.ParameterTable.serialize'):
+            new_meas_wizard_c.view.section_frames[3].continue_button.invoke()
+            self.pump_events()
+
+            # stage 4: save
+            new_meas_wizard_c.view.section_frames[4].continue_button.invoke()
+            self.pump_events()
+
+            # Back to Main Window: run simulation measurement
+            self.assertEqual(len(self.expm.exp.to_do_list), 1)
+            self.assertEqual(len(self.expm.exp.measurements), 0)
+
+            # this needs to be patched, otherwise measurement executor thread fails
+            # ToDo: find out how to patch this properly
+            with patch('LabExT.View.MainWindow.MainWindowModel'):
+                self.mwm.commands[0].button_handle.invoke()
+                self.pump_events()
+
+            sleep(10)
+            self.pump_events()
+
+            self.assertEqual(len(self.expm.exp.to_do_list), 0)
+            self.assertEqual(len(self.expm.exp.measurements), 1)

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -116,12 +116,13 @@ class MainWindowTest(TKinterTestCase):
 
             # this needs to be patched, otherwise measurement executor thread fails
             # ToDo: find out how to patch this properly
-            with patch.object(self.mwm, 'exctrl_vars_changed'):
-                with patch.object(self.expm.exp, 'read_parameters_to_variables'):
-                    with patch.object(self.mwc, 'update_tables'):
-                        with patch.object(self.mwm, 'on_experiment_finished'):
-                            self.mwm.commands[0].button_handle.invoke()
-                            self.pump_events()
+            with patch('LabExT.Experiments.StandardExperiment.AutosaveDict.save'):
+                with patch.object(self.mwm, 'exctrl_vars_changed'):
+                    with patch.object(self.expm.exp, 'read_parameters_to_variables'):
+                        with patch.object(self.mwc, 'update_tables'):
+                            with patch.object(self.mwm, 'on_experiment_finished'):
+                                self.mwm.commands[0].button_handle.invoke()
+                                self.pump_events()
 
             sleep(10)
             self.pump_events()

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -28,14 +28,15 @@ def simulator_only_instruments_descriptions(name):
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):
-        with patch('LabExT.ExperimentManager.get_visa_lib_string', lambda: "@py"):
-            self.expm = ExperimentManager(self.root, "", skip_setup=True)
-            self.expm.exp.measurements_classes['InsertionLossSweep'] = InsertionLossSweep
-            self.expm.instrument_api.instruments['LaserSimulator'] = LaserSimulator
-            self.expm.instrument_api.instruments['PowerMeterSimulator'] = PowerMeterSimulator
-            self.mwc = self.expm.main_window
-            self.mwm = self.mwc.model
-            self.mwv = self.mwc.view
+        with patch('ExperimentManager.get_visa_lib_string', lambda: "@py"):
+            with patch('ExperimentManager.setup_instruments_config', lambda: False):
+                self.expm = ExperimentManager(self.root, "", skip_setup=True)
+                self.expm.exp.measurements_classes['InsertionLossSweep'] = InsertionLossSweep
+                self.expm.instrument_api.instruments['LaserSimulator'] = LaserSimulator
+                self.expm.instrument_api.instruments['PowerMeterSimulator'] = PowerMeterSimulator
+                self.mwc = self.expm.main_window
+                self.mwm = self.mwc.model
+                self.mwv = self.mwc.view
 
     def test_mainwindow_single_IL_sweep(self):
         with patch('LabExT.View.EditMeasurementWizard.EditMeasurementWizardController.get_visa_address',

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -243,7 +243,8 @@ class MainWindowController:
         """
         Open
         """
-        EditMeasurementWizardController(self.root, self.experiment_manager)
+        self.model.last_opened_new_meas_wizard_controller = \
+            EditMeasurementWizardController(self.root, self.experiment_manager)
 
     def repeat_last_exec_measurement(self):
         """

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -63,6 +63,8 @@ class MainWindowController:
 
         self._register_keyboard_shortcuts()
 
+        self.allow_GUI_changes = True
+
     def on_window_close(self):
         """Called when user closes the application. Save experiment
         settings in .json and call context-callback.
@@ -86,6 +88,9 @@ class MainWindowController:
     def update_tables(self, plot_new_meas=False):
         """Updates the two tables in the main window.
         """
+        if not self.allow_GUI_changes:
+            return
+
         self.logger.debug('Updating tables...')
         # set the cursor to loading
         self.root.config(cursor='circle')

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -62,6 +62,7 @@ class MainWindowModel:
         self.save_parameters = None
         self.live_plot_data = None
         self.selec_plot_data = None
+        self.last_opened_new_meas_wizard_controller = None
 
         self.load_exp_parameters()
 

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -91,6 +91,9 @@ class MainWindowModel:
         self.status_sfp_initialized = BooleanVar(self.root)
         self.status_sfp_initialized.trace("w", self.submodule_status_updated)
 
+        # for testing across threads
+        self.allow_GUI_changes = True  # set to False to not invoke TK callbacks
+
     def load_exp_parameters(self):
         """
         Loads all experiment parameters and saves them within the model.
@@ -115,6 +118,9 @@ class MainWindowModel:
         """
         Upon start of the experiment alters which buttons are pressable.
         """
+        if not self.allow_GUI_changes:
+            return
+
         # change control button states
         self.commands[0].can_execute = False  # disable the start button
         self.commands[1].can_execute = True  # enable the stop button
@@ -126,6 +132,9 @@ class MainWindowModel:
         """Called when an experiment is finished. Resets control
         buttons.
         """
+        if not self.allow_GUI_changes:
+            return
+
         self.logger.debug('Experiment finished, resetting controls...')
         self.commands[0].can_execute = True  # enable the start button
         self.commands[1].can_execute = False  # disable the stop button
@@ -141,6 +150,9 @@ class MainWindowModel:
         *args
             Tkinter arguments, not needed.
         """
+        if not self.allow_GUI_changes:
+            return
+
         self.logger.debug('State of manual mode is: %s', self.var_mm_pause.get())
         self.logger.debug('State of auto move is: %s', self.var_auto_move.get())
         self.logger.debug('State of SFP enable is: %s', self.var_sfp_ena.get())
@@ -154,6 +166,9 @@ class MainWindowModel:
         """
         Callback on any status change of the submodules
         """
+
+        if not self.allow_GUI_changes:
+            return
 
         # this variable should track Mover.mover_enabled
         mover_ena = bool(self.status_mover_driver_enabled.get())

--- a/LabExT/View/TooltipMenu.py
+++ b/LabExT/View/TooltipMenu.py
@@ -125,11 +125,14 @@ class CreateToolTip(object):
         self.tw.wm_overrideredirect(True)
         self.tw.wm_geometry("+%d+%d" % (x, y))
 
-        # here we load the docstring
-        meas_class = self.meas_class_dict[self.text]
-
-        # sanitize docstring for proper markdown display
-        sanitized = get_short_docstring(meas_class.__doc__)
+        try:
+            # load docstring from measurement class
+            meas_class = self.meas_class_dict[self.text]
+            # sanitize docstring for proper markdown display
+            sanitized = get_short_docstring(meas_class.__doc__)
+        except KeyError:
+            # unknown measurement class
+            sanitized = ''
 
         if sanitized == '' or self.text == '\n':
             sanitized = 'No description available.'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 filterwarnings =
-    error
     ignore:invalid escape sequence:SyntaxWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     error
+    "ignore:invalid escape sequence:SyntaxError"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 filterwarnings =
     error
-    "ignore:invalid escape sequence:SyntaxError"
+    ignore:invalid escape sequence:SyntaxWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
-    ignore:invalid escape sequence:SyntaxWarning
+    error
+    ignore:invalid escape sequence:DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cached-property==1.5.2
     # via
     #   h5py
     #   pytkdocs
-click==8.0.3
+click==8.1.2
     # via mkdocs
 collision==1.2.2
     # via -r .\requirements.in
@@ -18,25 +18,25 @@ colorama==0.4.4
     # via click
 cycler==0.11.0
     # via matplotlib
-fonttools==4.28.5
+fonttools==4.33.2
     # via matplotlib
 ghp-import==2.0.2
     # via mkdocs
 h5py==3.6.0
     # via -r .\requirements.in
-importlib-metadata==4.10.1
+importlib-metadata==4.11.3
     # via
     #   click
     #   markdown
     #   mkdocs
     #   pyvisa
     #   pyvisa-py
-jinja2==3.0.3
+jinja2==3.1.1
     # via
     #   mkdocs
     #   mkdocs-material
     #   mkdocstrings
-kiwisolver==1.3.2
+kiwisolver==1.4.2
     # via matplotlib
 markdown==3.3.6
     # via
@@ -45,7 +45,7 @@ markdown==3.3.6
     #   mkdocs-material
     #   mkdocstrings
     #   pymdown-extensions
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   mkdocstrings
@@ -53,21 +53,25 @@ matplotlib==3.5.1
     # via -r .\requirements.in
 mergedeep==1.3.4
     # via mkdocs
-mkdocs==1.2.3
+mkdocs==1.3.0
     # via
     #   -r .\requirements.in
     #   mkdocs-autorefs
     #   mkdocs-material
     #   mkdocstrings
-mkdocs-autorefs==0.3.1
+mkdocs-autorefs==0.4.1
     # via mkdocstrings
-mkdocs-material==8.1.7
+mkdocs-material==8.2.9
     # via -r .\requirements.in
 mkdocs-material-extensions==1.0.3
     # via mkdocs-material
-mkdocstrings==0.17.0
-    # via -r .\requirements.in
-numpy==1.21.5
+mkdocstrings==0.18.1
+    # via
+    #   -r .\requirements.in
+    #   mkdocstrings-python-legacy
+mkdocstrings-python-legacy==0.2.2
+    # via mkdocstrings
+numpy==1.21.6
     # via
     #   -r .\requirements.in
     #   h5py
@@ -77,18 +81,18 @@ packaging==21.3
     # via
     #   matplotlib
     #   mkdocs
-pillow==9.0.0
+pillow==9.1.0
     # via
     #   -r .\requirements.in
     #   matplotlib
     #   ttkwidgets
 pygments==2.11.2
     # via mkdocs-material
-pymdown-extensions==9.1
+pymdown-extensions==9.3
     # via
     #   mkdocs-material
     #   mkdocstrings
-pyparsing==3.0.6
+pyparsing==3.0.8
     # via
     #   matplotlib
     #   packaging
@@ -98,8 +102,8 @@ python-dateutil==2.8.2
     # via
     #   ghp-import
     #   matplotlib
-pytkdocs==0.15.0
-    # via mkdocstrings
+pytkdocs==0.16.1
+    # via mkdocstrings-python-legacy
 pyusb==1.2.1
     # via -r .\requirements.in
 pyvisa==1.11.3
@@ -122,15 +126,16 @@ six==1.16.0
     #   python-dateutil
 ttkwidgets==0.12.1
     # via -r .\requirements.in
-typing-extensions==4.0.1
+typing-extensions==4.2.0
     # via
     #   importlib-metadata
+    #   kiwisolver
     #   pytkdocs
     #   pyvisa
     #   pyvisa-py
-watchdog==2.1.6
+watchdog==2.1.7
     # via mkdocs
 wheel==0.37.1
     # via astunparse
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -2,6 +2,7 @@
 # This file is manually updated and describes the dependencies for running code testing for LabExT
 #
 pytest
+pytest-xvfb
+parametrized
 tox
 tox-gh-actions
-parametrized

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,0 +1,6 @@
+#
+# This file is manually updated and describes the dependencies for running code testing for LabExT
+#
+pytest
+tox
+tox-gh-actions

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -4,3 +4,4 @@
 pytest
 tox
 tox-gh-actions
+parametrized


### PR DESCRIPTION
This PR tries to add a full click-through unittest of the basic InsertionLossSweep measurement within the tkinter GUI.
