### PR TITLE
Add code linter + windows unittests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 127
+extend-ignore = E203

--- a/.github/workflows/labext-ci-linter.yml
+++ b/.github/workflows/labext-ci-linter.yml
@@ -1,0 +1,24 @@
+name: Linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black flake8 isort
+    - name: Lint with black
+      run: black --check . --exclude docs/
+    - name: Lint with flake8
+      run: flake8 .
+    - name: Run isort
+      run: isort --profile black .

--- a/.github/workflows/labext-ci-tests.yml
+++ b/.github/workflows/labext-ci-tests.yml
@@ -1,4 +1,4 @@
-name: LabExT CI
+name: Tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/labext-ci.yml
+++ b/.github/workflows/labext-ci.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Build and Upload Python Package for LabExT to PyPI
+name: Publish to PyPI
 
 on:
   release:

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -17,7 +17,7 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_dialog_initial_state(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path') as config_path:
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
@@ -33,7 +33,7 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_without_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
@@ -48,8 +48,8 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_with_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
-        new_driver_path = '/my/new/path.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
+        new_driver_path = str(Path('/my/new/path.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -61,5 +61,5 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
+                self.assertEqual(Path(dialog.driver_path), Path(new_driver_path))
                 self.assertTrue(dialog.path_has_changed)

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -7,6 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 from unittest.mock import patch, mock_open
+from pathlib import Path
 
 from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
@@ -42,7 +43,7 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(dialog.driver_path, current_driver_path)
+                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
                 self.assertFalse(dialog.path_has_changed)
 
     def test_save_with_change(self):
@@ -60,5 +61,5 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(dialog.driver_path, new_driver_path)
+                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
                 self.assertTrue(dialog.path_has_changed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,11 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 127
+include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"
+line_length = 127


### PR DESCRIPTION
We should enforce the coding style in the project, so I propose black and isort for formatting and flake8 for linting.

This PR only adds the CI tests and does not reformat any code yet. Lets take it as a ground for discussion.
