### PR TITLE
Adding test-compilation of docs to CI

### DIFF
--- a/.github/workflows/test_documentation_compilation.yml
+++ b/.github/workflows/test_documentation_compilation.yml
@@ -1,0 +1,20 @@
+name: Test-compile documentation
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test-compile documentation with mkdocs
+      run: mkdocs build

--- a/docs/reference_InstrumentAPI.md
+++ b/docs/reference_InstrumentAPI.md
@@ -1,6 +1,6 @@
 # InstrumentAPI
 
-::: LabExT.Instruments.InstrumentAPI.Instrument
+::: LabExT.Instruments.InstrumentAPI.Instrument.Instrument
     rendering:
         show_root_heading: true
         sort_members: source

--- a/docs/reference_InstrumentAPI.md
+++ b/docs/reference_InstrumentAPI.md
@@ -1,6 +1,6 @@
 # InstrumentAPI
 
-::: LabExT.Instruments.InstrumentAPI.Instrument.Instrument
+::: LabExT.Instruments.InstrumentAPI.Instrument
     rendering:
         show_root_heading: true
         sort_members: source


### PR DESCRIPTION
So far, we did not notice if docs compilation fails before we actually merged into main branch. This CI fixes this: CI would fail if mkdocs cannot compile the documentation.

# Goal
Improve visibility in documentation generation

# Approach
Adding a CI workflow which compiles the documentation using mkdocs. If mkdocs detects any errors in building the docs, the CI will fail and one can see it in a pull request.

# Compatibility
Just adding a single CI job, no compatibility issues expected.
