### PR TITLE
Movement Calibration [6/7] Move Absolute

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -397,3 +397,55 @@ class Calibration:
             y=stage_offset.y,
             z=stage_offset.z,
             wait_for_stopping=wait_for_stopping)
+
+    @assert_minimum_state_for_coordinate_system(
+        stage_coordinate_system=State.CONNECTED,
+        chip_coordinate_system=State.SINGLE_POINT_FIXED)
+    def move_absolute(self,
+                      coordinate: Union[Type[StageCoordinate],
+                                        Type[ChipCoordinate]],
+                      wait_for_stopping: bool = True) -> None:
+        """
+        Moves the stage absolute to the given coordinate.
+        The coordinate can be passed in stage or chip coordinates,
+        depending on the coordinate system in which this method is called.
+
+        Parameters
+        ----------
+        coordinate: StageCoordinate | ChipCoordinate
+            Coordinate offset in stage or chip coordinates.
+
+        Raises
+        ------
+        CalibrationError
+            If the state of calibration is lower than the required one.
+        TypeError
+            If the passed offset does not have the correct type.
+        RuntimeError
+            If coordinate system is unsupported.
+        """
+        if not isinstance(coordinate, self.coordinate_system):
+            raise TypeError(
+                f"Given coordinate is in {type(coordinate)}. Need coordinate in {self.coordinate_system} to move the stage absolute in this system.")
+
+        if self.coordinate_system == StageCoordinate:
+            stage_coordinate = coordinate
+        elif self.coordinate_system == ChipCoordinate:
+            if self.state == State.FULLY_CALIBRATED:
+                stage_coordinate = self._kabsch_rotation.chip_to_stage(
+                    coordinate)
+            elif self.state == State.SINGLE_POINT_FIXED:
+                stage_coordinate = self._single_point_offset.chip_to_stage(
+                    coordinate)
+            else:
+                raise CalibrationError(
+                    "Insufficient calibration state to move the stage absolutely.")
+        else:
+            RuntimeError(
+                f"Unsupported coordinate system {self.coordinate_system} to move the stage absolutely.")
+
+        self.stage.move_absolute(
+            x=stage_coordinate.x,
+            y=stage_coordinate.y,
+            z=stage_coordinate.z,
+            wait_for_stopping=wait_for_stopping)

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from shutil import move
 import unittest
 import numpy as np
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 from parameterized import parameterized
 
 from LabExT.Tests.Utils import get_calibrations_from_file
@@ -473,3 +473,111 @@ class CalibrationTest(CalibrationTestCase):
             y=-required_movement[2],
             z=-required_movement[0],
             wait_for_stopping=wait_for_stopping)
+    #
+    #
+    #
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(
+            self):
+        self.calibration.disconnect_to_stage()
+        self.assertEqual(self.calibration.state, State.UNINITIALIZED)
+
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_axes_rotation()
+        self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(CalibrationError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_stage_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        with self.calibration.perform_in_stage_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(ChipCoordinate(1, 2, 3))
+
+    def test_move_absolute_in_chip_coordinate_raises_error_if_coord_type_invalid(
+            self):
+        self.calibration.connect_to_stage()
+        self.set_valid_single_point_offset()
+        with self.calibration.perform_in_chip_coordinates():
+            with self.assertRaises(TypeError):
+                self.calibration.move_absolute(StageCoordinate(1, 2, 3))
+
+    @parameterized.expand([(True,), (False,)])
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_stage_coordinates(
+            self, wait_for_stopping, move_absolute_mock):
+        self.set_invalid_axes_rotation()
+        required_movement = [100.0, 200.0, 300.0]
+
+        with self.calibration.perform_in_stage_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                StageCoordinate.from_list(required_movement),
+                wait_for_stopping)
+
+        self.assertEqual(self.calibration.state, State.CONNECTED)
+        move_absolute_mock.assert_called_once_with(
+            x=required_movement[0],
+            y=required_movement[1],
+            z=required_movement[2],
+            wait_for_stopping=wait_for_stopping)
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_single_point_offset(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
+
+        move_absolute_mock.assert_called_once()
+
+        stage_call = move_absolute_mock.call_args_list[0]
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([stage_call.kwargs['x'], stage_call.kwargs['y'], stage_call.kwargs['z']]),
+                rtol=1,
+                atol=1))
+
+    @patch.object(DummyStage, "move_absolute")
+    def test_move_absolute_in_chip_coordinates_with_kabsch_rotation(
+            self, move_absolute_mock):
+        self.set_valid_single_point_offset()
+        self.set_valid_kabsch_rotation()
+        expected_stage_pos, expected_chip_pos = (
+            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+
+        with self.calibration.perform_in_chip_coordinates():
+            self.calibration.connect_to_stage()
+            self.calibration.move_absolute(
+                ChipCoordinate.from_numpy(expected_chip_pos),
+                True)
+
+        self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
+
+        move_absolute_mock.assert_called_once()
+
+        stage_call = move_absolute_mock.call_args_list[0]
+        self.assertTrue(
+            np.allclose(
+                expected_stage_pos,
+                np.array([stage_call.kwargs['x'], stage_call.kwargs['y'], stage_call.kwargs['z']]),
+                rtol=1,
+                atol=1))

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -548,11 +548,11 @@ class CalibrationTest(CalibrationTestCase):
 
         move_absolute_mock.assert_called_once()
 
-        stage_call = move_absolute_mock.call_args_list[0]
+        _, kwargs = move_absolute_mock.call_args
         self.assertTrue(
             np.allclose(
                 expected_stage_pos,
-                np.array([stage_call.kwargs['x'], stage_call.kwargs['y'], stage_call.kwargs['z']]),
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
                 rtol=1,
                 atol=1))
 
@@ -574,10 +574,10 @@ class CalibrationTest(CalibrationTestCase):
 
         move_absolute_mock.assert_called_once()
 
-        stage_call = move_absolute_mock.call_args_list[0]
+        _, kwargs = move_absolute_mock.call_args
         self.assertTrue(
             np.allclose(
                 expected_stage_pos,
-                np.array([stage_call.kwargs['x'], stage_call.kwargs['y'], stage_call.kwargs['z']]),
+                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
                 rtol=1,
                 atol=1))


### PR DESCRIPTION
Adds a method to move the stage absolutely. If it is to be moved in stage coordinates, no change is made. If it is to be moved in chip coordinates, a valid transformation (kabsch or single point) must be defined to convert the chip coordinate to a stage coordinate.