### PR TITLE
Add an optional wait time between measurements

### DIFF
--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -192,7 +192,7 @@ class StandardExperiment:
                 self.logger.info('Search for peak done.')
             else:
                 data['search for peak'] = None
-                self.logger.info('Search for peak not enabled. Not executing automatic search for peak.')
+                self.logger.debug('Search for peak not enabled. Not executing automatic search for peak.')
 
             self._parent.config(cursor='circle')
             self.logger.info('Executing measurement %s on device %s.',

--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 import socket
 import sys
+import time
 import traceback
 from collections import OrderedDict
 from glob import glob
@@ -77,6 +78,7 @@ class StandardExperiment:
         self.exctrl_pause_after_device = False
         self.exctrl_auto_move_stages = False
         self.exctrl_enable_sfp = False
+        self.exctrl_inter_measurement_wait_time = 0.0
 
         # data structures for FINISHED measurements
         self.measurements = ObservableList()
@@ -272,6 +274,12 @@ class StandardExperiment:
 
                 messagebox.showinfo("Measurements finished!", "Measurements finished!")
                 self.logger.info("Experiment and hereby all measurements finished.")
+
+                return
+
+            if self.exctrl_inter_measurement_wait_time > 0.0:
+                self.logger.info(f"Waiting {self.exctrl_inter_measurement_wait_time:.0f}s before continuing...")
+                time.sleep(self.exctrl_inter_measurement_wait_time)
 
     def load_measurement_dataset(self, meas_dict, file_path, force_gui_update=True):
         """

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -151,7 +151,6 @@ class MainWindowModel:
         if self.var_mm_pause.get():
             self.view.frame.control_panel.exctrl_wait_time.config(state='disabled')
             self.view.frame.control_panel.wait_time_lbl.config(state='disabled')
-            self.var_imeas_wait_time_str.set("0.0")
         else:
             self.view.frame.control_panel.exctrl_wait_time.config(state='normal')
             self.view.frame.control_panel.wait_time_lbl.config(state='normal')

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -49,13 +49,10 @@ class MainWindowModel:
         self.commands = list()
         start_button = ControlCommand(
             self.controller.start, self.root, name='Run (F5)')
+        self.commands.append(start_button)
         stop_button = ControlCommand(
             self.controller.stop, self.root, name='Abort (Escape)', can_execute=False)
-        finish_button = ControlCommand(
-            self.finish, self.root, name='Finish', can_execute=False)
-        self.commands.append(start_button)
         self.commands.append(stop_button)
-        self.commands.append(finish_button)
 
         self.experiment = None
         self.chip_parameters = None
@@ -108,9 +105,6 @@ class MainWindowModel:
 
     def settings(self):
         raise DeprecationWarning("Open Settings window is deprecated. Do not use!")
-
-    def finish(self):
-        raise DeprecationWarning("Finish button function is deprecated. Do not use!")
 
     def on_experiment_start(self):
         """

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import logging
 from platform import system
 from tkinter import Frame, Menu, Checkbutton, \
-    Label, StringVar, OptionMenu, LabelFrame, Button, scrolledtext
+    Label, StringVar, OptionMenu, LabelFrame, Button, scrolledtext, Entry
 
 from LabExT.Logs.LoggingWidgetHandler import LoggingWidgetHandler
 from LabExT.Utils import get_labext_version
@@ -153,28 +153,34 @@ class MainWindowControlPanel(ControlPanel):
         self.exctrl_mm_pause_reason.config(state='disabled')
         self.add_widget(self.exctrl_mm_pause_reason, column=2, row=1, sticky='we')
 
+        self.wait_time_lbl = Label(self, text="Wait time between measurements")
+        self.add_widget(self.wait_time_lbl, column=1, row=2, sticky='we')
+        self.exctrl_wait_time = Entry(self, textvariable=self.model.var_imeas_wait_time_str)
+        self.add_widget(self.exctrl_wait_time, column=2, row=2, sticky='we')
+
         self.exctrl_auto_move = Checkbutton(
             self,
             text="Automatically move Piezo Stages to device",
             variable=self.model.var_auto_move)
-        self.add_widget(self.exctrl_auto_move, column=0, row=2, columnspan=2, sticky='we')
+        self.add_widget(self.exctrl_auto_move, column=0, row=3, columnspan=2, sticky='we')
         self.exctrl_auto_move_reason = Label(self, textvariable=self.model.var_auto_move_reason)
         self.exctrl_auto_move_reason.config(state='disabled')
-        self.add_widget(self.exctrl_auto_move_reason, column=2, row=2, sticky='we')
+        self.add_widget(self.exctrl_auto_move_reason, column=2, row=3, sticky='we')
 
         self.exctrl_sfp_ena = Checkbutton(
             self,
             text="Execute Search-for-Peak before measurement",
             variable=self.model.var_sfp_ena)
-        self.add_widget(self.exctrl_sfp_ena, column=0, row=3, columnspan=2, sticky='we')
+        self.add_widget(self.exctrl_sfp_ena, column=0, row=4, columnspan=2, sticky='we')
         self.exctrl_sfp_ena_reason = Label(self, textvariable=self.model.var_sfp_ena_reason)
         self.exctrl_sfp_ena_reason.config(state='disabled')
-        self.add_widget(self.exctrl_sfp_ena_reason, column=2, row=3, sticky='we')
+        self.add_widget(self.exctrl_sfp_ena_reason, column=2, row=4, sticky='we')
 
         self.rowconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
         self.rowconfigure(2, weight=1)
         self.rowconfigure(3, weight=1)
+        self.rowconfigure(4, weight=1)
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
         self.columnconfigure(2, weight=1)

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -153,7 +153,7 @@ class MainWindowControlPanel(ControlPanel):
         self.exctrl_mm_pause_reason.config(state='disabled')
         self.add_widget(self.exctrl_mm_pause_reason, column=1, row=1, sticky='we')
 
-        self.wait_time_lbl = Label(self, text="Wait time between measurements")
+        self.wait_time_lbl = Label(self, text="Seconds to wait between measurements")
         self.add_widget(self.wait_time_lbl, column=0, row=2, sticky='e')
         self.exctrl_wait_time = Entry(self, textvariable=self.model.var_imeas_wait_time_str)
         self.add_widget(self.exctrl_wait_time, column=1, row=2, sticky='w', padx=5, pady=5)

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -140,41 +140,41 @@ class MainWindowControlPanel(ControlPanel):
         self.logger.debug('Adding control buttons..')
         self.grid(row=5, column=0, sticky='we')
         self.title = 'Execute ToDos'
-        self.button_width = 15
         self.command_source = self.model.commands
+        self.button_width = None
 
         # add checkboxes for execution controls
         self.exctrl_mm_pause = Checkbutton(
             self,
             text="Pause after every device (Manual Mode)",
             variable=self.model.var_mm_pause)
-        self.add_widget(self.exctrl_mm_pause, column=0, row=1, columnspan=2, sticky='we')
+        self.add_widget(self.exctrl_mm_pause, column=0, row=1, sticky='we')
         self.exctrl_mm_pause_reason = Label(self, textvariable=self.model.var_mm_pause_reason)
         self.exctrl_mm_pause_reason.config(state='disabled')
-        self.add_widget(self.exctrl_mm_pause_reason, column=2, row=1, sticky='we')
+        self.add_widget(self.exctrl_mm_pause_reason, column=1, row=1, sticky='we')
 
         self.wait_time_lbl = Label(self, text="Wait time between measurements")
-        self.add_widget(self.wait_time_lbl, column=1, row=2, sticky='we')
+        self.add_widget(self.wait_time_lbl, column=0, row=2, sticky='e')
         self.exctrl_wait_time = Entry(self, textvariable=self.model.var_imeas_wait_time_str)
-        self.add_widget(self.exctrl_wait_time, column=2, row=2, sticky='we')
+        self.add_widget(self.exctrl_wait_time, column=1, row=2, sticky='w', padx=5, pady=5)
 
         self.exctrl_auto_move = Checkbutton(
             self,
             text="Automatically move Piezo Stages to device",
             variable=self.model.var_auto_move)
-        self.add_widget(self.exctrl_auto_move, column=0, row=3, columnspan=2, sticky='we')
+        self.add_widget(self.exctrl_auto_move, column=0, row=3, sticky='we')
         self.exctrl_auto_move_reason = Label(self, textvariable=self.model.var_auto_move_reason)
         self.exctrl_auto_move_reason.config(state='disabled')
-        self.add_widget(self.exctrl_auto_move_reason, column=2, row=3, sticky='we')
+        self.add_widget(self.exctrl_auto_move_reason, column=1, row=3, sticky='we')
 
         self.exctrl_sfp_ena = Checkbutton(
             self,
             text="Execute Search-for-Peak before measurement",
             variable=self.model.var_sfp_ena)
-        self.add_widget(self.exctrl_sfp_ena, column=0, row=4, columnspan=2, sticky='we')
+        self.add_widget(self.exctrl_sfp_ena, column=0, row=4, sticky='we')
         self.exctrl_sfp_ena_reason = Label(self, textvariable=self.model.var_sfp_ena_reason)
         self.exctrl_sfp_ena_reason.config(state='disabled')
-        self.add_widget(self.exctrl_sfp_ena_reason, column=2, row=4, sticky='we')
+        self.add_widget(self.exctrl_sfp_ena_reason, column=1, row=4, sticky='we')
 
         self.rowconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
@@ -182,8 +182,7 @@ class MainWindowControlPanel(ControlPanel):
         self.rowconfigure(3, weight=1)
         self.rowconfigure(4, weight=1)
         self.columnconfigure(0, weight=1)
-        self.columnconfigure(1, weight=1)
-        self.columnconfigure(2, weight=1)
+        self.columnconfigure(1, weight=2)
 
 
 class MainWindowCouplingTools(LabelFrame):


### PR DESCRIPTION
# Goal
Add an optional waiting time

# Approach
Below the manual mode checkbox in the experiment control section in the main GUI there is now a text box entry which allows to enter the wait time. When running the experiment and manual mode is disabled, the experiment runner will pause for the set amount of seconds after every successfully completed ToDo.

# Implementation
* The wait time can only be changed if manual mode is disabled. If a negative number is entered, the wait time is set to 0.
* Also removed the "Finish" button from the main window, as it was without functionality anyway.

# Compatibility
No compatibility issues expected.