### PR TITLE
Movement Calibration [5/7] Stage relative movement

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -8,6 +8,9 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from typing import TYPE_CHECKING, Type, Union
 from functools import wraps
 from contextlib import contextmanager
+from time import sleep
+
+import numpy as np
 
 from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction
 from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
@@ -354,6 +357,10 @@ class Calibration:
             RuntimeError(
                 f"Unsupported coordinate system {self.coordinate_system} to return the stage position")
 
+    #
+    #   Movement methods
+    #
+
     @assert_minimum_state_for_coordinate_system(
         stage_coordinate_system=State.CONNECTED,
         chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
@@ -397,3 +404,94 @@ class Calibration:
             y=stage_offset.y,
             z=stage_offset.z,
             wait_for_stopping=wait_for_stopping)
+
+    @assert_minimum_state_for_coordinate_system(
+        stage_coordinate_system=State.CONNECTED,
+        chip_coordinate_system=State.SINGLE_POINT_FIXED)
+    def move_absolute(self,
+                      coordinate: Union[Type[StageCoordinate],
+                                        Type[ChipCoordinate]],
+                      wait_for_stopping: bool = True) -> None:
+        """
+        Moves the stage absolute to the given coordinate.
+        The coordinate can be passed in stage or chip coordinates,
+        depending on the coordinate system in which this method is called.
+
+        Parameters
+        ----------
+        coordinate: StageCoordinate | ChipCoordinate
+            Coordinate offset in stage or chip coordinates.
+
+        Raises
+        ------
+        CalibrationError
+            If the state of calibration is lower than the required one.
+        TypeError
+            If the passed offset does not have the correct type.
+        RuntimeError
+            If coordinate system is unsupported.
+        """
+        if not isinstance(coordinate, self.coordinate_system):
+            raise TypeError(
+                f"Given coordinate is in {type(coordinate)}. Need coordinate in {self.coordinate_system} to move the stage absolute in this system.")
+
+        if self.coordinate_system == StageCoordinate:
+            stage_coordinate = coordinate
+        elif self.coordinate_system == ChipCoordinate:
+            if self.state == State.FULLY_CALIBRATED:
+                stage_coordinate = self._kabsch_rotation.chip_to_stage(
+                    coordinate)
+            elif self.state == State.SINGLE_POINT_FIXED:
+                stage_coordinate = self._single_point_offset.chip_to_stage(
+                    coordinate)
+            else:
+                raise CalibrationError(
+                    "Insufficient calibration state to move the stage absolutely.")
+        else:
+            RuntimeError(
+                f"Unsupported coordinate system {self.coordinate_system} to move the stage absolutely.")
+
+        self.stage.move_absolute(
+            x=stage_coordinate.x,
+            y=stage_coordinate.y,
+            z=stage_coordinate.z,
+            wait_for_stopping=wait_for_stopping)
+
+    def wiggle_axis(
+            self,
+            wiggle_axis: Axis,
+            wiggle_distance: float = 1e3,
+            wiggle_speed: float = 1e3,
+            wait_time: float = 2) -> None:
+        """
+        Wiggles an axis of the stage.
+        Moves the axis first in a positive direction then in a negative direction.
+        This method can be used to check the axis rotation.
+        This method is executed in chip coordinates.
+
+        Parameters
+        ----------
+        wiggle_axis: Axis
+            Axis to be wiggled.
+        wiggle_distance: float = 1e3
+            Specifies how much the axis should be moved in one direction [um].
+        wiggle_speed: float = 1e3
+            Specifies how fast the axis should be moved in one direction [um/s].
+        wait_time: float = 2
+            Specifies how long to wait between positive and negative movement [s].
+        """
+        current_speed_xy = self.stage.get_speed_xy()
+        current_speed_z = self.stage.get_speed_z()
+
+        self.stage.set_speed_xy(wiggle_speed)
+        self.stage.set_speed_z(wiggle_speed)
+
+        wiggle_difference = np.array(
+            [wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
+        with self.perform_in_chip_coordinates():
+            self.move_relative(ChipCoordinate.from_numpy(wiggle_difference))
+            sleep(wait_time)
+            self.move_relative(ChipCoordinate.from_numpy(-wiggle_difference))
+
+        self.stage.set_speed_xy(current_speed_xy)
+        self.stage.set_speed_z(current_speed_z)

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from shutil import move
 import unittest
 import numpy as np
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 from parameterized import parameterized
 
 from LabExT.Tests.Utils import get_calibrations_from_file
@@ -473,3 +473,165 @@ class CalibrationTest(CalibrationTestCase):
             y=-required_movement[2],
             z=-required_movement[0],
             wait_for_stopping=wait_for_stopping)
+    #
+    #
+    #
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(
+            self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_single_point_offset()
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_stage_coordinates(
+            self, wait_for_stopping, move_absolute_mock):
+        self.set_invalid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                StageCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+        move_absolute_mock.assert_called_once_with(
+            x=required_movement[0],
+            y=required_movement[1],
+            z=required_movement[2],
+            wait_for_stopping=wait_for_stopping)
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_single_point_offset(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
+
+        move_absolute_mock.assert_called_once()
+
+        _, kwargs = move_absolute_mock.call_args
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+                rtol=1,
+                atol=1))
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_kabsch_rotation(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        self.set_valid_kabsch_rotation()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+        move_absolute_mock.assert_called_once()
+
+        _, kwargs = move_absolute_mock.call_args
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+                rtol=1,
+                atol=1))
+
+    @parameterized.expand([
+        (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
+    ])
+    @patch.object(DummyStage, "move_relative")
+    def test_wiggle_axis_applies_axes_rotation(
+            self,
+            wiggle_axis,
+            x_movement,
+            y_movement,
+            z_movement,
+            move_relative_mock):
+
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.calibration.wiggle_axis(
+            wiggle_axis, wiggle_distance=1000, wait_time=0)
+
+        move_relative_mock.assert_has_calls([
+            call(x=y_movement, y=-z_movement, z=-x_movement, wait_for_stopping=True),
+            call(x=-y_movement, y=z_movement, z=x_movement, wait_for_stopping=True)])
+
+    @parameterized.expand([
+        (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
+    ])
+    @patch.object(DummyStage, "move_relative")
+    @patch.object(DummyStage, "set_speed_xy")
+    @patch.object(DummyStage, "set_speed_z")
+    def test_wiggle_axis_sets_and_resets_speed(
+            self,
+            wiggle_axis,
+            x_movement,
+            y_movement,
+            z_movement,
+            set_speed_z_mock,
+            set_speed_xy_mock,
+            move_relative_mock):
+        current_speed_xy = self.stage._speed_xy
+        current_speed_z = self.stage._speed_z
+
+        self.calibration.connect_to_stage()
+
+        self.calibration.wiggle_axis(
+            wiggle_axis,
+            wiggle_distance=1000,
+            wiggle_speed=5000,
+            wait_time=0)
+
+        move_relative_mock.assert_has_calls([
+            call(x=x_movement, y=y_movement, z=z_movement, wait_for_stopping=True),
+            call(x=-x_movement, y=-y_movement, z=-z_movement, wait_for_stopping=True)])
+        set_speed_z_mock.assert_has_calls([call(5000), call(current_speed_z)])
+        set_speed_xy_mock.assert_has_calls(
+            [call(5000), call(current_speed_xy)])

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -5,6 +5,7 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+from shutil import move
 import unittest
 import numpy as np
 from unittest.mock import Mock, patch
@@ -399,3 +400,76 @@ class CalibrationTest(CalibrationTestCase):
                 atol=1))
 
         get_position_mock.assert_called_once()
+
+    def test_move_relative_in_stage_coordinate_raises_error_if_unconnected(
+            self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    def test_move_relative_in_chip_coordinate_raises_error_if_axes_rotation_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_invalid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    def test_move_relative_in_stage_coordinate_raises_error_if_offset_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_relative(ChipCoordinate(1, 2, 3))
+
+    def test_move_relative_in_chip_coordinate_raises_error_if_offset_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_relative(StageCoordinate(1, 2, 3))
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_relative")
+    def test_move_relative_in_stage_coordinates(
+            self, wait_for_stopping, move_relative_mock):
+        self.set_invalid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_relative(
+                StageCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+        move_relative_mock.assert_called_once_with(
+            x=required_movement[0],
+            y=required_movement[1],
+            z=required_movement[2],
+            wait_for_stopping=wait_for_stopping)
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_relative")
+    def test_move_relative_in_chip_coordinates_with_axes_rotation(
+            self, wait_for_stopping, move_relative_mock):
+        self.set_valid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_relative(
+                ChipCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+        move_relative_mock.assert_called_once_with(
+            x=required_movement[1],
+            y=-required_movement[2],
+            z=-required_movement[0],
+            wait_for_stopping=wait_for_stopping)


### PR DESCRIPTION
Adds a method to move the stage relatively. If it is to be moved in stage coordinates, no change is made. If it is to be moved in chip coordinates, a valid axis rotation must be defined to convert the chip coordinate to a stage coordinate.