### PR TITLE
[Movement] Simplify and stabilise coordinate control

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -14,7 +14,7 @@ from time import sleep
 
 import numpy as np
 
-from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction
+from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction, CoordinateSystem
 from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
 from LabExT.Movement.Stage import StageError
 from LabExT.Movement.PathPlanning import StagePolygon, SingleModeFiber
@@ -46,17 +46,17 @@ def assert_minimum_state_for_coordinate_system(
     def assert_state(func):
         @wraps(func)
         def wrap(calibration: Type["Calibration"], *args, **kwargs):
-            if calibration.coordinate_system is None:
+            if calibration.coordinate_system == CoordinateSystem.UNKNOWN:
                 raise CalibrationError(
                     "Function {} needs a cooridnate system to operate in. Please use the context to set the system.".format(
                         func.__name__))
 
-            if calibration.coordinate_system == ChipCoordinate and calibration.state < chip_coordinate_system:
+            if calibration.coordinate_system == CoordinateSystem.CHIP and calibration.state < chip_coordinate_system:
                 raise CalibrationError(
                     "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
                         func.__name__, chip_coordinate_system))
 
-            if calibration.coordinate_system == StageCoordinate and calibration.state < stage_coordinate_system:
+            if calibration.coordinate_system == CoordinateSystem.STAGE and calibration.state < stage_coordinate_system:
                 raise CalibrationError(
                     "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(
                         func.__name__, stage_coordinate_system))
@@ -156,7 +156,7 @@ class Calibration:
         self._orientation = orientation
         self._device_port = device_port
 
-        self._coordinate_system = None
+        self._coordinate_system = CoordinateSystem.UNKNOWN
 
         self._axes_rotation = axes_rotation
         if axes_rotation is None:
@@ -226,70 +226,61 @@ class Calibration:
     #
 
     @property
-    def coordinate_system(
-            self) -> Union[None, StageCoordinate, ChipCoordinate]:
+    def coordinate_system(self) -> CoordinateSystem:
         """
         Returns the current coordinate system
         """
         return self._coordinate_system
 
-    @coordinate_system.setter
-    def coordinate_system(self, system) -> None:
+    @property
+    def is_chip_coordinate_system_set(self) -> bool:
+        """
+        Returns True if chip coordinate system is set.
+        """
+        return self.coordinate_system == CoordinateSystem.CHIP
+
+    @property
+    def is_stage_coordinate_system_set(self) -> bool:
+        """
+        Returns True if stage coordinate system is set.
+        """
+        return self.coordinate_system == CoordinateSystem.STAGE
+
+    def set_coordinate_system(
+        self,
+        system: CoordinateSystem
+    ) -> None:
         """
         Sets the current coordinate system
-
-        If None, the system will be reset.
-
-        Parameters
-        ----------
-        system : Coordinate
-            Coordinate system to be stored, either chip or stage system.
 
         Raises
         ------
         ValueError
             If the requested system is not supported.
-        CalibrationError
-            If a coordinate system is already set.
         """
-        if system is None:
-            self._coordinate_system = None
-            return
-
-        if system not in [ChipCoordinate, StageCoordinate]:
+        if not isinstance(system, CoordinateSystem):
             raise ValueError(
-                f"The requested coordinate system {system} is not supported.")
+                f"Requested coordinate system {system} for {self} is invalid.")
 
-        if self._coordinate_system is not None:
-            raise CalibrationError("A coordinate system is already set.")
+        self._logger.debug(
+            f"Set coordinate system for {self} to {system}")
 
         self._coordinate_system = system
 
     @contextmanager
-    def perform_in_chip_coordinates(self):
+    def perform_in_system(self, system: CoordinateSystem):
         """
-        Context manager to execute a block of instructions in chip coordinates.
+        Context manager to execute a block of instructions in requested coordinates.
 
-        Sets the coordinate system to chip system first and resets the system at the end.
+        Resets the system at the end.
         """
-        self.coordinate_system = ChipCoordinate
+        prior_coordinate_system = self.coordinate_system
+
+        self.set_coordinate_system(system)
         try:
             yield
         finally:
-            self.coordinate_system = None
-
-    @contextmanager
-    def perform_in_stage_coordinates(self):
-        """
-        Context manager to execute a block of instructions in stage coordinates.
-
-        Sets the coordinate system to stage system first and resets the system at the end.
-        """
-        self.coordinate_system = StageCoordinate
-        try:
-            yield
-        finally:
-            self.coordinate_system = None
+            self.set_coordinate_system(prior_coordinate_system)
 
     #
     #   Calibration Setup Methods
@@ -459,9 +450,9 @@ class Calibration:
         """
         stage_position = StageCoordinate.from_list(self.stage.get_position())
 
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             return stage_position
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             if self.state == State.FULLY_CALIBRATED:
                 return self._kabsch_rotation.stage_to_chip(stage_position)
             elif self.state == State.SINGLE_POINT_FIXED:
@@ -498,18 +489,12 @@ class Calibration:
         ------
         CalibrationError
             If the state of calibration is lower than the required one.
-        TypeError
-            If the passed offset does not have the correct type.
         RuntimeError
             If coordinate system is unsupported.
         """
-        if not isinstance(offset, self.coordinate_system):
-            raise TypeError(
-                f"Given offset is in {type(offset)}. Need offset in {self.coordinate_system} to move the stage relative in this system.")
-
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             stage_offset = offset
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             stage_offset = self._axes_rotation.chip_to_stage(offset)
         else:
             RuntimeError(
@@ -542,18 +527,12 @@ class Calibration:
         ------
         CalibrationError
             If the state of calibration is lower than the required one.
-        TypeError
-            If the passed offset does not have the correct type.
         RuntimeError
             If coordinate system is unsupported.
         """
-        if not isinstance(coordinate, self.coordinate_system):
-            raise TypeError(
-                f"Given coordinate is in {type(coordinate)}. Need coordinate in {self.coordinate_system} to move the stage absolute in this system.")
-
-        if self.coordinate_system == StageCoordinate:
+        if self.is_stage_coordinate_system_set:
             stage_coordinate = coordinate
-        elif self.coordinate_system == ChipCoordinate:
+        elif self.is_chip_coordinate_system_set:
             if self.state == State.FULLY_CALIBRATED:
                 stage_coordinate = self._kabsch_rotation.chip_to_stage(
                     coordinate)
@@ -604,7 +583,8 @@ class Calibration:
 
         wiggle_difference = np.array(
             [wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
-        with self.perform_in_chip_coordinates():
+
+        with self.perform_in_system(CoordinateSystem.CHIP):
             self.move_relative(ChipCoordinate.from_numpy(wiggle_difference))
             sleep(wait_time)
             self.move_relative(ChipCoordinate.from_numpy(-wiggle_difference))

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -7,15 +7,15 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 
-from contextlib import contextmanager
 from time import sleep, time
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
 from typing import Dict, Tuple, Type, List
 from functools import wraps
 from os.path import exists
 from datetime import datetime
+from contextlib import contextmanager
 
-from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, DevicePort
+from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, DevicePort, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import ChipCoordinate
@@ -143,9 +143,10 @@ class MoverNew:
         if not _main_window:
             return
 
-        _main_window.model.status_mover_connected_stages.set(self.has_connected_stages)
-        _main_window.model.status_mover_can_move_to_device.set(self.can_move_absolutely)
-
+        _main_window.model.status_mover_connected_stages.set(
+            self.has_connected_stages)
+        _main_window.model.status_mover_can_move_to_device.set(
+            self.can_move_absolutely)
 
     #
     #   Reload properties
@@ -340,6 +341,27 @@ class MoverNew:
         return calibration
 
     #
+    #   Coordinate System Control
+    #
+
+    @contextmanager
+    def set_stages_coordinate_system(self, system: CoordinateSystem):
+        """
+        Sets the coordinate system of all connected stages to the requested one.
+        """
+        prior_coordinate_systems = {
+            c: c.coordinate_system for c in self.calibrations.values()}
+
+        for calibration in self.calibrations.values():
+            calibration.set_coordinate_system(system)
+
+        try:
+            yield
+        finally:
+            for calibration, prior_coordinate_system in prior_coordinate_systems.items():
+                calibration.set_coordinate_system(prior_coordinate_system)
+
+    #
     #   Stage Settings Methods
     #
 
@@ -522,7 +544,7 @@ class MoverNew:
         # Move stages on safe trajectory
         for calibration_waypoints in path_planning.trajectory():
             for calibration, waypoint in calibration_waypoints.items():
-                with calibration.perform_in_chip_coordinates():
+                with calibration.perform_in_system(CoordinateSystem.CHIP):
                     calibration.move_absolute(waypoint, wait_for_stopping)
 
             # Wait for all stages to stop if stages move simultaneously.
@@ -590,7 +612,7 @@ class MoverNew:
             calibration = resolved_calibrations[orientation]
             requested_target = movement_commands[orientation]
 
-            with calibration.perform_in_chip_coordinates():
+            with calibration.perform_in_system(CoordinateSystem.CHIP):
                 calibration.move_relative(requested_target, wait_for_stopping)
 
     @contextmanager
@@ -604,7 +626,7 @@ class MoverNew:
 
         def _lift_lower_stages(lift):
             for calibration in self.calibrations.values():
-                with calibration.perform_in_chip_coordinates():
+                with calibration.perform_in_system(CoordinateSystem.CHIP):
                     calibration.move_absolute(
                         calibration.get_position() + ChipCoordinate(z=lift))
 

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy.spatial.distance import pdist
 
 from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.config import Orientation
+from LabExT.Movement.config import CoordinateSystem, Orientation
 
 if TYPE_CHECKING:
     from LabExT.Movement.Calibration import Calibration
@@ -235,7 +235,7 @@ class PotentialField:
         self.potential_field = np.zeros_like(
             self.cx) + self.attractive_potential_field
 
-        with self.calibration.perform_in_chip_coordinates():
+        with self.calibration.perform_in_system(CoordinateSystem.CHIP):
             self.start_coordinate = self.calibration.get_position()
             self.target_position.z = self.start_coordinate.z
 
@@ -293,7 +293,7 @@ class PotentialField:
             self.cx) + self.attractive_potential_field
 
         for calibration in calibrations:
-            with calibration.perform_in_chip_coordinates():
+            with calibration.perform_in_system(CoordinateSystem.CHIP):
                 stage_mask = calibration.stage_polygon.stage_in_meshgrid(
                     calibration.get_position(),
                     self.cx,

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -54,6 +54,14 @@ class DevicePort(BaseEnum):
     OUTPUT = auto()
 
 
+class CoordinateSystem(BaseEnum):
+    """
+    Enumerate different coordinate systems
+    """
+    UNKNOWN = auto()
+    STAGE = auto()
+    CHIP = auto()
+
 @total_ordering
 class State(BaseEnum):
     """

--- a/LabExT/View/Controls/CoordinateWidget.py
+++ b/LabExT/View/Controls/CoordinateWidget.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from typing import Type
 from tkinter import LEFT, SUNKEN, Frame, Label
 
-from LabExT.Movement.config import Axis
+from LabExT.Movement.config import Axis, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Transformations import Coordinate
 
@@ -63,7 +63,7 @@ class StagePositionWidget(CoordinateWidget):
     def __init__(self, parent, calibration: Type[Calibration]):
         self.calibration = calibration
 
-        with self.calibration.perform_in_stage_coordinates():
+        with self.calibration.perform_in_system(CoordinateSystem.STAGE):
             super().__init__(parent, self.calibration.get_position())
 
         self._update_pos_job = self.after(
@@ -84,7 +84,7 @@ class StagePositionWidget(CoordinateWidget):
         Kills update job, if an error occurred.
         """
         try:
-            with self.calibration.perform_in_stage_coordinates():
+            with self.calibration.perform_in_system(CoordinateSystem.STAGE):
                 self.coordinate = self.calibration.get_position()
         except Exception as exc:
             self.after_cancel(self._update_pos_job)

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -15,6 +15,7 @@ from LabExT.View.Controls.CoordinateWidget import CoordinateWidget, StagePositio
 from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Calibration import Calibration
+from LabExT.Movement.config import CoordinateSystem
 from LabExT.Wafer.Chip import Chip
 
 
@@ -273,7 +274,7 @@ class CoordinatePairingsWindow(Toplevel):
         elif calibration.is_output_stage:
             chip_coord = self._device.output_coordinate
 
-        with calibration.perform_in_stage_coordinates():
+        with calibration.perform_in_system(CoordinateSystem.STAGE):
             return CoordinatePairing(
                 calibration,
                 calibration.get_position(),


### PR DESCRIPTION
# td;lr
Removed some constraints on setting the coordinate system for calibrations.

# What I changed
Simplify coordinate system control in calibrations.
Recall: Each `Calibration` (`Calibration` is an abstraction of one `Stage` which contains all data to allow the stage to move in any coordinate system, e.g. in Chip or Stage system) stores a value `coordinate_system` which specifies the system in which all operations on this stage should be performed. The following options are available: 

```python
class CoordinateSystem(BaseEnum):
    UNKNOWN = 0
    STAGE = 1
    CHIP = 2
```

The default is `CoordinateSystem.UNKNOWN`. If this is the case, no operation (e.g `move_relative`, `get_position`) can be performed, since the system is not clear.

To change this, one needs to use the `set_coordinate_system` method on the calibration level which takes a `CoordinateSystem` enum as input. So far there is nothing new compared to the old version.
What I changed is the following:
- Before we raised an error if the system was already set. E.g if the system is currently CHIP and you request STAGE, you must first reset the system to UNKNOWN before setting it to STAGE. Now you can switch directly. 
- Before we also raised an error if you want to set the system to the same system. I removed that check.

I think these checks did not really introduce more safety, on contrary, they make the calibrations more error-prone.

To make the switch easier there is a context manager called `perform_in_system` which takes a `CoordinateSystem` as input. The manager changes the system to the requested one, executes the block, and resets the system in a `finally` block after block execution.
What I changed:
- Before we reset the system to UNKNOWN after block execution, which disallows nested context managers. But we might have use cases for this, or we cannot guarantee that no nested block will occur. Now I remember the prior system before block execution and set the system to the prior system after execution.

This allows the following
```python
# no system set, no operations possible
with self.calibration.perform_in_system(CoordinateSystem.CHIP):
    # all operations are in chip coordinates
    chip_pos = self.calibrations.get_position()

   with self.calibration.perform_in_system(CoordinateSystem.STAGE):
      # all operations are in stage coordinates
      stage_pos = self.calibrations.get_position()

   # all operations are in chip coordinates again
# no system set, no operations possible
```

Moreover, I added a context manager on the `Mover` level. `set_stages_coordinate_system` takes a `CoordinateSystem` as input and sets the system of all connected calibrations to the request one and resets it after block execution.

For all methods, I added tests.