### PR TITLE
Workaround: MacOS not starting due to TKinter bug

### DIFF
--- a/LabExT/View/ProgressBar/ProgressBar.py
+++ b/LabExT/View/ProgressBar/ProgressBar.py
@@ -8,6 +8,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import _tkinter
 from tkinter import Toplevel, ttk, Label, StringVar
 
+import platform
+
 
 class ProgressBar(Toplevel):
     def __init__(self, root, text):
@@ -27,8 +29,10 @@ class ProgressBar(Toplevel):
                     textvariable=self.text)
         lbl.grid(row=0, column=0)
 
-        # don't show classical window bar for progress bar
-        self.overrideredirect(True)
+        # do not disable window border for MacOS w/ TKinter 8.6 as tkinter is buggy
+        if 'darwin' not in platform.system().lower():
+            # don't show classical window bar for progress bar
+            self.overrideredirect(True)
 
         # this lets the window manager draw all windows, which is necessary as
         while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):

--- a/LabExT/View/ProgressBar/ProgressBar.py
+++ b/LabExT/View/ProgressBar/ProgressBar.py
@@ -35,6 +35,7 @@ class ProgressBar(Toplevel):
             self.overrideredirect(True)
 
         # this lets the window manager draw all windows, which is necessary as
+        # the sizes of the window will be read below
         while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
             pass
 


### PR DESCRIPTION
There is a bug in TKinter 8.6 (shipped with Python 3.7 - 3.9) that the `Toplevel.overrideredirect(True)` results in an error. This is a TKinter bug, see https://github.com/PySimpleGUI/PySimpleGUI/issues/3048 so we just implement a simple workaround.

Fixes #79 