### PR TITLE
Movement Calibration [4/7] Position of Stage

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -38,7 +38,7 @@ def assert_minimum_state_for_coordinate_system(
     """
     def assert_state(func):
         @wraps(func)
-        def wrap(calibration: Type[Calibration], *args, **kwargs):
+        def wrap(calibration: Type["Calibration"], *args, **kwargs):
             if calibration.coordinate_system is None:
                 raise CalibrationError(
                     "Function {} needs a cooridnate system to operate in. Please use the context to set the system.".format(
@@ -316,11 +316,11 @@ class Calibration:
     #   Position method
     #
 
-    @property
     @assert_minimum_state_for_coordinate_system(
         stage_coordinate_system=State.CONNECTED,
         chip_coordinate_system=State.SINGLE_POINT_FIXED)
-    def position(self) -> Union[Type[StageCoordinate], Type[ChipCoordinate]]:
+    def get_position(
+            self) -> Union[Type[StageCoordinate], Type[ChipCoordinate]]:
         """
         Method to read out the current position of the stage.
         This method can display the position in stage and chip coordinates,

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -75,8 +75,7 @@ class Calibration:
         self._coordinate_system = None
 
         self._axes_rotation: Type[AxesRotation] = AxesRotation()
-        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(
-            self._axes_rotation)
+        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(self._axes_rotation)
         self._kabsch_rotation: Type[KabschRotation] = KabschRotation()
 
     #

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -8,6 +8,9 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from typing import TYPE_CHECKING, Type, Union
 from functools import wraps
 from contextlib import contextmanager
+from time import sleep
+
+import numpy as np
 
 from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction
 from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
@@ -353,3 +356,142 @@ class Calibration:
         else:
             RuntimeError(
                 f"Unsupported coordinate system {self.coordinate_system} to return the stage position")
+
+    #
+    #   Movement methods
+    #
+
+    @assert_minimum_state_for_coordinate_system(
+        stage_coordinate_system=State.CONNECTED,
+        chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
+    def move_relative(self,
+                      offset: Union[Type[StageCoordinate],
+                                    Type[ChipCoordinate]],
+                      wait_for_stopping: bool = True) -> None:
+        """
+        Moves the stage relative in its coordinate system.
+        The offset can be passed a stage or chip coordinate,
+        depending on the context in which this method is used.
+
+        Parameters
+        ----------
+        offset: StageCoordinate | ChipCoordinate
+            Relative offset in stage or chip coordinates.
+
+        Raises
+        ------
+        CalibrationError
+            If the state of calibration is lower than the required one.
+        TypeError
+            If the passed offset does not have the correct type.
+        RuntimeError
+            If coordinate system is unsupported.
+        """
+        if not isinstance(offset, self.coordinate_system):
+            raise TypeError(
+                f"Given offset is in {type(offset)}. Need offset in {self.coordinate_system} to move the stage relative in this system.")
+
+        if self.coordinate_system == StageCoordinate:
+            stage_offset = offset
+        elif self.coordinate_system == ChipCoordinate:
+            stage_offset = self._axes_rotation.chip_to_stage(offset)
+        else:
+            RuntimeError(
+                f"Unsupported coordinate system {self.coordinate_system} to move the stage relatively.")
+
+        self.stage.move_relative(
+            x=stage_offset.x,
+            y=stage_offset.y,
+            z=stage_offset.z,
+            wait_for_stopping=wait_for_stopping)
+
+    @assert_minimum_state_for_coordinate_system(
+        stage_coordinate_system=State.CONNECTED,
+        chip_coordinate_system=State.SINGLE_POINT_FIXED)
+    def move_absolute(self,
+                      coordinate: Union[Type[StageCoordinate],
+                                        Type[ChipCoordinate]],
+                      wait_for_stopping: bool = True) -> None:
+        """
+        Moves the stage absolute to the given coordinate.
+        The coordinate can be passed in stage or chip coordinates,
+        depending on the coordinate system in which this method is called.
+
+        Parameters
+        ----------
+        coordinate: StageCoordinate | ChipCoordinate
+            Coordinate offset in stage or chip coordinates.
+
+        Raises
+        ------
+        CalibrationError
+            If the state of calibration is lower than the required one.
+        TypeError
+            If the passed offset does not have the correct type.
+        RuntimeError
+            If coordinate system is unsupported.
+        """
+        if not isinstance(coordinate, self.coordinate_system):
+            raise TypeError(
+                f"Given coordinate is in {type(coordinate)}. Need coordinate in {self.coordinate_system} to move the stage absolute in this system.")
+
+        if self.coordinate_system == StageCoordinate:
+            stage_coordinate = coordinate
+        elif self.coordinate_system == ChipCoordinate:
+            if self.state == State.FULLY_CALIBRATED:
+                stage_coordinate = self._kabsch_rotation.chip_to_stage(
+                    coordinate)
+            elif self.state == State.SINGLE_POINT_FIXED:
+                stage_coordinate = self._single_point_offset.chip_to_stage(
+                    coordinate)
+            else:
+                raise CalibrationError(
+                    "Insufficient calibration state to move the stage absolutely.")
+        else:
+            RuntimeError(
+                f"Unsupported coordinate system {self.coordinate_system} to move the stage absolutely.")
+
+        self.stage.move_absolute(
+            x=stage_coordinate.x,
+            y=stage_coordinate.y,
+            z=stage_coordinate.z,
+            wait_for_stopping=wait_for_stopping)
+
+    def wiggle_axis(
+            self,
+            wiggle_axis: Axis,
+            wiggle_distance: float = 1e3,
+            wiggle_speed: float = 1e3,
+            wait_time: float = 2) -> None:
+        """
+        Wiggles an axis of the stage.
+        Moves the axis first in a positive direction then in a negative direction.
+        This method can be used to check the axis rotation.
+        This method is executed in chip coordinates.
+
+        Parameters
+        ----------
+        wiggle_axis: Axis
+            Axis to be wiggled.
+        wiggle_distance: float = 1e3
+            Specifies how much the axis should be moved in one direction [um].
+        wiggle_speed: float = 1e3
+            Specifies how fast the axis should be moved in one direction [um/s].
+        wait_time: float = 2
+            Specifies how long to wait between positive and negative movement [s].
+        """
+        current_speed_xy = self.stage.get_speed_xy()
+        current_speed_z = self.stage.get_speed_z()
+
+        self.stage.set_speed_xy(wiggle_speed)
+        self.stage.set_speed_z(wiggle_speed)
+
+        wiggle_difference = np.array(
+            [wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
+        with self.perform_in_chip_coordinates():
+            self.move_relative(ChipCoordinate.from_numpy(wiggle_difference))
+            sleep(wait_time)
+            self.move_relative(ChipCoordinate.from_numpy(-wiggle_difference))
+
+        self.stage.set_speed_xy(current_speed_xy)
+        self.stage.set_speed_z(current_speed_z)

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -75,7 +75,8 @@ class Calibration:
         self._coordinate_system = None
 
         self._axes_rotation: Type[AxesRotation] = AxesRotation()
-        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(self._axes_rotation)
+        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(
+            self._axes_rotation)
         self._kabsch_rotation: Type[KabschRotation] = KabschRotation()
 
     #
@@ -310,3 +311,45 @@ class Calibration:
             return
 
         self._state = State.FULLY_CALIBRATED
+
+    #
+    #   Position method
+    #
+
+    @property
+    @assert_minimum_state_for_coordinate_system(
+        stage_coordinate_system=State.CONNECTED,
+        chip_coordinate_system=State.SINGLE_POINT_FIXED)
+    def position(self) -> Union[Type[StageCoordinate], Type[ChipCoordinate]]:
+        """
+        Method to read out the current position of the stage.
+        This method can display the position in stage and chip coordinates,
+        depending on the context in which this method is used.
+
+        Returns
+        -------
+        position: StageCoordinate | ChipCoordinate
+            Position of the stage in chip or stage coordinates.
+
+        Raises
+        ------
+        CalibrationError
+            If the state of calibration is lower than the required one.
+        RuntimeError
+            If coordinate system is unsupported.
+        """
+        stage_position = StageCoordinate.from_list(self.stage.get_position())
+
+        if self.coordinate_system == StageCoordinate:
+            return stage_position
+        elif self.coordinate_system == ChipCoordinate:
+            if self.state == State.FULLY_CALIBRATED:
+                return self._kabsch_rotation.stage_to_chip(stage_position)
+            elif self.state == State.SINGLE_POINT_FIXED:
+                return self._single_point_offset.stage_to_chip(stage_position)
+            else:
+                raise CalibrationError(
+                    "Insufficient calibration state to return the position in chip coordinates.")
+        else:
+            RuntimeError(
+                f"Unsupported coordinate system {self.coordinate_system} to return the stage position")

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -6,6 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import unittest
+import numpy as np
 from unittest.mock import Mock, patch
 from parameterized import parameterized
 
@@ -312,3 +313,89 @@ class DetermineStateTest(CalibrationTestCase):
         self.assertTrue(self.calibration._kabsch_rotation.is_valid)
 
         self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+
+class CalibrationTest(CalibrationTestCase):
+
+    def test_position_in_stage_coordinate_raises_error_if_unconnected(self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.get_position()
+
+    def test_position_in_chip_coordinate_raises_error_if_not_single_point_fixed(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.get_position()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_stage_coordinates(self, get_position_mock):
+        expected_position = [100, 200, 300]
+        get_position_mock.return_value = expected_position
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        self.assertIsInstance(position, StageCoordinate)
+        self.assertEqual(position.to_list(), expected_position)
+
+        get_position_mock.assert_called_once()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_chip_coordinates_with_single_point_offset(
+            self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+        get_position_mock.return_value = expected_stage_pos
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.set_valid_single_point_offset()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
+
+        self.assertIsInstance(position, ChipCoordinate)
+        self.assertTrue(
+            np.allclose(
+                position.to_numpy(),
+                expected_chip_pos,
+                rtol=1,
+                atol=1))
+
+        get_position_mock.assert_called_once()
+
+    @patch.object(DummyStage, "get_position")
+    def test_position_in_chip_coordinates_with_kabsch_rotation(
+            self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+        get_position_mock.return_value = expected_stage_pos
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.set_valid_single_point_offset()
+            self.set_valid_kabsch_rotation()
+            position = self.calibration.get_position()
+
+        self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+        self.assertIsInstance(position, ChipCoordinate)
+        self.assertTrue(
+            np.allclose(
+                position.to_numpy(),
+                expected_chip_pos,
+                rtol=1,
+                atol=1))
+
+        get_position_mock.assert_called_once()


### PR DESCRIPTION
Adds a method to read out the position of the stage in stage coordinates (no change) or in chip coordinates. To read it in chip coordinates, you need at least a single point offset transformation or a Kabsch rotation, the later being preferred.