### PR TITLE
Movement Calibration [3/7] Update the calibration and state

### DIFF
--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -5,8 +5,10 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+from shutil import move
 import unittest
-from unittest.mock import Mock, patch
+import numpy as np
+from unittest.mock import Mock, patch, call
 from parameterized import parameterized
 
 from LabExT.Tests.Utils import get_calibrations_from_file
@@ -312,3 +314,324 @@ class DetermineStateTest(CalibrationTestCase):
         self.assertTrue(self.calibration._kabsch_rotation.is_valid)
 
         self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+
+class CalibrationTest(CalibrationTestCase):
+
+    def test_position_in_stage_coordinate_raises_error_if_unconnected(self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.get_position()
+
+    def test_position_in_chip_coordinate_raises_error_if_not_single_point_fixed(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.get_position()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_stage_coordinates(self, get_position_mock):
+        expected_position = [100, 200, 300]
+        get_position_mock.return_value = expected_position
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        self.assertIsInstance(position, StageCoordinate)
+        self.assertEqual(position.to_list(), expected_position)
+
+        get_position_mock.assert_called_once()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_chip_coordinates_with_single_point_offset(
+            self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+        get_position_mock.return_value = expected_stage_pos
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.set_valid_single_point_offset()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
+
+        self.assertIsInstance(position, ChipCoordinate)
+        self.assertTrue(
+            np.allclose(
+                position.to_numpy(),
+                expected_chip_pos,
+                rtol=1,
+                atol=1))
+
+        get_position_mock.assert_called_once()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_chip_coordinates_with_kabsch_rotation(
+            self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+        get_position_mock.return_value = expected_stage_pos
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.set_valid_single_point_offset()
+            self.set_valid_kabsch_rotation()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+        self.assertIsInstance(position, ChipCoordinate)
+        self.assertTrue(
+            np.allclose(
+                position.to_numpy(),
+                expected_chip_pos,
+                rtol=1,
+                atol=1))
+
+        get_position_mock.assert_called_once()
+
+    def test_move_relative_in_stage_coordinate_raises_error_if_unconnected(
+            self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    def test_move_relative_in_chip_coordinate_raises_error_if_axes_rotation_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_invalid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    def test_move_relative_in_stage_coordinate_raises_error_if_offset_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_relative(ChipCoordinate(1, 2, 3))
+
+    def test_move_relative_in_chip_coordinate_raises_error_if_offset_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_relative")
+    def test_move_relative_in_stage_coordinates(
+            self, wait_for_stopping, move_relative_mock):
+        self.set_invalid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_relative(
+                StageCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+        move_relative_mock.assert_called_once_with(
+            x=required_movement[0],
+            y=required_movement[1],
+            z=required_movement[2],
+            wait_for_stopping=wait_for_stopping)
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_relative")
+    def test_move_relative_in_chip_coordinates_with_axes_rotation(
+            self, wait_for_stopping, move_relative_mock):
+        self.set_valid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_relative(
+                ChipCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+        move_relative_mock.assert_called_once_with(
+            x=required_movement[1],
+            y=-required_movement[2],
+            z=-required_movement[0],
+            wait_for_stopping=wait_for_stopping)
+    #
+    #
+    #
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(
+            self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_single_point_offset()
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_stage_coordinates(
+            self, wait_for_stopping, move_absolute_mock):
+        self.set_invalid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                StageCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+        move_absolute_mock.assert_called_once_with(
+            x=required_movement[0],
+            y=required_movement[1],
+            z=required_movement[2],
+            wait_for_stopping=wait_for_stopping)
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_single_point_offset(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
+
+        move_absolute_mock.assert_called_once()
+
+        _, kwargs = move_absolute_mock.call_args
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+                rtol=1,
+                atol=1))
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_kabsch_rotation(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        self.set_valid_kabsch_rotation()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+        move_absolute_mock.assert_called_once()
+
+        _, kwargs = move_absolute_mock.call_args
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+                rtol=1,
+                atol=1))
+
+    @parameterized.expand([
+        (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
+    ])
+    @patch.object(DummyStage, "move_relative")
+    def test_wiggle_axis_applies_axes_rotation(
+            self,
+            wiggle_axis,
+            x_movement,
+            y_movement,
+            z_movement,
+            move_relative_mock):
+
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.calibration.wiggle_axis(
+            wiggle_axis, wiggle_distance=1000, wait_time=0)
+
+        move_relative_mock.assert_has_calls([
+            call(x=y_movement, y=-z_movement, z=-x_movement, wait_for_stopping=True),
+            call(x=-y_movement, y=z_movement, z=x_movement, wait_for_stopping=True)])
+
+    @parameterized.expand([
+        (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
+    ])
+    @patch.object(DummyStage, "move_relative")
+    @patch.object(DummyStage, "set_speed_xy")
+    @patch.object(DummyStage, "set_speed_z")
+    def test_wiggle_axis_sets_and_resets_speed(
+            self,
+            wiggle_axis,
+            x_movement,
+            y_movement,
+            z_movement,
+            set_speed_z_mock,
+            set_speed_xy_mock,
+            move_relative_mock):
+        current_speed_xy = self.stage._speed_xy
+        current_speed_z = self.stage._speed_z
+
+        self.calibration.connect_to_stage()
+
+        self.calibration.wiggle_axis(
+            wiggle_axis,
+            wiggle_distance=1000,
+            wiggle_speed=5000,
+            wait_time=0)
+
+        move_relative_mock.assert_has_calls([
+            call(x=x_movement, y=y_movement, z=z_movement, wait_for_stopping=True),
+            call(x=-x_movement, y=-y_movement, z=-z_movement, wait_for_stopping=True)])
+        set_speed_z_mock.assert_has_calls([call(5000), call(current_speed_z)])
+        set_speed_xy_mock.assert_has_calls(
+            [call(5000), call(current_speed_xy)])


### PR DESCRIPTION
Adds methods to connect and disconnect from the stage and to change axis rotation, single point offset or full calibration. 
These methods call the corresponding transformations. After each update, a method is called to determine the new state of the calibration. This works as follows:

1. checks whether the stage responds. If so, the status is at least `CONNECTED`.
2. checks whether the axis rotation is valid. If yes, the status is at least `COORDINATE SYSTEM FIXED`.
3. checks whether the single point fixation is valid. If yes, the status is at least `SINGLE POINT FIXED`.
4. checks whether the full calibration is valid. If yes, the status is `FULLY CALIBRATED`.