### PR TITLE
[Movement]: Move relative method

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -4,6 +4,8 @@
 LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
+from __future__ import annotations
+import logging
 
 from typing import TYPE_CHECKING, Type, Union
 from functools import wraps
@@ -19,6 +21,8 @@ from LabExT.Movement.PathPlanning import StagePolygon, SingleModeFiber
 
 if TYPE_CHECKING:
     from LabExT.Movement.Stage import Stage
+    from LabExT.Movement.MoverNew import MoverNew
+    from LabExT.Wafer.Chip import Chip
 
 
 class CalibrationError(RuntimeError):
@@ -67,22 +71,110 @@ class Calibration:
     Represents a calibration of one stage.
     """
 
-    def __init__(self, mover, stage, orientation, device_port) -> None:
+    _logger = logging.getLogger()
+
+    @classmethod
+    def load(
+        cls,
+        mover: Type[MoverNew],
+        stage: Type[Stage],
+        calibration_data: dict,
+        chip: Type[Chip] = None
+    ) -> Type[Calibration]:
+        """
+        Creates a new calibration based on calibration data.
+
+        Parameters
+        ----------
+        mover : Mover
+            Instance of mover associated with this calibration.
+        stage : Stage
+            Instance of a stage
+        calibration_data : dict
+            Dumped calibration data
+
+        Returns
+        -------
+        Calibration
+            Instance of calibration
+        """
+        try:
+            orientation = Orientation[calibration_data["orientation"]]
+            device_port = DevicePort[calibration_data["device_port"]]
+        except KeyError as err:
+            raise CalibrationError(
+                f"The parameter is not defined: {err}. "
+                "Make sure to pass a valid orientation and device port.")
+
+        axes_rotation = None
+        if "axes_rotation" in calibration_data:
+            axes_rotation = AxesRotation.load(
+                calibration_data["axes_rotation"])
+
+        single_point_offset = None
+        if "single_point_offset" in calibration_data:
+            if axes_rotation is not None:
+                single_point_offset = SinglePointOffset.load(
+                    calibration_data["single_point_offset"], axes_rotation=axes_rotation)
+            else:
+                cls._logger.debug(
+                    "Cannot set single point offset when axes rotation is not defined")
+
+        kabsch_rotation = None
+        if "kabsch_rotation" in calibration_data:
+            if axes_rotation is not None and chip is not None:
+                kabsch_rotation = KabschRotation.load(
+                    calibration_data["kabsch_rotation"], chip=chip, axes_rotation=axes_rotation)
+            else:
+                cls._logger.debug(
+                    "Cannot set kabsch rotation when axes rotation or chip is not defined")
+
+        return cls(
+            mover,
+            stage,
+            orientation,
+            device_port,
+            axes_rotation,
+            single_point_offset,
+            kabsch_rotation)
+
+    def __init__(
+        self,
+        mover: Type[MoverNew],
+        stage: Type[Stage],
+        orientation: Orientation,
+        device_port: DevicePort,
+        axes_rotation: Type[AxesRotation] = None,
+        single_point_offset: Type[SinglePointOffset] = None,
+        kabsch_rotation: Type[KabschRotation] = None
+    ) -> None:
         self.mover = mover
         self.stage: Type[Stage] = stage
 
         self.stage_polygon: Type[StagePolygon] = SingleModeFiber(orientation)
 
-        self._state = State.CONNECTED if stage.connected else State.UNINITIALIZED
         self._orientation = orientation
         self._device_port = device_port
 
         self._coordinate_system = None
 
-        self._axes_rotation: Type[AxesRotation] = AxesRotation()
-        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(
-            self._axes_rotation)
-        self._kabsch_rotation: Type[KabschRotation] = KabschRotation(self._axes_rotation)
+        self._axes_rotation = axes_rotation
+        if axes_rotation is None:
+            self._axes_rotation = AxesRotation()
+
+        self._single_point_offset = single_point_offset
+        if single_point_offset is None:
+            self._single_point_offset = SinglePointOffset(self._axes_rotation)
+
+        self._kabsch_rotation = kabsch_rotation
+        if kabsch_rotation is None:
+            self._kabsch_rotation = KabschRotation(self._axes_rotation)
+
+        assert self._single_point_offset.axes_rotation == self._axes_rotation, "Axes rotation for single point offset must be the same than for the calibration."
+        assert self._kabsch_rotation.axes_rotation == self._axes_rotation, "Axes rotation for kabsch rotation must be the same than for the calibration"
+
+        self._state = State.UNINITIALIZED
+        self.determine_state(skip_connection=False)
 
     #
     #   Representation
@@ -497,3 +589,23 @@ class Calibration:
 
         self.stage.set_speed_xy(current_speed_xy)
         self.stage.set_speed_z(current_speed_z)
+
+    def dump(self) -> dict:
+        """
+        Returns a dict of all calibration properties.
+        """
+        calibration_dump = {
+            "orientation": self.orientation.value,
+            "device_port": self._device_port.value}
+
+        if self._axes_rotation.is_valid:
+            calibration_dump["axes_rotation"] = self._axes_rotation.dump()
+
+        if self._single_point_offset.is_valid:
+            calibration_dump["single_point_offset"] = self._single_point_offset.dump(
+            )
+
+        if self._kabsch_rotation.is_valid:
+            calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
+
+        return calibration_dump

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -169,6 +169,9 @@ class MoverNew:
         """
         Returns True if mover can move absolutely in chip coordinates.
         """
+        if not self.calibrations:
+            return False
+
         return all(c.state == State.SINGLE_POINT_FIXED or c.state ==
                    State.FULLY_CALIBRATED for c in self.calibrations.values())
 

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -8,8 +8,8 @@ for details see LICENSE file.
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, NamedTuple, Type
-from abc import ABC, abstractmethod, abstractproperty
+from typing import TYPE_CHECKING, Any, NamedTuple, Type
+from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
 from functools import wraps
 import numpy as np
 
@@ -17,10 +17,12 @@ from LabExT.Movement.config import Axis, Direction
 
 if TYPE_CHECKING:
     from LabExT.Movement.Calibration import Calibration
+    from LabExT.Wafer.Device import Device
     from LabExT.Wafer.Chip import Chip
 
 
 logger = logging.getLogger()
+
 
 class Coordinate(ABC):
     """
@@ -109,6 +111,13 @@ class Coordinate(ABC):
         """
         return self.type.from_numpy(self.to_numpy() * scalar)
 
+    @property
+    def is_zero(self) -> bool:
+        """
+        Returns True if the coordinate is equal to [0,0,0]
+        """
+        return np.all(self.to_numpy() == 0)
+
     def to_list(self) -> list:
         """
         Returns the coordinate as a list.
@@ -143,8 +152,64 @@ class ChipCoordinate(Coordinate):
 class CoordinatePairing(NamedTuple):
     calibration: Type[Calibration]
     stage_coordinate: Type[StageCoordinate]
-    device: Type[Chip]
+    device: Type[Device]
     chip_coordinate: Type[ChipCoordinate]
+
+    @classmethod
+    def load(
+        cls,
+        pairing: dict,
+        device: Type[Device] = None,
+        calibration: Type[Calibration] = None
+    ) -> Type[CoordinatePairing]:
+        """
+        Creates a new coordinate pairing for given data.
+
+        Parameters
+        ----------
+        pairing : dict
+            Pairing consisting of stage and chip coordinate
+        device : Device = None
+            Devices associated with the pairing
+        calibration : Calibration
+            Calibration associated with the pairing
+
+        Raises
+        ------
+        ValueError
+            If pairing is not well-formed.
+
+        Returns
+        -------
+        CoordinatePairing based on the given data
+        """
+        if "stage_coordinate" not in pairing or "chip_coordinate" not in pairing:
+            raise ValueError(
+                f"Cannot create coordinate paring. Stage and Chip coordinate are required.")
+
+        return cls(
+            calibration=calibration,
+            stage_coordinate=StageCoordinate.from_list(
+                pairing["stage_coordinate"]),
+            device=device,
+            chip_coordinate=StageCoordinate.from_list(
+                pairing["chip_coordinate"]))
+
+    def dump(self, include_device_id: bool = True) -> dict:
+        """
+        Returns the pairing as dict.
+
+        Includes device ID if required.
+        """
+        pairing = {
+            "stage_coordinate": self.stage_coordinate.to_list(),
+            "chip_coordinate": self.chip_coordinate.to_list()}
+
+        if not include_device_id:
+            return pairing
+
+        pairing["device_id"] = self.device.id
+        return pairing
 
 
 class Transformation(ABC):
@@ -153,6 +218,13 @@ class Transformation(ABC):
 
     The base class cannot be initialised directly.
     """
+
+    @abstractclassmethod
+    def load(cls, data: Any, *args, **kwargs) -> Type[Transformation]:
+        """
+        Creates a new Transformation from data
+        """
+        pass
 
     @abstractmethod
     def __init__(self) -> None:
@@ -190,6 +262,12 @@ class Transformation(ABC):
         """
         pass
 
+    def dump(self, *args, **kwargs) -> Any:
+        """
+        Dumps transformation into storable format.
+        """
+        pass
+
 
 class TransformationError(RuntimeError):
     pass
@@ -224,6 +302,51 @@ class AxesRotation(Transformation):
     - Chip-to-Stage: Given a chip coordinate, this is multiplied on the right by the matrix to obtain a stage coordinate.
     - Stage-to-Chip: Given a stage coordinate, this is multiplied on the right by the inverse matrix to obtain a chip coordinate.
     """
+
+    @classmethod
+    def load(cls, mapping: dict) -> Type[AxesRotation]:
+        """
+        Creates a new axes rotation transformation based on axes mapping.
+
+        Parameters
+        ----------
+        mapping: Dict[str, (str, str)]
+            Mapping from a chip axis to a tuple with direction and stage axis
+
+        Raises
+        ------
+        TransformationError
+            If mapping is not well-formed
+            If mapping does not define a valid axes rotation
+
+        Returns
+        -------
+        AxesRotation
+            A valid axes rotation based on the mapping.
+        """
+        if len(mapping) != 3:
+            raise TransformationError(
+                "Cannot create axes rotation. "
+                f"Axis mapping must consist of 3 mappings, got mapping with {len(mapping)} mappings.")
+
+        axes_rotation = cls()
+        for chip_axis, (direction, stage_axis) in mapping.items():
+            try:
+                chip_axis = Axis[chip_axis]
+                direction = Direction[direction]
+                stage_axis = Axis[stage_axis]
+            except KeyError as err:
+                raise TransformationError(
+                    f"The parameter is not defined: {err}. "
+                    "Make sure to pass a mapping of valid directions and axes.")
+
+            axes_rotation.update(chip_axis, direction, stage_axis)
+
+        if not axes_rotation.is_valid:
+            raise TransformationError(
+                "Cannot create axes rotation from stored mapping. Mapping is invalid")
+
+        return axes_rotation
 
     def __init__(self) -> None:
         self.initialize()
@@ -339,6 +462,14 @@ class AxesRotation(Transformation):
         return ChipCoordinate.from_numpy(
             np.linalg.inv(self.matrix).dot(stage_coordinate.to_numpy()))
 
+    def dump(self) -> dict:
+        """
+        Returns the axes rotation as an axis mapping in a dict
+        """
+        return {
+            chip_axis.name: (direction.name, stage_axis.name)
+            for chip_axis, (direction, stage_axis) in self.mapping.items()}
+
 
 class SinglePointOffset(Transformation):
     """
@@ -354,6 +485,48 @@ class SinglePointOffset(Transformation):
 
     Note: The transformation assumes that the stage and chip axes are parallel. This is not the case in reality, so this transformation is only an approximation.
     """
+
+    @classmethod
+    def load(
+        cls,
+        pairing: Any,
+        axes_rotation: Type[AxesRotation]
+    ) -> Type[SinglePointOffset]:
+        """
+        Creates a new single point transformation based on pairing.
+
+        Parameters
+        ----------
+        pairing : dict
+            pairing for stage and chip coordinate
+        axes_rotation : AxesRotation
+            axes rotation associated with the transformation
+
+        Raises
+        ------
+        TransformationError
+            If pairing is not well-formed
+            If pairing does not define a valid transformation
+
+        Returns
+        -------
+        SinglePointOffset
+            A valid single point transformation based on the pairing.
+        """
+        try:
+            pairing = CoordinatePairing.load(pairing)
+        except Exception as err:
+            raise TransformationError(
+                f"Could not create pairing for {pairing}: {err}")
+
+        transformation = cls(axes_rotation)
+        transformation.update(pairing)
+
+        if not transformation.is_valid:
+            raise TransformationError(
+                "Cannot create single point offset from stored pairing. Pairing is invalid")
+
+        return transformation
 
     def __init__(self, axes_rotation: Type[AxesRotation]) -> None:
         self.axes_rotation: Type[AxesRotation] = axes_rotation
@@ -449,6 +622,15 @@ class SinglePointOffset(Transformation):
         return self.axes_rotation.stage_to_chip(
             stage_coordinate + self.stage_offset)
 
+    def dump(self) -> dict:
+        """
+        Returns the single point transformation as pairing.
+        """
+        if not self.pairing:
+            return {}
+
+        return self.pairing.dump()
+
 
 class KabschRotation(Transformation):
     """
@@ -460,6 +642,55 @@ class KabschRotation(Transformation):
     """
 
     MIN_POINTS = 3
+
+    @classmethod
+    def load(
+        cls,
+        pairings: list,
+        chip: Type[Chip],
+        axes_rotation: Type[KabschRotation]
+    ) -> Type[Transformation]:
+        """
+        Creates a new kabsch rotation based on pairings.
+
+        Parameters
+        ----------
+        pairings : list
+            pairings for stage and chip coordinates
+        axes_rotation : AxesRotation
+            axes rotation associated with the transformation
+
+        Raises
+        ------
+        TransformationError
+            If pairings are not well-formed
+            If pairings do not define a valid transformation
+
+        Returns
+        -------
+        KabschRotation
+            A valid kabsch rotation based on the pairings.
+        """
+        kabsch_rotation = cls(axes_rotation)
+        for pairing in pairings:
+            device = chip.devices.get(pairing["device_id"])
+            if device is None:
+                raise TransformationError(
+                    f"Could not find Device with ID {pairing['device_id']} for given chip {chip}")
+
+            try:
+                pairing = CoordinatePairing.load(pairing, device=device)
+            except Exception as err:
+                raise TransformationError(
+                    f"Could not create pairing for {pairing}: {err}")
+
+            kabsch_rotation.update(pairing)
+
+        if not kabsch_rotation.is_valid:
+            raise TransformationError(
+                "Cannot create kabsch rotation from stored pairings. Rotation is invalid.")
+
+        return kabsch_rotation
 
     def __init__(self, axes_rotation: Type[AxesRotation] = None) -> None:
         self.initialize(axes_rotation)
@@ -515,7 +746,8 @@ class KabschRotation(Transformation):
         ValueError
            If the pairing is not well defined or a pairing for the chip has already been set.
         """
-        if not isinstance(pairing, CoordinatePairing) or not all(pairing):
+        if not isinstance(pairing, CoordinatePairing) or (
+                pairing.device is None or pairing.chip_coordinate is None or pairing.stage_coordinate is None):
             raise ValueError(
                 "Use a complete CoordinatePairing object to update the rotation. ")
 
@@ -541,7 +773,7 @@ class KabschRotation(Transformation):
         # the second argument is the target set.
         #
         # INPUT: chip coordinates as start set and stage coordinate as target set
-        # OUTPUT: R, t, R^-1, t' s.t. 
+        # OUTPUT: R, t, R^-1, t' s.t.
         # -> R * Chip-Coordinates + t = Stage-Coordinates
         # -> R^-1 * Stage-Coordinates + t' = Chip-Coordinates
 
@@ -594,6 +826,13 @@ class KabschRotation(Transformation):
         return ChipCoordinate.from_numpy((
             self.rotation_to_chip.dot(stage_coordinate.to_numpy()) +
             self.translation_to_chip.T).flatten())
+
+    def dump(self) -> Any:
+        """
+        Returns a list of pairings defining the rotation.
+        """
+        return [
+            p.dump(include_device_id=True) for p in self.pairings]
 
 
 def rigid_transform_with_orientation_preservation(

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -41,6 +41,13 @@ class Orientation(BaseEnum):
     BOTTOM = auto()
 
 
+CLOCKWISE_ORDERING = [
+    Orientation.TOP,
+    Orientation.RIGHT,
+    Orientation.BOTTOM,
+    Orientation.LEFT]
+
+
 class DevicePort(BaseEnum):
     """Enumerate different device ports."""
     INPUT = auto()

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -6,6 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from shutil import move
+from typing import Any
 import unittest
 import numpy as np
 from unittest.mock import Mock, patch, call
@@ -19,6 +20,8 @@ from LabExT.Movement.Stages.DummyStage import DummyStage
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Transformations import ChipCoordinate, CoordinatePairing, StageCoordinate
 from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
+from ...Wafer.Chip import Chip
+from LabExT.Wafer.Device import Device
 
 EXPECTED_TO_REJECT = [
     (State.UNINITIALIZED, [State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
@@ -71,17 +74,17 @@ class CalibrationTestCase(unittest.TestCase):
         self.calibration.update_single_point_offset(CoordinatePairing(
             self.calibration,
             StageCoordinate.from_numpy(VACHERIN_STAGE_COORDS[0]),
-            Mock(),
+            Device(id=1, in_position=[0,0], out_position=[1,1]),
             ChipCoordinate.from_numpy(VACHERIN_CHIP_COORDS[0])
         ))
 
     def set_valid_kabsch_rotation(self):
-        for stage_coord, chip_coord in zip(
-                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS):
+        for device_id, (stage_coord, chip_coord) in enumerate(zip(
+                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS)):
             self.calibration.update_kabsch_rotation(CoordinatePairing(
                 calibration=self.calibration,
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
-                device=Mock(),
+                device=Device(device_id, [0,0], [1,1]),
                 chip_coordinate=ChipCoordinate.from_numpy(chip_coord)))
 
 
@@ -635,3 +638,148 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_z_mock.assert_has_calls([call(5000), call(current_speed_z)])
         set_speed_xy_mock.assert_has_calls(
             [call(5000), call(current_speed_xy)])
+
+    def test_dump_includes_orientation_and_port(self):
+        calibration = Calibration(self.mover, self.stage, Orientation.BOTTOM, DevicePort.INPUT)
+        calibration_dump = calibration.dump()
+
+        self.assertEqual(calibration_dump["orientation"], "BOTTOM")
+        self.assertEqual(calibration_dump["device_port"], "INPUT")
+
+
+    def test_dump_with_no_single_point_offset(self):
+        self.assertFalse(self.calibration._single_point_offset.is_valid)
+        self.assertFalse("single_point_offset" in self.calibration.dump())
+
+    def test_dump_with_single_point_offset(self):
+        self.set_valid_single_point_offset()
+
+        self.assertTrue(self.calibration._single_point_offset.is_valid)
+        self.assertDictEqual(self.calibration.dump()["single_point_offset"], {
+            'stage_coordinate': [23236.35, -7888.67, 18956.06],
+            'chip_coordinate': [-1550.0, 1120.0, 0.0],
+            'device_id': 1
+        })
+
+    def test_dump_with_axes_rotation(self):
+        self.set_valid_axes_rotation()
+
+        self.assertTrue(self.calibration._axes_rotation.is_valid)
+        self.assertDictEqual(self.calibration.dump()["axes_rotation"], {
+            'X': ('NEGATIVE', 'Z'),
+            'Y': ('POSITIVE', 'X'),
+            'Z': ('NEGATIVE', 'Y')
+        })
+
+    def test_dump_with_kabsch_rotation(self):
+        self.set_valid_kabsch_rotation()
+        self.assertTrue(self.calibration._kabsch_rotation.is_valid)
+        self.assertListEqual(self.calibration.dump()["kabsch_rotation"], [
+            {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 0
+            },
+            {
+                'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                'chip_coordinate': [-1050.0, -160.0, 0.0],
+                'device_id': 1
+            },
+            {
+                'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                'chip_coordinate': [1046.25, -1337.5, 0.0],
+                'device_id': 2
+            },
+            {
+                'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                'chip_coordinate': [1046.25, 1287.5, 0.0],
+                'device_id': 3
+            }])
+
+
+    def test_load_with_axes_rotation(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+    def test_load_with_single_point_offset(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
+
+    def test_load_with_kabsch_rotation(self):
+        self.stage.connect()
+        chip = Chip(
+            name="Dummy Chip",
+            devices=[
+                Device(0, [0,0], [1,1]),
+                Device(1, [2,2], [3,3]),
+                Device(2, [4,4], [5,5]),
+                Device(3, [6,6], [7,7])
+            ])
+
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            },
+            "kabsch_rotation": [
+                {
+                    'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                    'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                    'device_id': 0
+                },
+                {
+                    'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                    'chip_coordinate': [-1050.0, -160.0, 0.0],
+                    'device_id': 1
+                },
+                {
+                    'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                    'chip_coordinate': [1046.25, -1337.5, 0.0],
+                    'device_id': 2
+                },
+                {
+                    'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                    'chip_coordinate': [1046.25, 1287.5, 0.0],
+                    'device_id': 3
+                }   
+            ]
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
+

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -68,6 +68,13 @@ class MainWindowContextMenu(Menu):
         self._movement_new.add_command(
             label="Calibrate Stages...",
             command=self._menu_listener.client_calibrate_stage)
+        self._movement_new.add_separator()
+        self._movement_new.add_command(
+            label="Move Stages Relative",
+            command=self._menu_listener.client_move_stages)
+        self._movement_new.add_command(
+            label="Move Stages to Device",
+            command=self._menu_listener.client_move_device)
 
         self._movement.add_command(
             label="Configure Stages",
@@ -75,12 +82,6 @@ class MainWindowContextMenu(Menu):
         self._movement.add_command(
             label="Define Chip-Stage Coordinate Transformation",
             command=self._menu_listener.client_transformation)
-        self._movement.add_command(
-            label="Move Stages Relative",
-            command=self._menu_listener.client_move_stages)
-        self._movement.add_command(
-            label="Move Stages to Device",
-            command=self._menu_listener.client_move_device)
         self._movement.add_command(
             label="Search for Peak (Ctrl+S)",
             command=self._menu_listener.client_search_for_peak)

--- a/LabExT/View/Movement/MoveStagesDeviceWindow.py
+++ b/LabExT/View/Movement/MoveStagesDeviceWindow.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y
+from typing import Type
+from LabExT.Utils import run_with_wait_window
+
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.View.Controls.DeviceTable import DeviceTable
+from LabExT.Wafer.Chip import Chip, Device
+
+
+class MoveStagesDeviceWindow(Toplevel):
+    """
+    Window to move stages to device
+    """
+
+    def __init__(
+        self,
+        master,
+        mover: Type[MoverNew],
+        chip: Type[Chip]
+    ) -> None:
+        """
+        Constructor for new move to device Window.
+
+        Parameters
+        ----------
+        master : Tk
+            Tk instance of the master toplevel
+        mover : Mover
+            Instance of the current mover.
+        mover : Chip
+            Instance of the current chip.
+
+        Raises
+        ------
+        RuntimeError
+            If mover cannot move absolutely
+            If chip is None.
+        """
+        self.mover: Type[MoverNew] = mover
+        self.chip: Type[Chip] = chip
+
+        if not self.mover.can_move_absolutely:
+            raise RuntimeError(
+                f"Cannot perform absolute movement, not all active stages are calibrated correctly. "
+                "Note for each stage a coordinate transformation must be defined.")
+
+        if self.chip is None:
+            raise RuntimeError(
+                "'No chip file imported before moving to device. Cannot move to device without chip file present.")
+
+        super(MoveStagesDeviceWindow, self).__init__(master)
+
+        # Set up window
+        self.title("Move Stages to Device")
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1000, 400, 200, 200))
+        self.protocol('WM_DELETE_WINDOW', self.destroy)
+
+        # Build window
+        self._main_frame = Frame(self, borderwidth=0, relief=FLAT)
+        self._main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
+
+        hint = "Automatically move the stages to a device selected below.\n"\
+               f"The stages are z-lifted by {self.mover.z_lift:.0f}nm before the lateral movement and lowered again afterwards.\n"
+        Label(self._main_frame, text=hint).pack(side=TOP, fill=X)
+
+        self._buttons_frame = Frame(
+            self,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0)
+        self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
+
+        self._execute_button = Button(
+            self._buttons_frame,
+            text="Execute Movement",
+            width=15,
+            command=self.execute_movement)
+        self._execute_button.pack(
+            side=RIGHT, fill=Y, expand=0)
+
+        self._device_table = DeviceTable(self._main_frame, self.chip)
+        self._device_table.pack(side=TOP, fill=X)
+
+    def execute_movement(self):
+        """
+        Callback, when user wants to execute the movement.
+        """
+        selected_device = self._device_table.get_selected_device()
+        if selected_device is None:
+            messagebox.showwarning(
+                'Selection Needed',
+                'Please select one device.',
+                parent=self)
+            return
+
+        if self._confirm_movement(selected_device):
+            run_with_wait_window(
+                self,
+                f"Moving to Device {selected_device.id}",
+                lambda: self.mover.move_to_device(self.chip, selected_device))
+
+    def _confirm_movement(self, device: Type[Device]) -> bool:
+        """
+        Asks the user to confirm the movement.
+        """
+        message = f"By proceeding the stages will be moved to device {device.id}\n"\
+            "Do you want to proceed?"
+
+        return messagebox.askokcancel("Confirm Movement", message, parent=self)

--- a/LabExT/View/Movement/MoveStagesRelativeWindow.py
+++ b/LabExT/View/Movement/MoveStagesRelativeWindow.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y
+from typing import Type
+from LabExT.Movement.Transformations import ChipCoordinate
+from LabExT.Movement.config import Axis
+from LabExT.Utils import run_with_wait_window
+
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.View.Controls.ParameterTable import ConfigParameter, ParameterTable
+
+
+class MoveStagesRelativeWindow(Toplevel):
+    """
+    Window to move stages relative in chip coordinates
+    """
+
+    def __init__(
+        self,
+        master,
+        mover: Type[MoverNew]
+    ) -> None:
+        """
+        Constructor for new CoordinatePairing Window.
+
+        Parameters
+        ----------
+        master : Tk
+            Tk instance of the master toplevel
+        mover : Mover
+            Instance of the current mover.
+
+        Raises
+        ------
+        ValueError
+            If input or output calibration are undefined but requested by user.
+            If chip is None.
+        """
+        self.mover: Type[MoverNew] = mover
+
+        if not self.mover.can_move_relatively:
+            raise RuntimeError(
+                f"Cannot perform relative movement, not all active stages are calibrated correctly. "
+                "Note for each stage the coordinate system must be fixed.")
+
+        super(MoveStagesRelativeWindow, self).__init__(master)
+
+        self.parameters = {}
+
+        # Set up window
+        self.title("Move Stages Relative")
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(600, 400, 200, 200))
+        self.protocol('WM_DELETE_WINDOW', self.destroy)
+
+        # Build window
+        self._main_frame = Frame(self, borderwidth=0, relief=FLAT)
+        self._main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
+
+        hint = "Move the stages relative in the chip coordinate system.\n"\
+               "Note: the stages are NOT automatically z-lifted before lateral movement.\n"\
+               "The stages will move one after each other in the order: top, right, bottom, left"
+        Label(self._main_frame, text=hint).pack(side=TOP, fill=X)
+
+        self._buttons_frame = Frame(
+            self,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0)
+        self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
+
+        self._execute_button = Button(
+            self._buttons_frame,
+            text="Execute Movement",
+            width=15,
+            command=self.execute_movement)
+        self._execute_button.pack(
+            side=RIGHT, fill=Y, expand=0)
+
+        self.parameter_tables = {}
+        for calibration in self.mover.calibrations.values():
+            movement_params = {}
+            for axis in Axis:
+                movement_params[axis] = ConfigParameter(
+                    self, unit='um', parameter_type='number_float')
+
+            parameter_table = ParameterTable(self._main_frame)
+            parameter_table.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
+            parameter_table.title = f"Relative movement of {calibration}"
+            parameter_table.parameter_source = movement_params
+
+            self.parameter_tables[calibration] = parameter_table
+            self.parameters[calibration] = movement_params
+
+    def execute_movement(self):
+        """
+        Callback, when user wants to execute the movement.
+        """
+        movement_commands = {}
+        for calibration, params in self.parameters.items():
+            requested_offset = ChipCoordinate(
+                x=float(params[Axis.X].value),
+                y=float(params[Axis.Y].value),
+                z=float(params[Axis.Z].value))
+
+            if not requested_offset.is_zero:
+                movement_commands[calibration.orientation] = requested_offset
+
+        if self._confirm_movement(movement_commands):
+            run_with_wait_window(
+                self,
+                "Moving stages relatively",
+                lambda: self.mover.move_relative(movement_commands))
+
+    def _confirm_movement(self, movement_commands) -> bool:
+        """
+        Asks the user to confirm the movement.
+        """
+        message = "By proceeding the following movement will be executed: \n\n"
+        for orientation, coord in movement_commands.items():
+            message += f"{orientation} stage is shifted by the offset {coord}.\n"
+
+        message += "\nDo you want to proceed?"
+
+        return messagebox.askokcancel("Confirm Movement", message, parent=self)

--- a/LabExT/View/Movement/__init__.py
+++ b/LabExT/View/Movement/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Module for Movement related GUIs
+"""
+
+from .MovementWizard import (
+    StageWizard,
+    MoverWizard,
+    CalibrationWizard
+)
+from .CoordinatePairingsWindow import CoordinatePairingsWindow
+from .MoveStagesRelativeWindow import MoveStagesRelativeWindow
+from .MoveStagesDeviceWindow import MoveStagesDeviceWindow


### PR DESCRIPTION
Implements move relative in new Mover.
Relative movements are performed without collision avoidance. When multiple stages are requested to move, they move clockwise unless otherwise requested.

Tests for this behavior have been added.