### PR TITLE
Movement Calibration [2/7] Coordinate system management

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -5,15 +5,54 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from typing import Type
+from typing import Type, Union
+from functools import wraps
+from contextlib import contextmanager
 
 from LabExT.Movement.config import DevicePort, Orientation, State
-from LabExT.Movement.Transformations import SinglePointOffset, AxesRotation, KabschRotation
+from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, SinglePointOffset, AxesRotation, KabschRotation
 from LabExT.Movement.Stage import StageError
 
 
 class CalibrationError(RuntimeError):
     pass
+
+
+def assert_minimum_state_for_coordinate_system(
+    chip_coordinate_system=None,
+    stage_coordinate_system=None
+):
+    """
+    Decorator to require a minimum calibration state to perform the given function in the given coordinate system.
+
+    Parameters
+    ----------
+    chip_coordinate_system : State
+        Minimum state to execute the method in the chip coordinate system.
+    stage_coordinate_system : State
+        Minimum state to execute the method in the stage coordinate system.
+    """
+    def assert_state(func):
+        @wraps(func)
+        def wrap(calibration: Type[Calibration], *args, **kwargs):
+            if calibration.coordinate_system is None:
+                raise CalibrationError(
+                    "Function {} needs a cooridnate system to operate in. Please use the context to set the system.".format(
+                        func.__name__))
+
+            if calibration.coordinate_system == ChipCoordinate and calibration.state < chip_coordinate_system:
+                raise CalibrationError(
+                    "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
+                        func.__name__, chip_coordinate_system))
+
+            if calibration.coordinate_system == StageCoordinate and calibration.state < stage_coordinate_system:
+                raise CalibrationError(
+                    "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(
+                        func.__name__, stage_coordinate_system))
+
+            return func(calibration, *args, **kwargs)
+        return wrap
+    return assert_state
 
 
 class Calibration:
@@ -28,6 +67,8 @@ class Calibration:
         self._state = State.CONNECTED if stage.connected else State.UNINITIALIZED
         self._orientation = orientation
         self._device_port = device_port
+
+        self._corrdinate_system = None
 
         self._axes_rotation: Type[AxesRotation] = None
         self._single_point_offset: Type[SinglePointOffset] = None
@@ -76,6 +117,76 @@ class Calibration:
         Returns True if the stage will move to the output of a device.
         """
         return self._device_port == DevicePort.OUTPUT
+
+    #
+    #   Coordinate System Control
+    #
+
+    @property
+    def coordinate_system(
+            self) -> Union[None, StageCoordinate, ChipCoordinate]:
+        """
+        Returns the current coordinate system
+        """
+        return self._corrdinate_system
+
+    @coordinate_system.setter
+    def coordinate_system(self, system) -> None:
+        """
+        Sets the current coordinate system
+
+        If None, the system will be reset.
+
+        Parameters
+        ----------
+        system : Coordinate
+            Coordinate system to be stored, either chip or stage system.
+
+        Raises
+        ------
+        ValueError
+            If the requested system is not supported.
+        CalibrationError
+            If a coordinate system is already set.
+        """
+        if system is None:
+            self._coordinate_system = None
+            return
+
+        if system not in [ChipCoordinate, StageCoordinate]:
+            raise ValueError(
+                f"The requested coordinate system {system} is not supported.")
+
+        if self._coordinate_system is not None:
+            raise CalibrationError("A coordinate system is already set.")
+
+        self._coordinate_system = system
+
+    @contextmanager
+    def perform_in_chip_coordinates(self):
+        """
+        Context manager to execute a block of instructions in chip coordinates.
+
+        Sets the coordinate system to chip system first and resets the system at the end.
+        """
+        self.coordinate_system = ChipCoordinate
+        try:
+            yield
+        finally:
+            self.coordinate_system = None
+
+    @contextmanager
+    def perform_in_stage_coordinates(self):
+        """
+        Context manager to execute a block of instructions in stage coordinates.
+
+        Sets the coordinate system to stage system first and resets the system at the end.
+        """
+        self.coordinate_system = StageCoordinate
+        try:
+            yield
+        finally:
+            self.coordinate_system = None
 
     #
     #   Calibration Setup Methods

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -68,7 +68,7 @@ class Calibration:
         self._orientation = orientation
         self._device_port = device_port
 
-        self._corrdinate_system = None
+        self._coordinate_system = None
 
         self._axes_rotation: Type[AxesRotation] = None
         self._single_point_offset: Type[SinglePointOffset] = None
@@ -128,7 +128,7 @@ class Calibration:
         """
         Returns the current coordinate system
         """
-        return self._corrdinate_system
+        return self._coordinate_system
 
     @coordinate_system.setter
     def coordinate_system(self, system) -> None:

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -7,6 +7,7 @@ for details see LICENSE file.
 """
 
 from enum import Enum, auto
+from functools import total_ordering
 
 
 class BaseEnum(Enum):
@@ -46,6 +47,7 @@ class DevicePort(BaseEnum):
     OUTPUT = auto()
 
 
+@total_ordering
 class State(BaseEnum):
     """
     Enumerate different calibration states.
@@ -57,3 +59,21 @@ class State(BaseEnum):
     FULLY_CALIBRATED = 4
 
     def __str__(self) -> str: return self.name.replace('_', ' ').capitalize()
+
+    def __eq__(self, other):
+        """
+        Compare two states for equality.
+        """
+        if self.__class__ is other.__class__:
+            return self.value == other.value
+
+        return NotImplemented
+
+    def __lt__(self, other):
+        """
+        Compare two states on "less than".
+        """
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+
+        return NotImplemented

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import unittest
+from unittest.mock import Mock
+from parameterized import parameterized
+
+from LabExT.Movement.config import State, Orientation, DevicePort
+from LabExT.Movement.Stage import Stage
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.Movement.Transformations import ChipCoordinate, StageCoordinate
+from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
+
+EXPECTED_TO_REJECT = [
+    (State.UNINITIALIZED, [State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
+    (State.CONNECTED, [State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
+    (State.COORDINATE_SYSTEM_FIXED, [State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
+    (State.SINGLE_POINT_FIXED, [State.FULLY_CALIBRATED])]
+
+EXPECTED_TO_ACCEPT = [
+    (State.UNINITIALIZED, [State.UNINITIALIZED]),
+    (State.CONNECTED, [State.UNINITIALIZED, State.CONNECTED]),
+    (State.COORDINATE_SYSTEM_FIXED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED]),
+    (State.SINGLE_POINT_FIXED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED]),
+    (State.FULLY_CALIBRATED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED])]
+
+class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.calibration = Mock(spec=Calibration)
+        self.func = Mock()
+        self.func.__name__ = "Dummy Function"
+
+        self.low_state = 0
+        self.high_state = 1
+
+        return super().setUp()
+
+    def test_raises_error_if_coordinate_system_is_not_fixed(self):
+        self.calibration.coordinate_system = None
+
+        with self.assertRaises(CalibrationError):
+            assert_minimum_state_for_coordinate_system()(self.func)(self.calibration)
+
+        self.func.assert_not_called()
+
+    @parameterized.expand(EXPECTED_TO_REJECT)
+    def test_rejectes_all_states_higher_than_given_in_chip_system(
+            self,
+            given_state,
+            required_states):
+        self.calibration.coordinate_system = ChipCoordinate
+        self.calibration.state = given_state
+
+        for required_state in required_states:
+            with self.assertRaises(CalibrationError):
+                assert_minimum_state_for_coordinate_system(
+                    chip_coordinate_system=required_state
+                )(self.func)(self.calibration)
+
+            self.func.assert_not_called()
+
+    @parameterized.expand(EXPECTED_TO_REJECT)
+    def test_rejectes_all_states_higher_than_given_in_stage_system(
+            self,
+            given_state,
+            required_states):
+        self.calibration.coordinate_system = StageCoordinate
+        self.calibration.state = given_state
+
+        for required_state in required_states:
+            with self.assertRaises(CalibrationError):
+                assert_minimum_state_for_coordinate_system(
+                    stage_coordinate_system=required_state
+                )(self.func)(self.calibration)
+
+            self.func.assert_not_called()
+
+    @parameterized.expand(EXPECTED_TO_ACCEPT)
+    def test_accepts_all_states_higher_than_given_in_chip_system(
+            self,
+            given_state,
+            required_states):
+        self.calibration.coordinate_system = ChipCoordinate
+        self.calibration.state = given_state
+
+        for required_state in required_states:
+            assert_minimum_state_for_coordinate_system(
+                chip_coordinate_system=required_state
+            )(self.func)(self.calibration)
+
+            self.func.assert_called_once()
+            self.func.reset_mock()
+
+    @parameterized.expand(EXPECTED_TO_ACCEPT)
+    def test_accepts_all_states_higher_than_given_in_stage_system(
+            self,
+            given_state,
+            required_states):
+        self.calibration.coordinate_system = StageCoordinate
+        self.calibration.state = given_state
+
+        for required_state in required_states:
+            assert_minimum_state_for_coordinate_system(
+                stage_coordinate_system=required_state
+            )(self.func)(self.calibration)
+
+            self.func.assert_called_once()
+            self.func.reset_mock()
+
+
+class CoordinateSystemControlTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stage = Mock(spec=Stage)
+        self.stage.connected = False
+
+        self.mover = MoverNew(None)
+
+        self.calibration = Calibration(
+            self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
+
+        return super().setUp()
+
+    def test_set_chip_coordinate_system(self):
+        with self.calibration.perform_in_chip_coordinates():
+            self.assertEqual(
+                self.calibration.coordinate_system,
+                ChipCoordinate)
+
+        self.assertIsNone(self.calibration.coordinate_system)
+
+    def test_set_stage_coordinate_system(self):
+        with self.calibration.perform_in_stage_coordinates():
+            self.assertEqual(
+                self.calibration.coordinate_system,
+                StageCoordinate)
+
+        self.assertIsNone(self.calibration.coordinate_system)
+
+    def test_set_coordinate_system_twice(self):
+        with self.assertRaises(CalibrationError):
+            with self.calibration.perform_in_chip_coordinates():
+                self.calibration.coordinate_system = StageCoordinate
+
+        with self.assertRaises(CalibrationError):
+            with self.calibration.perform_in_stage_coordinates():
+                self.calibration.coordinate_system = ChipCoordinate
+
+    @parameterized.expand([
+        ('chip',), ('stage',), (ChipCoordinate(),), (StageCoordinate(),)
+    ])
+    def test_set_invalid_coordinate_system(self, invalid_system):
+        with self.assertRaises(ValueError):
+            self.calibration.coordinate_system = invalid_system
+
+    def test_reset_coordinate_system(self):
+        self.calibration.coordinate_system = ChipCoordinate
+        self.assertEqual(self.calibration.coordinate_system, ChipCoordinate)
+
+        self.calibration.coordinate_system = None
+        self.assertIsNone(self.calibration.coordinate_system)
+
+    def test_set_chip_coordinate_system_with_block_error(self):
+        func = Mock(side_effect=RuntimeError)
+
+        with self.assertRaises(RuntimeError):
+            with self.calibration.perform_in_chip_coordinates():
+                self.assertEqual(
+                    self.calibration.coordinate_system,
+                    ChipCoordinate)
+                func()
+
+        self.assertIsNone(self.calibration.coordinate_system)
+
+    def test_set_stage_coordinate_system_with_block_error(self):
+        func = Mock(side_effect=RuntimeError)
+
+        with self.assertRaises(RuntimeError):
+            with self.calibration.perform_in_stage_coordinates():
+                self.assertEqual(
+                    self.calibration.coordinate_system,
+                    StageCoordinate)
+                func()
+
+        self.assertIsNone(self.calibration.coordinate_system)


### PR DESCRIPTION
Adds a decorator. This decorator executes the decorated method only if the state of the calibration is at least the defined one. Different states can be defined for both coordinate systems (chip, stage). A total order among the states was defined:
```
UNINITIALIZED  < CONNECTED  < COORDINATE_SYSTEM_FIXED < SINGLE_POINT_FIXED < FULLY_CALIBRATED
```

Furthermore, a property `coordinate_system` was added to the calibration. This decides in which system later methods are to be executed. Context managers were added to facilitate handling.