### PR TITLE
Adding CI testing to run under Windows runners, too

### DIFF
--- a/.github/workflows/labext-ci.yml
+++ b/.github/workflows/labext-ci.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -14,7 +14,7 @@ from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
 
 
-@flaky(max_runs=5)
+@flaky(max_runs=3)
 class DriverPathDialogTest(TKinterTestCase):
 
     def test_dialog_initial_state(self):

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -14,7 +14,7 @@ from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=5)
 class DriverPathDialogTest(TKinterTestCase):
 
     def test_dialog_initial_state(self):

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -17,7 +17,7 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_dialog_initial_state(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path') as config_path:
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
@@ -33,7 +33,7 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_without_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):
@@ -48,8 +48,8 @@ class DriverPathDialogTest(TKinterTestCase):
 
     def test_save_with_change(self):
         settings_file_path = 'my_path_file.txt'
-        current_driver_path = '/path/to/control/module.py'
-        new_driver_path = '/my/new/path.py'
+        current_driver_path = str(Path('/path/to/control/module.py'))
+        new_driver_path = str(Path('/my/new/path.py'))
 
         with patch('LabExT.View.Controls.DriverPathDialog.get_configuration_file_path'):
             with patch('builtins.open', mock_open(read_data=json.dumps(current_driver_path))):

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -61,5 +61,5 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
+                self.assertEqual(Path(dialog.driver_path), Path(new_driver_path))
                 self.assertTrue(dialog.path_has_changed)

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -8,11 +8,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import json
 from unittest.mock import patch, mock_open
 from pathlib import Path
+from flaky import flaky
 
 from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
 
 
+@flaky(max_runs=3)
 class DriverPathDialogTest(TKinterTestCase):
 
     def test_dialog_initial_state(self):

--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -7,6 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 from unittest.mock import patch, mock_open
+from pathlib import Path
 
 from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
@@ -42,7 +43,7 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(dialog.driver_path, current_driver_path)
+                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
                 self.assertFalse(dialog.path_has_changed)
 
     def test_save_with_change(self):
@@ -60,5 +61,5 @@ class DriverPathDialogTest(TKinterTestCase):
                     dialog._save_button.invoke()
 
                 messagebox_mock.assert_called_once()
-                self.assertEqual(dialog.driver_path, new_driver_path)
+                self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
                 self.assertTrue(dialog.path_has_changed)

--- a/LabExT/Tests/View/Controls/Wizard_test.py
+++ b/LabExT/Tests/View/Controls/Wizard_test.py
@@ -13,7 +13,7 @@ import tkinter
 from LabExT.View.Controls.Wizard import Step, Wizard
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=5)
 class WizardUnitTest(TKinterTestCase):
     """
     Unittests for Wizard Widget.
@@ -245,7 +245,7 @@ class WizardUnitTest(TKinterTestCase):
         on_reload.assert_called_once()
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=5)
 class WizardIntegrationTest(TKinterTestCase):
     """
     Integration test for a Wizard with 2 steps.

--- a/LabExT/Tests/View/Controls/Wizard_test.py
+++ b/LabExT/Tests/View/Controls/Wizard_test.py
@@ -7,11 +7,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from unittest.mock import Mock
 from LabExT.Tests.Utils import TKinterTestCase
+from flaky import flaky
 
 import tkinter
 from LabExT.View.Controls.Wizard import Step, Wizard
 
 
+@flaky(max_runs=3)
 class WizardUnitTest(TKinterTestCase):
     """
     Unittests for Wizard Widget.
@@ -243,6 +245,7 @@ class WizardUnitTest(TKinterTestCase):
         on_reload.assert_called_once()
 
 
+@flaky(max_runs=3)
 class WizardIntegrationTest(TKinterTestCase):
     """
     Integration test for a Wizard with 2 steps.

--- a/LabExT/Tests/View/Controls/Wizard_test.py
+++ b/LabExT/Tests/View/Controls/Wizard_test.py
@@ -13,7 +13,7 @@ import tkinter
 from LabExT.View.Controls.Wizard import Step, Wizard
 
 
-@flaky(max_runs=5)
+@flaky(max_runs=3)
 class WizardUnitTest(TKinterTestCase):
     """
     Unittests for Wizard Widget.
@@ -245,7 +245,7 @@ class WizardUnitTest(TKinterTestCase):
         on_reload.assert_called_once()
 
 
-@flaky(max_runs=5)
+@flaky(max_runs=3)
 class WizardIntegrationTest(TKinterTestCase):
     """
     Integration test for a Wizard with 2 steps.

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -31,7 +31,7 @@ def simulator_only_instruments_descriptions(name):
         raise ValueError('Unknown name for simulator descriptions:' + str(name))
 
 
-@flaky(max_runs=5)
+@flaky(max_runs=3)
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -7,7 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import json
 import random
 from os import remove
-from time import sleep
+from flaky import flaky
 from unittest.mock import patch
 
 import LabExT.Wafer.Device
@@ -31,6 +31,7 @@ def simulator_only_instruments_descriptions(name):
         raise ValueError('Unknown name for simulator descriptions:' + str(name))
 
 
+@flaky(max_runs=3)
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -31,7 +31,7 @@ def simulator_only_instruments_descriptions(name):
         raise ValueError('Unknown name for simulator descriptions:' + str(name))
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=5)
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cached-property==1.5.2
     # via
     #   h5py
     #   pytkdocs
-click==8.0.3
+click==8.1.3
     # via mkdocs
 collision==1.2.2
     # via -r .\requirements.in
@@ -18,56 +18,60 @@ colorama==0.4.4
     # via click
 cycler==0.11.0
     # via matplotlib
-fonttools==4.28.5
+fonttools==4.33.3
     # via matplotlib
-ghp-import==2.0.2
+ghp-import==2.1.0
     # via mkdocs
 h5py==3.6.0
     # via -r .\requirements.in
-importlib-metadata==4.10.1
+importlib-metadata==4.11.3
     # via
     #   click
     #   markdown
     #   mkdocs
     #   pyvisa
     #   pyvisa-py
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   mkdocs
     #   mkdocs-material
     #   mkdocstrings
-kiwisolver==1.3.2
+kiwisolver==1.4.2
     # via matplotlib
-markdown==3.3.6
+markdown==3.3.7
     # via
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocs-material
     #   mkdocstrings
     #   pymdown-extensions
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   mkdocstrings
-matplotlib==3.5.1
+matplotlib==3.5.2
     # via -r .\requirements.in
 mergedeep==1.3.4
     # via mkdocs
-mkdocs==1.2.3
+mkdocs==1.3.0
     # via
     #   -r .\requirements.in
     #   mkdocs-autorefs
     #   mkdocs-material
     #   mkdocstrings
-mkdocs-autorefs==0.3.1
+mkdocs-autorefs==0.4.1
     # via mkdocstrings
-mkdocs-material==8.1.7
+mkdocs-material==8.2.14
     # via -r .\requirements.in
 mkdocs-material-extensions==1.0.3
     # via mkdocs-material
-mkdocstrings==0.17.0
-    # via -r .\requirements.in
-numpy==1.21.5
+mkdocstrings==0.18.1
+    # via
+    #   -r .\requirements.in
+    #   mkdocstrings-python-legacy
+mkdocstrings-python-legacy==0.2.2
+    # via mkdocstrings
+numpy==1.21.6
     # via
     #   -r .\requirements.in
     #   h5py
@@ -77,18 +81,18 @@ packaging==21.3
     # via
     #   matplotlib
     #   mkdocs
-pillow==9.0.0
+pillow==9.1.0
     # via
     #   -r .\requirements.in
     #   matplotlib
     #   ttkwidgets
-pygments==2.11.2
+pygments==2.12.0
     # via mkdocs-material
-pymdown-extensions==9.1
+pymdown-extensions==9.4
     # via
     #   mkdocs-material
     #   mkdocstrings
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via
     #   matplotlib
     #   packaging
@@ -98,15 +102,15 @@ python-dateutil==2.8.2
     # via
     #   ghp-import
     #   matplotlib
-pytkdocs==0.15.0
-    # via mkdocstrings
+pytkdocs==0.16.1
+    # via mkdocstrings-python-legacy
 pyusb==1.2.1
     # via -r .\requirements.in
-pyvisa==1.11.3
+pyvisa==1.12.0
     # via
     #   -r .\requirements.in
     #   pyvisa-py
-pyvisa-py==0.5.2
+pyvisa-py==0.5.3
     # via -r .\requirements.in
 pyyaml==6.0
     # via
@@ -122,15 +126,16 @@ six==1.16.0
     #   python-dateutil
 ttkwidgets==0.12.1
     # via -r .\requirements.in
-typing-extensions==4.0.1
+typing-extensions==4.2.0
     # via
     #   importlib-metadata
+    #   kiwisolver
     #   pytkdocs
     #   pyvisa
     #   pyvisa-py
-watchdog==2.1.6
+watchdog==2.1.7
     # via mkdocs
 wheel==0.37.1
     # via astunparse
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,6 +3,7 @@
 #
 pytest
 pytest-xvfb
+flaky
 parametrized
 tox
 tox-gh-actions

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,5 @@ python =
 deps =
     pytest
     pytest-xvfb
+    flaky
 commands = python -m LabExT.Tests.runtests


### PR DESCRIPTION
# Goal
Introduce running the CI also on Windows OS.

# Approach
Simply add the OS to the matrix of OSxVersions of the GitHub runner yaml config file.

# Compatibility
No compatility issues expected. I had to rewrite some tests for these to make file paths OS agnostic.