### PR TITLE
[Movement]: Make SfP applicable for new mover

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -14,7 +14,7 @@ from time import sleep
 
 import numpy as np
 
-from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction
+from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction, CoordinateSystem
 from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
 from LabExT.Movement.Stage import StageError
 from LabExT.Movement.PathPlanning import StagePolygon, SingleModeFiber
@@ -46,17 +46,17 @@ def assert_minimum_state_for_coordinate_system(
     def assert_state(func):
         @wraps(func)
         def wrap(calibration: Type["Calibration"], *args, **kwargs):
-            if calibration.coordinate_system is None:
+            if calibration.coordinate_system == CoordinateSystem.UNKNOWN:
                 raise CalibrationError(
                     "Function {} needs a cooridnate system to operate in. Please use the context to set the system.".format(
                         func.__name__))
 
-            if calibration.coordinate_system == ChipCoordinate and calibration.state < chip_coordinate_system:
+            if calibration.coordinate_system == CoordinateSystem.CHIP and calibration.state < chip_coordinate_system:
                 raise CalibrationError(
                     "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
                         func.__name__, chip_coordinate_system))
 
-            if calibration.coordinate_system == StageCoordinate and calibration.state < stage_coordinate_system:
+            if calibration.coordinate_system == CoordinateSystem.STAGE and calibration.state < stage_coordinate_system:
                 raise CalibrationError(
                     "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(
                         func.__name__, stage_coordinate_system))
@@ -156,7 +156,7 @@ class Calibration:
         self._orientation = orientation
         self._device_port = device_port
 
-        self._coordinate_system = None
+        self._coordinate_system = CoordinateSystem.UNKNOWN
 
         self._axes_rotation = axes_rotation
         if axes_rotation is None:
@@ -226,70 +226,61 @@ class Calibration:
     #
 
     @property
-    def coordinate_system(
-            self) -> Union[None, StageCoordinate, ChipCoordinate]:
+    def coordinate_system(self) -> CoordinateSystem:
         """
         Returns the current coordinate system
         """
         return self._coordinate_system
 
-    @coordinate_system.setter
-    def coordinate_system(self, system) -> None:
+    @property
+    def is_chip_coordinate_system_set(self) -> bool:
+        """
+        Returns True if chip coordinate system is set.
+        """
+        return self.coordinate_system == CoordinateSystem.CHIP
+
+    @property
+    def is_stage_coordinate_system_set(self) -> bool:
+        """
+        Returns True if stage coordinate system is set.
+        """
+        return self.coordinate_system == CoordinateSystem.STAGE
+
+    def set_coordinate_system(
+        self,
+        system: CoordinateSystem
+    ) -> None:
         """
         Sets the current coordinate system
-
-        If None, the system will be reset.
-
-        Parameters
-        ----------
-        system : Coordinate
-            Coordinate system to be stored, either chip or stage system.
 
         Raises
         ------
         ValueError
             If the requested system is not supported.
-        CalibrationError
-            If a coordinate system is already set.
         """
-        if system is None:
-            self._coordinate_system = None
-            return
-
-        if system not in [ChipCoordinate, StageCoordinate]:
+        if not isinstance(system, CoordinateSystem):
             raise ValueError(
-                f"The requested coordinate system {system} is not supported.")
+                f"Requested coordinate system {system} for {self} is invalid.")
 
-        if self._coordinate_system is not None:
-            raise CalibrationError("A coordinate system is already set.")
+        self._logger.debug(
+            f"Set coordinate system for {self} to {system}")
 
         self._coordinate_system = system
 
     @contextmanager
-    def perform_in_chip_coordinates(self):
+    def perform_in_system(self, system: CoordinateSystem):
         """
-        Context manager to execute a block of instructions in chip coordinates.
+        Context manager to execute a block of instructions in requested coordinates.
 
-        Sets the coordinate system to chip system first and resets the system at the end.
+        Resets the system at the end.
         """
-        self.coordinate_system = ChipCoordinate
+        prior_coordinate_system = self.coordinate_system
+
+        self.set_coordinate_system(system)
         try:
             yield
         finally:
-            self.coordinate_system = None
-
-    @contextmanager
-    def perform_in_stage_coordinates(self):
-        """
-        Context manager to execute a block of instructions in stage coordinates.
-
-        Sets the coordinate system to stage system first and resets the system at the end.
-        """
-        self.coordinate_system = StageCoordinate
-        try:
-            yield
-        finally:
-            self.coordinate_system = None
+            self.set_coordinate_system(prior_coordinate_system)
 
     #
     #   Calibration Setup Methods
@@ -459,9 +450,9 @@ class Calibration:
         """
         stage_position = StageCoordinate.from_list(self.stage.get_position())
 
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             return stage_position
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             if self.state == State.FULLY_CALIBRATED:
                 return self._kabsch_rotation.stage_to_chip(stage_position)
             elif self.state == State.SINGLE_POINT_FIXED:
@@ -498,18 +489,12 @@ class Calibration:
         ------
         CalibrationError
             If the state of calibration is lower than the required one.
-        TypeError
-            If the passed offset does not have the correct type.
         RuntimeError
             If coordinate system is unsupported.
         """
-        if not isinstance(offset, self.coordinate_system):
-            raise TypeError(
-                f"Given offset is in {type(offset)}. Need offset in {self.coordinate_system} to move the stage relative in this system.")
-
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             stage_offset = offset
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             stage_offset = self._axes_rotation.chip_to_stage(offset)
         else:
             RuntimeError(
@@ -542,18 +527,12 @@ class Calibration:
         ------
         CalibrationError
             If the state of calibration is lower than the required one.
-        TypeError
-            If the passed offset does not have the correct type.
         RuntimeError
             If coordinate system is unsupported.
         """
-        if not isinstance(coordinate, self.coordinate_system):
-            raise TypeError(
-                f"Given coordinate is in {type(coordinate)}. Need coordinate in {self.coordinate_system} to move the stage absolute in this system.")
-
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             stage_coordinate = coordinate
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             if self.state == State.FULLY_CALIBRATED:
                 stage_coordinate = self._kabsch_rotation.chip_to_stage(
                     coordinate)
@@ -604,7 +583,8 @@ class Calibration:
 
         wiggle_difference = np.array(
             [wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
-        with self.perform_in_chip_coordinates():
+
+        with self.perform_in_system(CoordinateSystem.CHIP):
             self.move_relative(ChipCoordinate.from_numpy(wiggle_difference))
             sleep(wait_time)
             self.move_relative(ChipCoordinate.from_numpy(-wiggle_difference))

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -328,8 +328,6 @@ class Calibration:
         """
         try:
             self._axes_rotation.update(chip_axis, direction, stage_axis)
-            print(
-                f"Calibration {str(self)} Axes Rotation update: {vars(self._axes_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -347,8 +345,6 @@ class Calibration:
         """
         try:
             self._single_point_offset.update(pairing)
-            print(
-                f"Calibration {str(self)} SP update: {vars(self._single_point_offset)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -365,8 +361,6 @@ class Calibration:
         """
         try:
             self._kabsch_rotation.update(pairing)
-            print(
-                f"Calibration {str(self)} Kabsch update: {vars(self._kabsch_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -328,6 +328,8 @@ class Calibration:
         """
         try:
             self._axes_rotation.update(chip_axis, direction, stage_axis)
+            print(
+                f"Calibration {str(self)} Axes Rotation update: {vars(self._axes_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -345,6 +347,8 @@ class Calibration:
         """
         try:
             self._single_point_offset.update(pairing)
+            print(
+                f"Calibration {str(self)} SP update: {vars(self._single_point_offset)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -361,6 +365,8 @@ class Calibration:
         """
         try:
             self._kabsch_rotation.update(pairing)
+            print(
+                f"Calibration {str(self)} Kabsch update: {vars(self._kabsch_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -512,7 +518,7 @@ class Calibration:
     def move_absolute(self,
                       coordinate: Union[Type[StageCoordinate],
                                         Type[ChipCoordinate]],
-                      wait_for_stopping: bool = True) -> None:
+                      wait_for_stopping: bool = False) -> None:
         """
         Moves the stage absolute to the given coordinate.
         The coordinate can be passed in stage or chip coordinates,

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -512,7 +512,7 @@ class Calibration:
     def move_absolute(self,
                       coordinate: Union[Type[StageCoordinate],
                                         Type[ChipCoordinate]],
-                      wait_for_stopping: bool = False) -> None:
+                      wait_for_stopping: bool = True) -> None:
         """
         Moves the stage absolute to the given coordinate.
         The coordinate can be passed in stage or chip coordinates,

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -7,15 +7,15 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 
-from contextlib import contextmanager
 from time import sleep, time
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
 from typing import Dict, Tuple, Type, List
 from functools import wraps
 from os.path import exists
 from datetime import datetime
+from contextlib import contextmanager
 
-from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, DevicePort
+from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, DevicePort, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import ChipCoordinate
@@ -143,9 +143,10 @@ class MoverNew:
         if not _main_window:
             return
 
-        _main_window.model.status_mover_connected_stages.set(self.has_connected_stages)
-        _main_window.model.status_mover_can_move_to_device.set(self.can_move_absolutely)
-
+        _main_window.model.status_mover_connected_stages.set(
+            self.has_connected_stages)
+        _main_window.model.status_mover_can_move_to_device.set(
+            self.can_move_absolutely)
 
     #
     #   Reload properties
@@ -340,6 +341,27 @@ class MoverNew:
         return calibration
 
     #
+    #   Coordinate System Control
+    #
+
+    @contextmanager
+    def set_stages_coordinate_system(self, system: CoordinateSystem):
+        """
+        Sets the coordinate system of all connected stages to the requested one.
+        """
+        prior_coordinate_systems = {
+            c: c.coordinate_system for c in self.calibrations.values()}
+
+        for calibration in self.calibrations.values():
+            calibration.set_coordinate_system(system)
+
+        try:
+            yield
+        finally:
+            for calibration, prior_coordinate_system in prior_coordinate_systems.items():
+                calibration.set_coordinate_system(prior_coordinate_system)
+
+    #
     #   Stage Settings Methods
     #
 
@@ -522,7 +544,7 @@ class MoverNew:
         # Move stages on safe trajectory
         for calibration_waypoints in path_planning.trajectory():
             for calibration, waypoint in calibration_waypoints.items():
-                with calibration.perform_in_chip_coordinates():
+                with calibration.perform_in_system(CoordinateSystem.CHIP):
                     calibration.move_absolute(waypoint, wait_for_stopping)
 
             # Wait for all stages to stop if stages move simultaneously.
@@ -590,7 +612,7 @@ class MoverNew:
             calibration = resolved_calibrations[orientation]
             requested_target = movement_commands[orientation]
 
-            with calibration.perform_in_chip_coordinates():
+            with calibration.perform_in_system(CoordinateSystem.CHIP):
                 calibration.move_relative(requested_target, wait_for_stopping)
 
     @contextmanager
@@ -604,7 +626,7 @@ class MoverNew:
 
         def _lift_lower_stages(lift):
             for calibration in self.calibrations.values():
-                with calibration.perform_in_chip_coordinates():
+                with calibration.perform_in_system(CoordinateSystem.CHIP):
                     calibration.move_absolute(
                         calibration.get_position() + ChipCoordinate(z=lift))
 

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -240,27 +240,27 @@ class MoverNew:
             c.state >= State.COORDINATE_SYSTEM_FIXED for c in self.calibrations.values())
 
     @property
-    def left_calibration(self): return self._get_calibration(
+    def left_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.LEFT)
 
     @property
-    def right_calibration(self): return self._get_calibration(
+    def right_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.RIGHT)
 
     @property
-    def top_calibration(self): return self._get_calibration(
+    def top_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.TOP)
 
     @property
-    def bottom_calibration(self): return self._get_calibration(
+    def bottom_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.BOTTOM)
 
     @property
-    def input_calibration(self): return self._get_calibration(
+    def input_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.INPUT)
 
     @property
-    def output_calibration(self): return self._get_calibration(
+    def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.OUTPUT)
 
     #
@@ -726,7 +726,7 @@ class MoverNew:
     #   Helpers
     #
 
-    def _get_calibration(self, port=None, orientation=None, default=None):
+    def _get_calibration(self, port=None, orientation=None, default=None) -> Type[Calibration]:
         """
         Get safely calibration by port and orientation.
         """

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy.spatial.distance import pdist
 
 from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.config import Orientation
+from LabExT.Movement.config import CoordinateSystem, Orientation
 
 if TYPE_CHECKING:
     from LabExT.Movement.Calibration import Calibration
@@ -235,7 +235,7 @@ class PotentialField:
         self.potential_field = np.zeros_like(
             self.cx) + self.attractive_potential_field
 
-        with self.calibration.perform_in_chip_coordinates():
+        with self.calibration.perform_in_system(CoordinateSystem.CHIP):
             self.start_coordinate = self.calibration.get_position()
             self.target_position.z = self.start_coordinate.z
 
@@ -293,7 +293,7 @@ class PotentialField:
             self.cx) + self.attractive_potential_field
 
         for calibration in calibrations:
-            with calibration.perform_in_chip_coordinates():
+            with calibration.perform_in_system(CoordinateSystem.CHIP):
                 stage_mask = calibration.stage_polygon.stage_in_meshgrid(
                     calibration.get_position(),
                     self.cx,

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -703,54 +703,13 @@ class Stage3DSmarAct(Stage):
 
     @assert_driver_loaded
     @assert_stage_connected
-    def move_absolute(self, *args, **kwargs) -> None:
-        """
-        Perfoms an absolute movement to the specified position in units of micrometers.
-
-        Attention: This method supports two method signatures to temporarily support the old version (v1)
-        and the new version (v2).
-        """
-        if isinstance(args[0], list):
-            self._move_absolute_v1(*args, **kwargs)
-        else:
-            self._move_absolute_v2(*args, **kwargs)
-
-    # Stage control
-
-    @assert_driver_loaded
-    @assert_stage_connected
-    def stop(self):
-        for channel in self.channels.values():
-            channel.stop()
-
-    # Move absolute methods
-    # Temporarily, two different methods for absolute movement are supported.
-
-    def _move_absolute_v1(self, pos, wait_for_stopping: bool = True):
-        warnings.warn(
-            "This method is deprecated and will be removed in the future. Please use the new signature.",
-            category=DeprecationWarning)
-
-        self._logger.debug(
-            'Want to absolute move %s to x = %s um and y = %s um',
-            self.address,
-            pos[0],
-            pos[1])
-
-        self.channels[Axis.X].move(
-            diff=pos[0], mode=MovementType.ABSOLUTE)
-        self.channels[Axis.Y].move(
-            diff=pos[1], mode=MovementType.ABSOLUTE)
-
-        if wait_for_stopping:
-            self._wait_for_stopping()
-
-    def _move_absolute_v2(
-            self,
-            x: float = None,
-            y: float = None,
-            z: float = None,
-            wait_for_stopping: bool = True) -> None:
+    def move_absolute(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        wait_for_stopping: bool = True
+    ) -> None:
         self._logger.debug(
             'Want to absolute move %s to x = %s um, y = %s um and z = %s um',
             self.address,
@@ -767,6 +726,14 @@ class Stage3DSmarAct(Stage):
 
         if wait_for_stopping:
             self._wait_for_stopping()
+
+    # Stage control
+
+    @assert_driver_loaded
+    @assert_stage_connected
+    def stop(self):
+        for channel in self.channels.values():
+            channel.stop()
 
     # Helper methods
 

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -727,14 +727,6 @@ class Stage3DSmarAct(Stage):
         if wait_for_stopping:
             self._wait_for_stopping()
 
-    # Stage control
-
-    @assert_driver_loaded
-    @assert_stage_connected
-    def stop(self):
-        for channel in self.channels.values():
-            channel.stop()
-
     # Helper methods
 
     @classmethod

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -54,6 +54,14 @@ class DevicePort(BaseEnum):
     OUTPUT = auto()
 
 
+class CoordinateSystem(BaseEnum):
+    """
+    Enumerate different coordinate systems
+    """
+    UNKNOWN = auto()
+    STAGE = auto()
+    CHIP = auto()
+
 @total_ordering
 class State(BaseEnum):
     """

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -97,9 +97,6 @@ class PeakSearcher(Measurement):
         self._left_calibration = self.mover.left_calibration
         self._right_calibration = self.mover.right_calibration
 
-        if self._left_calibration is None and self._right_calibration is None:
-            raise ValueError("The Search for Peak requires at least one left or right stage configured.")
-
         if self._left_calibration and self._right_calibration:
             self._dimension_names = self.DIMENSION_NAMES_TWO_STAGES
         else:
@@ -235,6 +232,9 @@ class PeakSearcher(Measurement):
         # double check if mover is actually enabled
         if not self.mover.has_connected_stages:
             raise RuntimeError('Mover has no connected stages! Cannot do automatic search for peak.')
+
+        if self._left_calibration is None and self._right_calibration is None:
+            raise RuntimeError("The Search for Peak requires at least one left or right stage configured.")
 
         # load laser and powermeter
         self.instr_powermeter = self.get_instrument('Power Meter')

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -80,11 +80,12 @@ class PeakSearcher(Measurement):
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
     def __init__(
-            self,
-            *args,
-            mover: Type[MoverNew] = None,
-            parent=None,
-            **kwargs):
+        self,
+        *args,
+        mover: Type[MoverNew] = None,
+        parent=None,
+        **kwargs
+    ) -> None:
         """Constructor
 
         Parameters
@@ -175,22 +176,13 @@ class PeakSearcher(Measurement):
         pinit = PeakSearcher._gaussian_param_initial_guess(x_data, y_data)
 
         # define bounds for the fitting parameters
-        # allow only positive gaussians, i.e. hills, not valleys
-        a_bounds = (0, np.inf)
+        a_bounds = (0, np.inf)  # allow only positive gaussians, i.e. hills, not valleys
         mu_bounds = (-np.inf, np.inf)
         sigma_bounds = (0, np.inf)
         offset_bounds = (-np.inf, np.inf)
 
-        lower_bounds = (
-            a_bounds[0],
-            mu_bounds[0],
-            sigma_bounds[0],
-            offset_bounds[0])
-        upper_bounds = (
-            a_bounds[1],
-            mu_bounds[1],
-            sigma_bounds[1],
-            offset_bounds[1])
+        lower_bounds = (a_bounds[0], mu_bounds[0], sigma_bounds[0], offset_bounds[0])
+        upper_bounds = (a_bounds[1], mu_bounds[1], sigma_bounds[1], offset_bounds[1])
 
         # fit a gaussian to the data
         popt, cov = curve_fit(PeakSearcher._gaussian,
@@ -281,8 +273,7 @@ class PeakSearcher(Measurement):
             'fitting information': {}
         }
         for param_name, cfg_param in self.parameters.items():
-            results['parameter'][param_name] = str(
-                cfg_param.value) + str(cfg_param.unit)
+            results['parameter'][param_name] = str(cfg_param.value) + str(cfg_param.unit)
 
         # send user specified parameters to instruments
         self.instr_laser.wavelength = self.parameters['Laser wavelength'].value
@@ -317,8 +308,7 @@ class PeakSearcher(Measurement):
 
             # parameters specifically for swept SfP
             t_sweep = self.parameters.get('(swept SfP only) Search time').value
-            no_points = int(self.parameters.get(
-                '(swept SfP only) Number of points').value)
+            no_points = int(self.parameters.get('(swept SfP only) Number of points').value)
 
             # define parameters
             # the sweep velocity is the distance passed (twice the search
@@ -357,18 +347,11 @@ class PeakSearcher(Measurement):
 
                 # create new plotting dataset for measurement
                 meas_plot = PlotData(ObservableList(), ObservableList(),
-                                     'scatter', color=color_strings[dimidx])
-                fit_plot = PlotData(
-                    ObservableList(),
-                    ObservableList(),
-                    color=color_strings[dimidx],
-                    label=dimension_name)
-                opt_pos_plot = PlotData(
-                    ObservableList(),
-                    ObservableList(),
-                    marker='x',
-                    markersize=10,
-                    color=color_strings[dimidx])
+                                      'scatter', color=color_strings[dimidx])
+                fit_plot = PlotData(ObservableList(), ObservableList(),
+                                    color=color_strings[dimidx], label=dimension_name)
+                opt_pos_plot = PlotData(ObservableList(), ObservableList(),
+                                        marker='x', markersize=10, color=color_strings[dimidx])
                 if dimidx < len(start_coordinates) / 2:
                     self.plots_left.append(meas_plot)
                     self.plots_left.append(fit_plot)
@@ -380,14 +363,13 @@ class PeakSearcher(Measurement):
 
                 # differentiate between the two types of SfP
                 if sfp_type == 'swept SfP (FA & N7744a PM models only)':
-                    allowed_pm_classes = [
-                        'PowerMeterN7744A', 'PowerMeterSimulator']
+                    allowed_pm_classes = ['PowerMeterN7744A', 'PowerMeterSimulator']
                     # complain if user selects a Power Meter that is not
                     # compatible with new Search for Peak
                     if self.instr_powermeter.__class__.__name__ not in allowed_pm_classes:
                         raise RuntimeError(
                             'swept SfP is only compatible with Keysight N7744A PM models, not {}'.format(
-                                self.instr_powermeter.__class__.__name__))
+                            self.instr_powermeter.__class__.__name__))
                     # move stage to initial position and setup
                     current_coordinates[dimidx] = p_start - radius_us
                     self._move_stages_absolute(current_coordinates)

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -79,7 +79,7 @@ class PeakSearcher(Measurement):
     DIMENSION_NAMES_TWO_STAGES = ['Left X', 'Left Y', 'Right X', 'Right Y']
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
-    def __init__(self, *args, mover=None, parent=None, **kwargs):
+    def __init__(self, *args, mover: Type[MoverNew] = None, parent = None, **kwargs):
         """Constructor
 
         Parameters
@@ -92,7 +92,7 @@ class PeakSearcher(Measurement):
         self._parent = parent
         self.name = "SearchForPeak-2DGaussianFit"
         self.settings_filename = "PeakSearcher_settings.json"
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
 
         self._left_calibration = self.mover.left_calibration
         self._right_calibration = self.mover.right_calibration
@@ -322,6 +322,8 @@ class PeakSearcher(Measurement):
                 _right_start_coordinates = self._right_calibration.get_position().to_list()
             start_coordinates = _left_start_coordinates + _right_start_coordinates
             current_coordinates = start_coordinates.copy()
+
+            self.logger.debug(f"Start Position: {start_coordinates}")
 
             estimated_through_power = -99.0
 

--- a/LabExT/View/Controls/CoordinateWidget.py
+++ b/LabExT/View/Controls/CoordinateWidget.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from typing import Type
 from tkinter import LEFT, SUNKEN, Frame, Label
 
-from LabExT.Movement.config import Axis
+from LabExT.Movement.config import Axis, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Transformations import Coordinate
 
@@ -63,7 +63,7 @@ class StagePositionWidget(CoordinateWidget):
     def __init__(self, parent, calibration: Type[Calibration]):
         self.calibration = calibration
 
-        with self.calibration.perform_in_stage_coordinates():
+        with self.calibration.perform_in_system(CoordinateSystem.STAGE):
             super().__init__(parent, self.calibration.get_position())
 
         self._update_pos_job = self.after(
@@ -84,7 +84,7 @@ class StagePositionWidget(CoordinateWidget):
         Kills update job, if an error occurred.
         """
         try:
-            with self.calibration.perform_in_stage_coordinates():
+            with self.calibration.perform_in_system(CoordinateSystem.STAGE):
                 self.coordinate = self.calibration.get_position()
         except Exception as exc:
             self.after_cancel(self._update_pos_job)

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -15,6 +15,7 @@ from LabExT.View.Controls.CoordinateWidget import CoordinateWidget, StagePositio
 from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Calibration import Calibration
+from LabExT.Movement.config import CoordinateSystem
 from LabExT.Wafer.Chip import Chip
 
 
@@ -273,7 +274,7 @@ class CoordinatePairingsWindow(Toplevel):
         elif calibration.is_output_stage:
             chip_coord = self._device.output_coordinate
 
-        with calibration.perform_in_stage_coordinates():
+        with calibration.perform_in_system(CoordinateSystem.STAGE):
             return CoordinatePairing(
                 calibration,
                 calibration.get_position(),


### PR DESCRIPTION
Makes `SearchForPeak` workable with new Mover without changing much in the general structure of the algorithm. When we redesign SfP, we can make this prettier. All fixes discovered during testing in the lab are included.
