### PR TITLE
[Movement]: Dump and load calibrations

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -82,7 +82,8 @@ class Calibration:
         self._axes_rotation: Type[AxesRotation] = AxesRotation()
         self._single_point_offset: Type[SinglePointOffset] = SinglePointOffset(
             self._axes_rotation)
-        self._kabsch_rotation: Type[KabschRotation] = KabschRotation(self._axes_rotation)
+        self._kabsch_rotation: Type[KabschRotation] = KabschRotation(
+            self._axes_rotation)
 
     #
     #   Representation
@@ -497,3 +498,22 @@ class Calibration:
 
         self.stage.set_speed_xy(current_speed_xy)
         self.stage.set_speed_z(current_speed_z)
+
+    def dump(self) -> dict:
+        """
+        Returns a dict of all calibration properties.
+        """
+        calibration_dump = {
+            "orientation": self.orientation.value,
+            "device_port": self._device_port.value}
+
+        if self._axes_rotation.is_valid:
+            calibration_dump["axes_rotation"] = self._axes_rotation.dump()
+
+        if self._single_point_offset.is_valid:
+            calibration_dump["single_point_offset"] = self._single_point_offset.dump()
+
+        if self._kabsch_rotation.is_valid:
+            calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
+
+        return calibration_dump

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -219,7 +219,7 @@ class Transformation(ABC):
     The base class cannot be initialised directly.
     """
 
-    @classmethod
+    @abstractclassmethod
     def load(cls, data: Any, *args, **kwargs) -> Type[Transformation]:
         """
         Creates a new Transformation from data

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -20,6 +20,7 @@ from LabExT.Movement.Stages.DummyStage import DummyStage
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Transformations import ChipCoordinate, CoordinatePairing, StageCoordinate
 from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
+from ...Wafer.Chip import Chip
 from LabExT.Wafer.Device import Device
 
 EXPECTED_TO_REJECT = [
@@ -694,3 +695,91 @@ class CalibrationTest(CalibrationTestCase):
                 'chip_coordinate': [1046.25, 1287.5, 0.0],
                 'device_id': 3
             }])
+
+
+    def test_load_with_axes_rotation(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
+
+    def test_load_with_single_point_offset(self):
+        self.stage.connect()
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            }
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
+
+    def test_load_with_kabsch_rotation(self):
+        self.stage.connect()
+        chip = Chip(
+            name="Dummy Chip",
+            devices=[
+                Device(0, [0,0], [1,1]),
+                Device(1, [2,2], [3,3]),
+                Device(2, [4,4], [5,5]),
+                Device(3, [6,6], [7,7])
+            ])
+
+        calibration_data = {
+            "orientation": "LEFT",
+            "device_port": "INPUT",
+            "axes_rotation": {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            },
+            "single_point_offset": {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': 1
+            },
+            "kabsch_rotation": [
+                {
+                    'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                    'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                    'device_id': 0
+                },
+                {
+                    'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                    'chip_coordinate': [-1050.0, -160.0, 0.0],
+                    'device_id': 1
+                },
+                {
+                    'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                    'chip_coordinate': [1046.25, -1337.5, 0.0],
+                    'device_id': 2
+                },
+                {
+                    'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                    'chip_coordinate': [1046.25, 1287.5, 0.0],
+                    'device_id': 3
+                }   
+            ]
+        }
+
+        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
+


### PR DESCRIPTION
This pull request adds two methods to the calibrations to export calibrations and load them again.

`dump` will export a calibration to a dict. `load` will take that dict together with a stage and mover to create a calibration object again.