### PR TITLE
[Movement]: Dump and load transformations

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -4,6 +4,8 @@
 LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
+from __future__ import annotations
+import logging
 
 from typing import TYPE_CHECKING, Type, Union
 from functools import wraps
@@ -19,6 +21,8 @@ from LabExT.Movement.PathPlanning import StagePolygon, SingleModeFiber
 
 if TYPE_CHECKING:
     from LabExT.Movement.Stage import Stage
+    from LabExT.Movement.MoverNew import MoverNew
+    from LabExT.Wafer.Chip import Chip
 
 
 class CalibrationError(RuntimeError):
@@ -67,22 +71,110 @@ class Calibration:
     Represents a calibration of one stage.
     """
 
-    def __init__(self, mover, stage, orientation, device_port) -> None:
+    _logger = logging.getLogger()
+
+    @classmethod
+    def load(
+        cls,
+        mover: Type[MoverNew],
+        stage: Type[Stage],
+        calibration_data: dict,
+        chip: Type[Chip] = None
+    ) -> Type[Calibration]:
+        """
+        Creates a new calibration based on calibration data.
+
+        Parameters
+        ----------
+        mover : Mover
+            Instance of mover associated with this calibration.
+        stage : Stage
+            Instance of a stage
+        calibration_data : dict
+            Dumped calibration data
+
+        Returns
+        -------
+        Calibration
+            Instance of calibration
+        """
+        try:
+            orientation = Orientation[calibration_data["orientation"]]
+            device_port = DevicePort[calibration_data["device_port"]]
+        except KeyError as err:
+            raise CalibrationError(
+                f"The parameter is not defined: {err}. "
+                "Make sure to pass a valid orientation and device port.")
+
+        axes_rotation = None
+        if "axes_rotation" in calibration_data:
+            axes_rotation = AxesRotation.load(
+                calibration_data["axes_rotation"])
+
+        single_point_offset = None
+        if "single_point_offset" in calibration_data:
+            if axes_rotation is not None:
+                single_point_offset = SinglePointOffset.load(
+                    calibration_data["single_point_offset"], axes_rotation=axes_rotation)
+            else:
+                cls._logger.debug(
+                    "Cannot set single point offset when axes rotation is not defined")
+
+        kabsch_rotation = None
+        if "kabsch_rotation" in calibration_data:
+            if axes_rotation is not None and chip is not None:
+                kabsch_rotation = KabschRotation.load(
+                    calibration_data["kabsch_rotation"], chip=chip, axes_rotation=axes_rotation)
+            else:
+                cls._logger.debug(
+                    "Cannot set kabsch rotation when axes rotation or chip is not defined")
+
+        return cls(
+            mover,
+            stage,
+            orientation,
+            device_port,
+            axes_rotation,
+            single_point_offset,
+            kabsch_rotation)
+
+    def __init__(
+        self,
+        mover: Type[MoverNew],
+        stage: Type[Stage],
+        orientation: Orientation,
+        device_port: DevicePort,
+        axes_rotation: Type[AxesRotation] = None,
+        single_point_offset: Type[SinglePointOffset] = None,
+        kabsch_rotation: Type[KabschRotation] = None
+    ) -> None:
         self.mover = mover
         self.stage: Type[Stage] = stage
 
         self.stage_polygon: Type[StagePolygon] = SingleModeFiber(orientation)
 
-        self._state = State.CONNECTED if stage.connected else State.UNINITIALIZED
         self._orientation = orientation
         self._device_port = device_port
 
         self._coordinate_system = None
 
-        self._axes_rotation: Type[AxesRotation] = AxesRotation()
-        self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(
-            self._axes_rotation)
-        self._kabsch_rotation: Type[KabschRotation] = KabschRotation(self._axes_rotation)
+        self._axes_rotation = axes_rotation
+        if axes_rotation is None:
+            self._axes_rotation = AxesRotation()
+
+        self._single_point_offset = single_point_offset
+        if single_point_offset is None:
+            self._single_point_offset = SinglePointOffset(self._axes_rotation)
+
+        self._kabsch_rotation = kabsch_rotation
+        if kabsch_rotation is None:
+            self._kabsch_rotation = KabschRotation(self._axes_rotation)
+
+        assert self._single_point_offset.axes_rotation == self._axes_rotation, "Axes rotation for single point offset must be the same than for the calibration."
+        assert self._kabsch_rotation.axes_rotation == self._axes_rotation, "Axes rotation for kabsch rotation must be the same than for the calibration"
+
+        self._state = State.UNINITIALIZED
+        self.determine_state(skip_connection=False)
 
     #
     #   Representation
@@ -497,3 +589,23 @@ class Calibration:
 
         self.stage.set_speed_xy(current_speed_xy)
         self.stage.set_speed_z(current_speed_z)
+
+    def dump(self) -> dict:
+        """
+        Returns a dict of all calibration properties.
+        """
+        calibration_dump = {
+            "orientation": self.orientation.value,
+            "device_port": self._device_port.value}
+
+        if self._axes_rotation.is_valid:
+            calibration_dump["axes_rotation"] = self._axes_rotation.dump()
+
+        if self._single_point_offset.is_valid:
+            calibration_dump["single_point_offset"] = self._single_point_offset.dump(
+            )
+
+        if self._kabsch_rotation.is_valid:
+            calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
+
+        return calibration_dump

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -642,6 +642,35 @@ class KabschRotation(Transformation):
 
     MIN_POINTS = 3
 
+    @classmethod
+    def load(
+        cls,
+        pairing: list,
+        axes_rotation: Type[KabschRotation]
+    ) -> Type[Transformation]:
+        """
+        Creates a new kabsch rotation based on pairings.
+
+        Parameters
+        ----------
+        pairings : list
+            pairings for stage and chip coordinates
+        axes_rotation : AxesRotation
+            axes rotation associated with the transformation
+
+        Raises
+        ------
+        TransformationError
+            If pairings are not well-formed
+            If pairings do not define a valid transformation
+
+        Returns
+        -------
+        KabschRotation
+            A valid kabsch rotation based on the pairings.
+        """
+        pass
+
     def __init__(self, axes_rotation: Type[AxesRotation] = None) -> None:
         self.initialize(axes_rotation)
 
@@ -775,6 +804,12 @@ class KabschRotation(Transformation):
         return ChipCoordinate.from_numpy((
             self.rotation_to_chip.dot(stage_coordinate.to_numpy()) +
             self.translation_to_chip.T).flatten())
+
+    def dump(self, *args, **kwargs) -> Any:
+        """
+        Returns a list of pairings defining the rotation.
+        """
+        return super().dump(*args, **kwargs)
 
 
 def rigid_transform_with_orientation_preservation(

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -219,7 +219,7 @@ class Transformation(ABC):
     The base class cannot be initialised directly.
     """
 
-    @classmethod
+    @abstractclassmethod
     def load(cls, data: Any, *args, **kwargs) -> Type[Transformation]:
         """
         Creates a new Transformation from data

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -8,8 +8,8 @@ for details see LICENSE file.
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, NamedTuple, Type
-from abc import ABC, abstractmethod, abstractproperty
+from typing import TYPE_CHECKING, Any, NamedTuple, Type
+from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
 from functools import wraps
 import numpy as np
 
@@ -162,6 +162,13 @@ class Transformation(ABC):
     The base class cannot be initialised directly.
     """
 
+    @abstractclassmethod
+    def load(cls, data: Any) -> Type[Transformation]:
+        """
+        Creates a new Transformation from data
+        """
+        pass
+
     @abstractmethod
     def __init__(self) -> None:
         pass
@@ -195,6 +202,13 @@ class Transformation(ABC):
             stage_coordinate: Type[StageCoordinate]) -> Type[ChipCoordinate]:
         """
         Transforms a coordinate in stage space to chip space.
+        """
+        pass
+
+    @abstractmethod
+    def dump(self) -> Any:
+        """
+        Dumps transformation into storable format.
         """
         pass
 

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -6,6 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from shutil import move
+from typing import Any
 import unittest
 import numpy as np
 from unittest.mock import Mock, patch, call
@@ -19,6 +20,8 @@ from LabExT.Movement.Stages.DummyStage import DummyStage
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Transformations import ChipCoordinate, CoordinatePairing, StageCoordinate
 from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
+from ...Wafer.Chip import Chip
+from LabExT.Wafer.Device import Device
 
 EXPECTED_TO_REJECT = [
     (State.UNINITIALIZED, [State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
@@ -71,17 +74,17 @@ class CalibrationTestCase(unittest.TestCase):
         self.calibration.update_single_point_offset(CoordinatePairing(
             self.calibration,
             StageCoordinate.from_numpy(VACHERIN_STAGE_COORDS[0]),
-            Mock(),
+            Device(id=1, in_position=[0,0], out_position=[1,1]),
             ChipCoordinate.from_numpy(VACHERIN_CHIP_COORDS[0])
         ))
 
     def set_valid_kabsch_rotation(self):
-        for stage_coord, chip_coord in zip(
-                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS):
+        for device_id, (stage_coord, chip_coord) in enumerate(zip(
+                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS)):
             self.calibration.update_kabsch_rotation(CoordinatePairing(
                 calibration=self.calibration,
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
-                device=Mock(),
+                device=Device(device_id, [0,0], [1,1]),
                 chip_coordinate=ChipCoordinate.from_numpy(chip_coord)))
 
 
@@ -635,3 +638,148 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_z_mock.assert_has_calls([call(5000), call(current_speed_z)])
         set_speed_xy_mock.assert_has_calls(
             [call(5000), call(current_speed_xy)])
+
+    def test_dump_includes_orientation_and_port(self):
+        calibration = Calibration(self.mover, self.stage, Orientation.BOTTOM, DevicePort.INPUT)
+        calibration_dump = calibration.dump()
+
+        self.assertEqual(calibration_dump["orientation"], "BOTTOM")
+        self.assertEqual(calibration_dump["device_port"], "INPUT")
+
+
+    def test_dump_with_no_single_point_offset(self):
+        self.assertFalse(self.calibration._single_point_offset.is_valid)
+        self.assertFalse("single_point_offset" in self.calibration.dump())
+
+    def test_dump_with_single_point_offset(self):
+        self.set_valid_single_point_offset()
+
+        self.assertTrue(self.calibration._single_point_offset.is_valid)
+        self.assertDictEqual(self.calibration.dump()["single_point_offset"], {
+            'stage_coordinate': [23236.35, -7888.67, 18956.06],
+            'chip_coordinate': [-1550.0, 1120.0, 0.0],
+            'device_id': 1
+        })
+
+    def test_dump_with_axes_rotation(self):
+        self.set_valid_axes_rotation()
+
+        self.assertTrue(self.calibration._axes_rotation.is_valid)
+        self.assertDictEqual(self.calibration.dump()["axes_rotation"], {
+            'X': ('NEGATIVE', 'Z'),
+            'Y': ('POSITIVE', 'X'),
+            'Z': ('NEGATIVE', 'Y')
+        })
+
+    def test_dump_with_kabsch_rotation(self):
+        self.set_valid_kabsch_rotation()
+        self.assertTrue(self.calibration._kabsch_rotation.is_valid)
+        self.assertListEqual(self.calibration.dump()["kabsch_rotation"], [
+            {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 0
+            },
+            {
+                'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                'chip_coordinate': [-1050.0, -160.0, 0.0],
+                'device_id': 1
+            },
+            {
+                'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                'chip_coordinate': [1046.25, -1337.5, 0.0],
+                'device_id': 2
+            },
+            {
+                'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                'chip_coordinate': [1046.25, 1287.5, 0.0],
+                'device_id': 3
+            }])
+
+
+    def test_load_with_axes_rotation(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+    def test_load_with_single_point_offset(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
+
+    def test_load_with_kabsch_rotation(self):
+        self.stage.connect()
+        chip = Chip(
+            name="Dummy Chip",
+            devices=[
+                Device(0, [0,0], [1,1]),
+                Device(1, [2,2], [3,3]),
+                Device(2, [4,4], [5,5]),
+                Device(3, [6,6], [7,7])
+            ])
+
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            },
+            "kabsch_rotation": [
+                {
+                    'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                    'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                    'device_id': 0
+                },
+                {
+                    'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                    'chip_coordinate': [-1050.0, -160.0, 0.0],
+                    'device_id': 1
+                },
+                {
+                    'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                    'chip_coordinate': [1046.25, -1337.5, 0.0],
+                    'device_id': 2
+                },
+                {
+                    'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                    'chip_coordinate': [1046.25, 1287.5, 0.0],
+                    'device_id': 3
+                }   
+            ]
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
+

--- a/LabExT/Tests/Movement/Transformations_test.py
+++ b/LabExT/Tests/Movement/Transformations_test.py
@@ -11,7 +11,7 @@ import unittest
 from unittest.mock import Mock
 import numpy as np
 from numpy.testing import assert_array_equal
-from random import uniform
+from random import seed, uniform
 from parameterized import parameterized
 from itertools import product, combinations, permutations
 from scipy.spatial.transform import Rotation
@@ -29,9 +29,7 @@ POSSIBLE_AXIS_ROTATIONS = list(product(
     permutations(Axis), product(
         Direction, repeat=3)))
 
-VACHERIN_ROTATION, VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS = get_calibrations_from_file(
-    "vacherin.json", "left")
-
+VACHERIN_ROTATION, VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS = get_calibrations_from_file("vacherin.json", "left")
 
 class CoordinateTest(unittest.TestCase):
 
@@ -208,42 +206,38 @@ class ChipCoordinateTest(CoordinateTest):
 
 class CoordinatePairingTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.device = Device(
-            id='1', in_position=[
-                1., 1.], out_position=[
-                2., 2.], type='test')
+        self.device = Device(id='1', in_position=[1., 1.], out_position=[2., 2.], type='test')
         self.pairing = CoordinatePairing(
             calibration=Mock(),
-            stage_coordinate=StageCoordinate(7, 8, 9),
+            stage_coordinate=StageCoordinate(7,8,9),
             device=self.device,
-            chip_coordinate=ChipCoordinate(1, 2, 3))
+            chip_coordinate=ChipCoordinate(1,2,3))
 
     def test_dump_with_device(self):
         pairing_data = self.pairing.dump(include_device_id=True)
 
         self.assertDictEqual(pairing_data, {
-            "stage_coordinate": [7, 8, 9],
-            "chip_coordinate": [1, 2, 3],
+            "stage_coordinate": [7,8,9],
+            "chip_coordinate": [1,2,3],
             "device_id": '1'})
 
     def test_dump_without_device(self):
         pairing_data = self.pairing.dump(include_device_id=False)
 
         self.assertDictEqual(pairing_data, {
-            "stage_coordinate": [7, 8, 9],
-            "chip_coordinate": [1, 2, 3]})
+            "stage_coordinate": [7,8,9],
+            "chip_coordinate": [1,2,3]})
 
     def test_load(self):
         pairing_data = {
-            "stage_coordinate": [4, 2, 1],
-            "chip_coordinate": [6, 5, 9]}
+            "stage_coordinate": [4,2,1],
+            "chip_coordinate": [6,5,9]}
 
         calibration = Mock()
-        pairing = CoordinatePairing.load(
-            pairing_data, self.device, calibration)
+        pairing = CoordinatePairing.load(pairing_data, self.device, calibration)
 
-        self.assertEqual(pairing.stage_coordinate.to_list(), [4, 2, 1])
-        self.assertEqual(pairing.chip_coordinate.to_list(), [6, 5, 9])
+        self.assertEqual(pairing.stage_coordinate.to_list(), [4,2,1])
+        self.assertEqual(pairing.chip_coordinate.to_list(), [6,5,9])
         self.assertEqual(pairing.device, self.device)
         self.assertEqual(pairing.calibration, calibration)
 
@@ -306,12 +300,9 @@ class AxesRotationTest(unittest.TestCase):
             self.rotation.stage_to_chip(stage_axis_unit),
             chip_axis_unit * direction.value)
 
-    @parameterized.expand(zip(POSSIBLE_AXIS_ROTATIONS,
-                              [np.array(d) * np.array(p) for p in permutations([1,
-                                                                                2,
-                                                                                3]) for d in product([-1,
-                                                                                                      1],
-                                                                                                     repeat=3)]))
+    @parameterized.expand(zip(
+        POSSIBLE_AXIS_ROTATIONS,
+        [np.array(d) * np.array(p) for p in permutations([1,2,3]) for d in product([-1,1],repeat=3)]))
     def test_possible_axes_assignments(
             self,
             stage_axes_mapping,
@@ -327,6 +318,7 @@ class AxesRotationTest(unittest.TestCase):
 
         self.assertEqual(self.rotation.stage_to_chip(stage_coord), chip_coord)
         self.assertEqual(self.rotation.chip_to_stage(chip_coord), stage_coord)
+
 
     def test_dump(self):
         self.rotation.update(Axis.X, Direction.NEGATIVE, Axis.Y)
@@ -353,21 +345,22 @@ class AxesRotationTest(unittest.TestCase):
 
         with self.assertRaises(TransformationError):
             AxesRotation.load(invalid_mapping)
+        
 
     def test_load(self):
         mapping = {
-            'Z': ('NEGATIVE', 'Z'),
-            'Y': ('NEGATIVE', 'X'),
-            'X': ('POSITIVE', 'Y')
-        }
+             'Z': ('NEGATIVE', 'Z'),
+             'Y': ('NEGATIVE', 'X'),
+             'X': ('POSITIVE', 'Y')
+         }
 
         rotation = AxesRotation.load(mapping)
 
         self.assertTrue(rotation.is_valid)
         assert_array_equal(rotation.matrix, [
-            [0, -1, 0],
-            [1, 0, 0],
-            [0, 0, -1]
+             [0, -1, 0],
+             [1,0,0],
+             [0,0,-1]
         ])
 
     def test_dump_and_load(self):
@@ -381,11 +374,10 @@ class AxesRotationTest(unittest.TestCase):
         restored_rotation = AxesRotation.load(self.rotation.dump())
 
         self.assertFalse(restored_rotation == self.rotation)
-
+        
         self.assertTrue(restored_rotation.is_valid)
         assert_array_equal(matrix_before, restored_rotation.matrix)
         self.assertDictEqual(mapping_before, restored_rotation.mapping)
-
 
 class SinglePointOffsetTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -463,7 +455,38 @@ class SinglePointOffsetTest(unittest.TestCase):
             rtol=1,
             atol=1))
 
+    
     def test_dump(self):
+        chip_coordinate = ChipCoordinate.from_list([-1550, 1120, 0])
+        stage_coordinate = StageCoordinate.from_list(
+             [23236.35, -7888.67, 18956.06])
+
+        device = Mock()
+        self.transformation.update(CoordinatePairing(
+            calibration=Mock(),
+            stage_coordinate=stage_coordinate,
+            device=device,
+            chip_coordinate=chip_coordinate))   
+
+        self.assertDictEqual(self.transformation.dump(), {
+            "stage_coordinate": [23236.35, -7888.67, 18956.06],
+            "chip_coordinate": [-1550, 1120, 0],
+            "device_id": device.id
+        })
+
+    def test_load(self):
+        stored_format = {
+            "stage_coordinate": [19,293.03,1029.02],
+            "chip_coordinate": [110203,29342,0],
+        }
+
+        transformation = SinglePointOffset.load(stored_format, self.rotation)
+
+        assert_array_equal(
+            transformation.stage_offset.to_numpy(),
+            np.array([110203,29342,0]) - np.array([19,293.03,1029.02]))
+
+    def test_dump_and_load(self):
         chip_coordinate = ChipCoordinate.from_list([-1550, 1120, 0])
         stage_coordinate = StageCoordinate.from_list(
             [23236.35, -7888.67, 18956.06])
@@ -474,32 +497,37 @@ class SinglePointOffsetTest(unittest.TestCase):
             device=Mock(),
             chip_coordinate=chip_coordinate))
 
-        self.transformation.dump()
+        current_offset = self.transformation.stage_offset.to_numpy()
+
+        from_stored_offset = SinglePointOffset.load(
+            self.transformation.dump(),
+            self.transformation.axes_rotation)
+
+        assert_array_equal(current_offset, from_stored_offset.stage_offset.to_numpy())
 
 
 class RigidTransformationTest(unittest.TestCase):
-
+    
     def assert_rmse_less_than(self, set_a, set_b, bound):
         _, n = set_a.shape
         diff = np.array(set_a) - np.array(set_b)
         rmsd = np.sqrt((diff * diff).sum() / n)
 
-        self.assertLess(
-            rmsd,
-            bound,
+        self.assertLess(rmsd, bound,
             f"Difference between start dataset and end dataset is greater than {bound} after recovery.")
 
     def test_with_random_rotation_and_translation(self):
         N = 10
 
         R = Rotation.random().as_matrix()
-        t = np.random.rand(3, 1)
+        t = np.random.rand(3,1)
 
         start_dataset = np.random.rand(3, N)
         target_dataset = (R @ start_dataset) + t
 
         R_ret, t_ret, R_inv_ret, t_inv_ret = rigid_transform_with_orientation_preservation(
-            S=start_dataset, T=target_dataset)
+            S=start_dataset,
+            T=target_dataset)
 
         target_dataset_ret = R_ret @ start_dataset + t_ret
         start_dataset_ret = R_inv_ret @ target_dataset + t_inv_ret
@@ -525,23 +553,14 @@ class KabschRotationTest(unittest.TestCase):
 
         self.assertFalse(self.transformation.is_valid)
 
-    @parameterized.expand(
-        [
-            (CoordinatePairing(
-                None, None, None, None),), (CoordinatePairing(
-                    None, StageCoordinate(
-                        1, 2, 3), None, None),), (CoordinatePairing(
-                            None, None, None, ChipCoordinate(
-                                1, 2, 3)),), (CoordinatePairing(
-                                    None, StageCoordinate(
-                                        1, 2, 3), None, ChipCoordinate(
-                                        1, 2, 3)),), (CoordinatePairing(
-                                            Mock(), StageCoordinate(
-                                                1, 2, 3), None, ChipCoordinate(
-                                                    1, 2, 3)),), (CoordinatePairing(
-                                                        None, StageCoordinate(
-                                                            1, 2, 3), Mock(), ChipCoordinate(
-                                                                1, 2, 3)),), ])
+    @parameterized.expand([
+        (CoordinatePairing(None, None, None, None),),
+        (CoordinatePairing(None, StageCoordinate(1, 2, 3), None, None),),
+        (CoordinatePairing(None, None, None, ChipCoordinate(1, 2, 3)),),
+        (CoordinatePairing(None, StageCoordinate(1, 2, 3), None, ChipCoordinate(1, 2, 3)),),
+        (CoordinatePairing(Mock(), StageCoordinate(1, 2, 3), None, ChipCoordinate(1, 2, 3)),),
+        (CoordinatePairing(None, StageCoordinate(1, 2, 3), Mock(), ChipCoordinate(1, 2, 3)),),
+    ])
     def test_update_with_invalid_pairing(self, invalid_pairing):
         with self.assertRaises(ValueError):
             self.transformation.update(invalid_pairing)
@@ -552,43 +571,27 @@ class KabschRotationTest(unittest.TestCase):
         device = Mock()
         pairing = CoordinatePairing(
             calibration=self.calibration,
-            stage_coordinate=StageCoordinate(1, 2, 3),
+            stage_coordinate=StageCoordinate(1,2,3),
             device=device,
-            chip_coordinate=ChipCoordinate(4, 5, 6))
+            chip_coordinate=ChipCoordinate(4,5,6))
 
         self.transformation.update(pairing)
         self.assertIn(pairing, self.transformation.pairings)
 
         pairing_2 = CoordinatePairing(
             calibration=self.calibration,
-            stage_coordinate=StageCoordinate(7, 8, 9),
+            stage_coordinate=StageCoordinate(7,8,9),
             device=device,
-            chip_coordinate=ChipCoordinate(8, 7, 6))
+            chip_coordinate=ChipCoordinate(8,7,6))
 
         with self.assertRaises(ValueError):
             self.transformation.update(pairing_2)
 
         self.assertNotIn(pairing_2, self.transformation.pairings)
 
-    @parameterized.expand([(np.delete(VACHERIN_STAGE_COORDS,
-                                      (i),
-                                      axis=0),
-                            np.delete(VACHERIN_CHIP_COORDS,
-                                      (i),
-                                      axis=0),
-                            VACHERIN_STAGE_COORDS[i,
-                                                  :],
-                            VACHERIN_CHIP_COORDS[i,
-                                                 :]) for i in range(0,
-                                                                    4)])
-    def test_transformation_estimates_fourth_variable(
-            self,
-            stage_coordinates,
-            chip_coordinates,
-            test_stage_coordinate,
-            test_chip_coordinate):
-        for stage_coord, chip_coord in zip(
-                stage_coordinates, chip_coordinates):
+    @parameterized.expand([(np.delete(VACHERIN_STAGE_COORDS, (i), axis=0), np.delete(VACHERIN_CHIP_COORDS, (i), axis=0), VACHERIN_STAGE_COORDS[i,:], VACHERIN_CHIP_COORDS[i,:]) for i in range(0,4)])
+    def test_transformation_estimates_fourth_variable(self, stage_coordinates, chip_coordinates, test_stage_coordinate, test_chip_coordinate):
+        for stage_coord, chip_coord in zip(stage_coordinates, chip_coordinates):
             pairing = CoordinatePairing(
                 calibration=Mock(),
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
@@ -600,48 +603,34 @@ class KabschRotationTest(unittest.TestCase):
 
         self.assertTrue(self.transformation.is_valid)
 
-        test_stage_coordinate = StageCoordinate.from_numpy(
-            test_stage_coordinate)
+        test_stage_coordinate = StageCoordinate.from_numpy(test_stage_coordinate)
         test_chip_coordinate = ChipCoordinate.from_numpy(test_chip_coordinate)
 
-        ret_stage_coordinate = self.transformation.chip_to_stage(
-            test_chip_coordinate)
-        ret_chip_coordinate = self.transformation.stage_to_chip(
-            test_stage_coordinate)
+        ret_stage_coordinate = self.transformation.chip_to_stage(test_chip_coordinate)
+        ret_chip_coordinate = self.transformation.stage_to_chip(test_stage_coordinate)
 
-        np.testing.assert_allclose(
-            test_stage_coordinate.to_numpy(),
-            ret_stage_coordinate.to_numpy(),
-            atol=20,
-            rtol=1e-3)
-        np.testing.assert_allclose(
-            test_chip_coordinate.to_numpy(),
-            ret_chip_coordinate.to_numpy(),
-            atol=20,
-            rtol=1e-3)
+        np.testing.assert_allclose(test_stage_coordinate.to_numpy(), ret_stage_coordinate.to_numpy(), atol=20, rtol=1e-3)
+        np.testing.assert_allclose(test_chip_coordinate.to_numpy(), ret_chip_coordinate.to_numpy(), atol=20, rtol=1e-3)
 
+    
     def test_reversibility(self):
-        for stage_coord, chip_coord in zip(
-                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS):
+        for stage_coord, chip_coord in zip(VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS):
             self.transformation.update(CoordinatePairing(
                 calibration=Mock(),
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
                 device=Mock(),
                 chip_coordinate=ChipCoordinate.from_numpy(chip_coord)))
 
-        chip_coordinate = ChipCoordinate(1, 2, 3)
-        stage_coordinate = StageCoordinate(4, 5, 6)
+        chip_coordinate = ChipCoordinate(1,2,3)
+        stage_coordinate = StageCoordinate(4,5,6)
 
-        self.assertTrue(
-            np.allclose(
-                self.transformation.stage_to_chip(
-                    self.transformation.chip_to_stage(chip_coordinate)).to_numpy(),
-                chip_coordinate.to_numpy()))
-        self.assertTrue(
-            np.allclose(
-                self.transformation.chip_to_stage(
-                    self.transformation.stage_to_chip(stage_coordinate)).to_numpy(),
-                stage_coordinate.to_numpy()))
+        self.assertTrue(np.allclose(
+            self.transformation.stage_to_chip(self.transformation.chip_to_stage(chip_coordinate)).to_numpy(),
+            chip_coordinate.to_numpy()))
+        self.assertTrue(np.allclose(
+            self.transformation.chip_to_stage(self.transformation.stage_to_chip(stage_coordinate)).to_numpy(),
+            stage_coordinate.to_numpy()))
+
 
 
 class KabschOrientationPerservationTest(unittest.TestCase):
@@ -659,9 +648,9 @@ class KabschOrientationPerservationTest(unittest.TestCase):
             ChipCoordinate(*[2295.00, -2650, 0])]
 
         cls.axes_rotation_matrix = np.array([
-            [1, 0, 0],
-            [0, 1, 0],
-            [0, 0, -1]
+            [1,0,0],
+            [0,1,0],
+            [0,0,-1]
         ])
 
         cls.axes_rotation = AxesRotation()
@@ -669,24 +658,16 @@ class KabschOrientationPerservationTest(unittest.TestCase):
 
         cls.kabsch = KabschRotation(cls.axes_rotation)
         for stage_coord, chip_coord in zip(stage_coords, chip_coords):
-            cls.kabsch.update(
-                CoordinatePairing(
-                    Mock(),
-                    stage_coord,
-                    Mock(),
-                    chip_coord))
+            cls.kabsch.update(CoordinatePairing(Mock(), stage_coord, Mock(), chip_coord))
 
     def test_axes_sanity_check(self):
-        np.testing.assert_array_equal(
-            self.axes_rotation.matrix,
-            self.axes_rotation_matrix)
+        np.testing.assert_array_equal(self.axes_rotation.matrix, self.axes_rotation_matrix)
 
     def test_x_unit_direction(self):
-        chip_x_unit = [1, 0, 0]
+        chip_x_unit = [1,0,0]
 
         kabsch_stage_x_unit = self.kabsch.rotation_to_stage.dot(chip_x_unit)
-        user_stage_x_unit = self.axes_rotation.chip_to_stage(
-            ChipCoordinate(*chip_x_unit))
+        user_stage_x_unit = self.axes_rotation.chip_to_stage(ChipCoordinate(*chip_x_unit))
 
         np.testing.assert_allclose(
             kabsch_stage_x_unit, user_stage_x_unit.to_numpy(),
@@ -694,11 +675,10 @@ class KabschOrientationPerservationTest(unittest.TestCase):
             atol=1)
 
     def test_y_unit_direction(self):
-        chip_y_unit = [0, 1, 0]
+        chip_y_unit = [0,1,0]
 
         kabsch_stage_y_unit = self.kabsch.rotation_to_stage.dot(chip_y_unit)
-        user_stage_y_unit = self.axes_rotation.chip_to_stage(
-            ChipCoordinate(*chip_y_unit))
+        user_stage_y_unit = self.axes_rotation.chip_to_stage(ChipCoordinate(*chip_y_unit))
 
         np.testing.assert_allclose(
             kabsch_stage_y_unit, user_stage_y_unit.to_numpy(),
@@ -706,16 +686,16 @@ class KabschOrientationPerservationTest(unittest.TestCase):
             atol=1)
 
     def test_z_unit_direction(self):
-        chip_z_unit = [0, 0, 1]
+        chip_z_unit = [0,0,1]
 
         kabsch_stage_z_unit = self.kabsch.rotation_to_stage.dot(chip_z_unit)
-        user_stage_z_unit = self.axes_rotation.chip_to_stage(
-            ChipCoordinate(*chip_z_unit))
-
+        user_stage_z_unit = self.axes_rotation.chip_to_stage(ChipCoordinate(*chip_z_unit))
+        
         np.testing.assert_allclose(
             kabsch_stage_z_unit, user_stage_z_unit.to_numpy(),
             rtol=1e-5,
             atol=1)
+
 
 
 class KabschOrientationPerservationRandomTest(unittest.TestCase):
@@ -726,7 +706,7 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
     def create_pairings(
         self,
         axes_rotation: Type[AxesRotation],
-        noise=np.array([0, 0, 0]),
+        noise=np.array([0,0,0]),
         number_of_pairings=3
     ) -> List[CoordinatePairing]:
         pairings = []
@@ -754,7 +734,7 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
                 0])
             new_stage_coord = axes_rotation.chip_to_stage(
                 new_chip_coord) - stage_offset
-
+            
             pairings.append(CoordinatePairing(
                 calibration=Mock(),
                 stage_coordinate=new_stage_coord,
@@ -763,6 +743,7 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
 
         return pairings
 
+
     @parameterized.expand(POSSIBLE_AXIS_ROTATIONS)
     def test_for_all_possible_axes_rotation(self, stage_axes, directions):
         axes_rotation = AxesRotation()
@@ -770,7 +751,7 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
             axes_rotation.update(chip_axis, directions[idx], stage_axes[idx])
 
         self.assertTrue(axes_rotation.is_valid)
-
+        
         kabsch_rotation = KabschRotation(axes_rotation)
         for pairing in self.create_pairings(
             axes_rotation,
@@ -780,22 +761,22 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
             kabsch_rotation.update(pairing)
 
         # Test x unit
-        x_unit_vector = np.array([1, 0, 0])
+        x_unit_vector = np.array([1,0,0])
         ground_truth = axes_rotation.matrix @ x_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ x_unit_vector
-        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0,
-                           "X-Unit Vector orientation not perserved!")
+        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
+            "X-Unit Vector orientation not perserved!")
 
         # Test y unit
-        y_unit_vector = np.array([0, 1, 0])
+        y_unit_vector = np.array([0,1,0])
         ground_truth = axes_rotation.matrix @ y_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ y_unit_vector
-        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0,
-                           "Y-Unit Vector orientation not perserved!")
+        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
+            "Y-Unit Vector orientation not perserved!")
 
         # Test x unit
-        z_unit_vector = np.array([0, 0, 1])
+        z_unit_vector = np.array([0,0,1])
         ground_truth = axes_rotation.matrix @ z_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ z_unit_vector
-        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0,
-                           "Z-Unit Vector orientation not perserved!")
+        self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
+            "Z-Unit Vector orientation not perserved!")


### PR DESCRIPTION
Added methods for dumping and loading transformation.
Each transformation (Axes Rotation, Single Point Offset and Kabsch Rotation) have a method to dump (export the transformation into some storable format) and to load (create transformation out of the stored format)

Tests have been added to verify the behaviour.