### PR TITLE
[Movement] Update stage lifting/lowering

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -337,8 +337,6 @@ class Calibration:
         """
         try:
             self._axes_rotation.update(chip_axis, direction, stage_axis)
-            print(
-                f"Calibration {str(self)} Axes Rotation update: {vars(self._axes_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -356,8 +354,6 @@ class Calibration:
         """
         try:
             self._single_point_offset.update(pairing)
-            print(
-                f"Calibration {str(self)} SP update: {vars(self._single_point_offset)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -374,8 +370,6 @@ class Calibration:
         """
         try:
             self._kabsch_rotation.update(pairing)
-            print(
-                f"Calibration {str(self)} Kabsch update: {vars(self._kabsch_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -337,6 +337,8 @@ class Calibration:
         """
         try:
             self._axes_rotation.update(chip_axis, direction, stage_axis)
+            print(
+                f"Calibration {str(self)} Axes Rotation update: {vars(self._axes_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -354,6 +356,8 @@ class Calibration:
         """
         try:
             self._single_point_offset.update(pairing)
+            print(
+                f"Calibration {str(self)} SP update: {vars(self._single_point_offset)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -370,6 +374,8 @@ class Calibration:
         """
         try:
             self._kabsch_rotation.update(pairing)
+            print(
+                f"Calibration {str(self)} Kabsch update: {vars(self._kabsch_rotation)}")
         finally:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
@@ -527,7 +533,7 @@ class Calibration:
     def move_absolute(self,
                       coordinate: Union[Type[StageCoordinate],
                                         Type[ChipCoordinate]],
-                      wait_for_stopping: bool = True) -> None:
+                      wait_for_stopping: bool = False) -> None:
         """
         Moves the stage absolute to the given coordinate.
         The coordinate can be passed in stage or chip coordinates,

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -252,6 +252,9 @@ class Calibration:
         CalibrationError
             If a coordinate system is already set.
         """
+        if system == self._coordinate_system:
+            return
+
         if system is None:
             self._coordinate_system = None
             return

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -641,8 +641,11 @@ class MoverNew:
                                 atol=1e-08).all():
                             self.logger.error(
                                 f"{calibration} didn't not move properly to {target_z} while lifting/lowering stage.")
-
-                        self._lifted_stages.add(calibration)
+                        
+                        if _is_lifted:
+                            self._lifted_stages.remove(calibration)
+                        else:
+                            self._lifted_stages.add(calibration)
 
         _toggle_stage_lift()
         try:

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -641,6 +641,7 @@ class MoverNew:
                                 atol=1e-08).all():
                             self.logger.error(
                                 f"{calibration} didn't not move properly to {target_z} while lifting/lowering stage.")
+                            return
                         
                         if _is_lifted:
                             self._lifted_stages.remove(calibration)

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -239,27 +239,27 @@ class MoverNew:
             c.state >= State.COORDINATE_SYSTEM_FIXED for c in self.calibrations.values())
 
     @property
-    def left_calibration(self): return self._get_calibration(
+    def left_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.LEFT)
 
     @property
-    def right_calibration(self): return self._get_calibration(
+    def right_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.RIGHT)
 
     @property
-    def top_calibration(self): return self._get_calibration(
+    def top_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.TOP)
 
     @property
-    def bottom_calibration(self): return self._get_calibration(
+    def bottom_calibration(self) -> Type[Calibration]: return self._get_calibration(
         orientation=Orientation.BOTTOM)
 
     @property
-    def input_calibration(self): return self._get_calibration(
+    def input_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.INPUT)
 
     @property
-    def output_calibration(self): return self._get_calibration(
+    def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.OUTPUT)
 
     #
@@ -704,7 +704,7 @@ class MoverNew:
     #   Helpers
     #
 
-    def _get_calibration(self, port=None, orientation=None, default=None):
+    def _get_calibration(self, port=None, orientation=None, default=None) -> Type[Calibration]:
         """
         Get safely calibration by port and orientation.
         """

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -371,9 +371,6 @@ class PathPlanning:
         ----------
         chip: Chip
             Instance of the a chip
-        z_level: float = None
-            Height of the z level on which the algorithm is to operate
-            If None, the current stage z coordinate is taken.
         """
         self.chip: Type[Chip] = chip
         self.grid_size, self.grid_outline = self._get_grid_properties(
@@ -382,13 +379,12 @@ class PathPlanning:
         self.potential_fields = {}
         self.last_moves = []
 
-        self._z_level = z_level
-
     def set_stage_target(
         self,
         calibration: Type["Calibration"],
-        target: Type[ChipCoordinate
-                     ]) -> None:
+        target: Type[ChipCoordinate],
+        z_level: float = None
+    ) -> None:
         """
         Registers a target for the given calibration.
 
@@ -398,13 +394,16 @@ class PathPlanning:
             Instance of a calibrated stage, such that the stage can move in chip coordinates.
         target : ChipCoordinate
             Target of the stage in chip coordinates.
+        z_level: float = None
+            Height of the z level on which the algorithm is to operate
+            If None, the current stage z coordinate is taken.
         """
         self.potential_fields[calibration] = PotentialField(
             calibration,
             target,
             self.grid_size,
             self.grid_outline,
-            z_level=self._z_level)
+            z_level=z_level)
 
     def trajectory(self, abort_local_minimum=3):
         """

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -703,54 +703,13 @@ class Stage3DSmarAct(Stage):
 
     @assert_driver_loaded
     @assert_stage_connected
-    def move_absolute(self, *args, **kwargs) -> None:
-        """
-        Perfoms an absolute movement to the specified position in units of micrometers.
-
-        Attention: This method supports two method signatures to temporarily support the old version (v1)
-        and the new version (v2).
-        """
-        if isinstance(args[0], list):
-            self._move_absolute_v1(*args, **kwargs)
-        else:
-            self._move_absolute_v2(*args, **kwargs)
-
-    # Stage control
-
-    @assert_driver_loaded
-    @assert_stage_connected
-    def stop(self):
-        for channel in self.channels.values():
-            channel.stop()
-
-    # Move absolute methods
-    # Temporarily, two different methods for absolute movement are supported.
-
-    def _move_absolute_v1(self, pos, wait_for_stopping: bool = True):
-        warnings.warn(
-            "This method is deprecated and will be removed in the future. Please use the new signature.",
-            category=DeprecationWarning)
-
-        self._logger.debug(
-            'Want to absolute move %s to x = %s um and y = %s um',
-            self.address,
-            pos[0],
-            pos[1])
-
-        self.channels[Axis.X].move(
-            diff=pos[0], mode=MovementType.ABSOLUTE)
-        self.channels[Axis.Y].move(
-            diff=pos[1], mode=MovementType.ABSOLUTE)
-
-        if wait_for_stopping:
-            self._wait_for_stopping()
-
-    def _move_absolute_v2(
-            self,
-            x: float = None,
-            y: float = None,
-            z: float = None,
-            wait_for_stopping: bool = True) -> None:
+    def move_absolute(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        wait_for_stopping: bool = True
+    ) -> None:
         self._logger.debug(
             'Want to absolute move %s to x = %s um, y = %s um and z = %s um',
             self.address,
@@ -767,6 +726,14 @@ class Stage3DSmarAct(Stage):
 
         if wait_for_stopping:
             self._wait_for_stopping()
+
+    # Stage control
+
+    @assert_driver_loaded
+    @assert_stage_connected
+    def stop(self):
+        for channel in self.channels.values():
+            channel.stop()
 
     # Helper methods
 

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -727,14 +727,6 @@ class Stage3DSmarAct(Stage):
         if wait_for_stopping:
             self._wait_for_stopping()
 
-    # Stage control
-
-    @assert_driver_loaded
-    @assert_stage_connected
-    def stop(self):
-        for channel in self.channels.values():
-            channel.stop()
-
     # Helper methods
 
     @classmethod

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -97,9 +97,6 @@ class PeakSearcher(Measurement):
         self._left_calibration = self.mover.left_calibration
         self._right_calibration = self.mover.right_calibration
 
-        if self._left_calibration is None and self._right_calibration is None:
-            raise ValueError("The Search for Peak requires at least one left or right stage configured.")
-
         if self._left_calibration and self._right_calibration:
             self._dimension_names = self.DIMENSION_NAMES_TWO_STAGES
         else:
@@ -235,6 +232,9 @@ class PeakSearcher(Measurement):
         # double check if mover is actually enabled
         if not self.mover.has_connected_stages:
             raise RuntimeError('Mover has no connected stages! Cannot do automatic search for peak.')
+
+        if self._left_calibration is None and self._right_calibration is None:
+            raise RuntimeError("The Search for Peak requires at least one left or right stage configured.")
 
         # load laser and powermeter
         self.instr_powermeter = self.get_instrument('Power Meter')

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -80,11 +80,12 @@ class PeakSearcher(Measurement):
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
     def __init__(
-            self,
-            *args,
-            mover: Type[MoverNew] = None,
-            parent=None,
-            **kwargs):
+        self,
+        *args,
+        mover: Type[MoverNew] = None,
+        parent=None,
+        **kwargs
+    ) -> None:
         """Constructor
 
         Parameters
@@ -175,22 +176,13 @@ class PeakSearcher(Measurement):
         pinit = PeakSearcher._gaussian_param_initial_guess(x_data, y_data)
 
         # define bounds for the fitting parameters
-        # allow only positive gaussians, i.e. hills, not valleys
-        a_bounds = (0, np.inf)
+        a_bounds = (0, np.inf)  # allow only positive gaussians, i.e. hills, not valleys
         mu_bounds = (-np.inf, np.inf)
         sigma_bounds = (0, np.inf)
         offset_bounds = (-np.inf, np.inf)
 
-        lower_bounds = (
-            a_bounds[0],
-            mu_bounds[0],
-            sigma_bounds[0],
-            offset_bounds[0])
-        upper_bounds = (
-            a_bounds[1],
-            mu_bounds[1],
-            sigma_bounds[1],
-            offset_bounds[1])
+        lower_bounds = (a_bounds[0], mu_bounds[0], sigma_bounds[0], offset_bounds[0])
+        upper_bounds = (a_bounds[1], mu_bounds[1], sigma_bounds[1], offset_bounds[1])
 
         # fit a gaussian to the data
         popt, cov = curve_fit(PeakSearcher._gaussian,
@@ -281,8 +273,7 @@ class PeakSearcher(Measurement):
             'fitting information': {}
         }
         for param_name, cfg_param in self.parameters.items():
-            results['parameter'][param_name] = str(
-                cfg_param.value) + str(cfg_param.unit)
+            results['parameter'][param_name] = str(cfg_param.value) + str(cfg_param.unit)
 
         # send user specified parameters to instruments
         self.instr_laser.wavelength = self.parameters['Laser wavelength'].value
@@ -317,8 +308,7 @@ class PeakSearcher(Measurement):
 
             # parameters specifically for swept SfP
             t_sweep = self.parameters.get('(swept SfP only) Search time').value
-            no_points = int(self.parameters.get(
-                '(swept SfP only) Number of points').value)
+            no_points = int(self.parameters.get('(swept SfP only) Number of points').value)
 
             # define parameters
             # the sweep velocity is the distance passed (twice the search
@@ -357,18 +347,11 @@ class PeakSearcher(Measurement):
 
                 # create new plotting dataset for measurement
                 meas_plot = PlotData(ObservableList(), ObservableList(),
-                                     'scatter', color=color_strings[dimidx])
-                fit_plot = PlotData(
-                    ObservableList(),
-                    ObservableList(),
-                    color=color_strings[dimidx],
-                    label=dimension_name)
-                opt_pos_plot = PlotData(
-                    ObservableList(),
-                    ObservableList(),
-                    marker='x',
-                    markersize=10,
-                    color=color_strings[dimidx])
+                                      'scatter', color=color_strings[dimidx])
+                fit_plot = PlotData(ObservableList(), ObservableList(),
+                                    color=color_strings[dimidx], label=dimension_name)
+                opt_pos_plot = PlotData(ObservableList(), ObservableList(),
+                                        marker='x', markersize=10, color=color_strings[dimidx])
                 if dimidx < len(start_coordinates) / 2:
                     self.plots_left.append(meas_plot)
                     self.plots_left.append(fit_plot)
@@ -380,14 +363,13 @@ class PeakSearcher(Measurement):
 
                 # differentiate between the two types of SfP
                 if sfp_type == 'swept SfP (FA & N7744a PM models only)':
-                    allowed_pm_classes = [
-                        'PowerMeterN7744A', 'PowerMeterSimulator']
+                    allowed_pm_classes = ['PowerMeterN7744A', 'PowerMeterSimulator']
                     # complain if user selects a Power Meter that is not
                     # compatible with new Search for Peak
                     if self.instr_powermeter.__class__.__name__ not in allowed_pm_classes:
                         raise RuntimeError(
                             'swept SfP is only compatible with Keysight N7744A PM models, not {}'.format(
-                                self.instr_powermeter.__class__.__name__))
+                            self.instr_powermeter.__class__.__name__))
                     # move stage to initial position and setup
                     current_coordinates[dimidx] = p_start - radius_us
                     self._move_stages_absolute(current_coordinates)

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -79,7 +79,7 @@ class PeakSearcher(Measurement):
     DIMENSION_NAMES_TWO_STAGES = ['Left X', 'Left Y', 'Right X', 'Right Y']
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
-    def __init__(self, *args, mover=None, parent=None, **kwargs):
+    def __init__(self, *args, mover: Type[MoverNew] = None, parent = None, **kwargs):
         """Constructor
 
         Parameters
@@ -92,7 +92,7 @@ class PeakSearcher(Measurement):
         self._parent = parent
         self.name = "SearchForPeak-2DGaussianFit"
         self.settings_filename = "PeakSearcher_settings.json"
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
 
         self._left_calibration = self.mover.left_calibration
         self._right_calibration = self.mover.right_calibration
@@ -322,6 +322,8 @@ class PeakSearcher(Measurement):
                 _right_start_coordinates = self._right_calibration.get_position().to_list()
             start_coordinates = _left_start_coordinates + _right_start_coordinates
             current_coordinates = start_coordinates.copy()
+
+            self.logger.debug(f"Start Position: {start_coordinates}")
 
             estimated_through_power = -99.0
 


### PR DESCRIPTION
Updates the z lift and lifting behaviour of stages during automatic movement of stages to device.

The following is need:
- Updated Path Finding Algo: Now you can set a z level in chip coordinates for each stage. If given the the stage, will also keep the z coordinate at this level. Note that we keep the chip coordinate z level equal, not the stage coordinate z level. This coordinate will be transformed in stage space. This can incorporate a slight tilt of the chip. If no level is z, the algo always tries to keep the z coordinate the same as before.
- Enhanced the lifting logic: Now we keep track of lifted stages individually. The idea is that we only lift or lower stages, if the stage was lowered or lifted before.