### PR TITLE
[Movement v1] Fix bug of reset axes rotation after declining calibration loading

### DIFF
--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -6,12 +6,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import json
+import os
+import logging
 
 from time import sleep, time
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
 from typing import Dict, Tuple, Type, List
 from functools import wraps
-from os.path import exists
 from datetime import datetime
 from contextlib import contextmanager
 
@@ -87,32 +88,51 @@ class MoverNew:
         chip : Chip = None
             Current instance of imported chip.
         """
+        self.logger = logging.getLogger()
+
         self.experiment_manager = experiment_manager
         self._chip: Type[Chip] = chip
 
         self._stage_classes: List[Stage] = []
         self._available_stages: List[Type[Stage]] = []
 
-        # Mover state
+        # Mover calibrations
         self._calibrations = bidict()
         self._port_by_orientation = bidict()
-        self._speed_xy = None
-        self._speed_z = None
-        self._acceleration_xy = None
-        self._z_lift = None
 
+        # Mover settings
+        self._speed_xy = self.DEFAULT_SPEED_XY
+        self._speed_z = self.DEFAULT_SPEED_Z
+        self._acceleration_xy = self.DEFAULT_ACCELERATION_XY
+        self._z_lift = self.DEFAULT_Z_LIFT
+
+        # Check for loaded stage classes and connected stages
         self.reload_stages()
         self.reload_stage_classes()
 
+        # Check for mover settings
+        self.load_settings()
+
     def reset(self):
         """
-        Resets Mover state.
+        Resets complete mover stage.
         """
+        self.reset_calibrations()
+
+        self._speed_xy = self.DEFAULT_SPEED_XY
+        self._speed_z = self.DEFAULT_SPEED_Z
+        self._acceleration_xy = self.DEFAULT_ACCELERATION_XY
+        self._z_lift = self.DEFAULT_Z_LIFT
+
+    def reset_calibrations(self):
+        """
+        Resets all calibrations
+        """
+        for s in self.connected_stages:
+            s.disconnect()
+
         self._calibrations = bidict()
         self._port_by_orientation = bidict()
-        self._speed_xy = None
-        self._speed_z = None
-        self._acceleration_xy = None
 
     #
     #   Set chip
@@ -263,6 +283,20 @@ class MoverNew:
     def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.OUTPUT)
 
+    @property
+    def has_input_calibration(self) -> bool:
+        """
+        Returns True if input calibration is defined.
+        """
+        return self.input_calibration is not None
+
+    @property
+    def has_output_calibration(self) -> bool:
+        """
+        Returns True if output calibration is defined.
+        """
+        return self.output_calibration is not None
+
     #
     #   Add new stage
     #
@@ -308,6 +342,14 @@ class MoverNew:
         self._calibrations.put(
             (orientation, port), calibration, OnDup(
                 key=RAISE))
+
+        # Stage successfully as stage registered
+        calibration.connect_to_stage()
+        # Setting stage settings
+        stage.set_speed_xy(self._speed_xy)
+        stage.set_speed_z(self._speed_z)
+        stage.set_acceleration_xy(self._acceleration_xy)
+
         return calibration
 
     def restore_stage_calibration(
@@ -364,16 +406,6 @@ class MoverNew:
     #
     #   Stage Settings Methods
     #
-
-    @assert_connected_stages
-    def set_default_settings(self) -> None:
-        """
-        Set mover default settings
-        """
-        self.speed_xy = self.DEFAULT_SPEED_XY
-        self.speed_z = self.DEFAULT_SPEED_Z
-        self.acceleration_xy = self.DEFAULT_ACCELERATION_XY
-        self.z_lift = self.DEFAULT_Z_LIFT
 
     @property
     @assert_connected_stages
@@ -695,6 +727,34 @@ class MoverNew:
                 "z_lift": self._z_lift
             }, fp)
 
+    def load_settings(self) -> None:
+        """
+        Loads mover settings from file if available.
+
+        Updates internal state of stage speed, lift and acceleration.
+        Sets these properties for all connected stages.
+        """
+        if not os.path.exists(self.MOVER_SETTINGS_FILE):
+            return
+
+        try:
+            with open(self.MOVER_SETTINGS_FILE) as fp:
+                mover_settings = json.load(fp)
+        except (OSError, json.decoder.JSONDecodeError) as err:
+            self.logger.error(
+                f"Failed to load/decode settings file {self.MOVER_SETTINGS_FILE}: {err}")
+            return
+
+        self._speed_xy = mover_settings.get("speed_xy", self.DEFAULT_SPEED_XY)
+        self._speed_z = mover_settings.get("speed_z", self.DEFAULT_SPEED_Z)
+        self._acceleration_xy = mover_settings.get(
+            "acceleration_xy", self.DEFAULT_ACCELERATION_XY)
+        self._z_lift = mover_settings.get("z_lift", self.DEFAULT_SPEED_Z)
+
+        self.logger.debug(
+            f"Restored mover settings: xy-speed = {self._speed_xy}; z-speed = {self._speed_z}; "
+            f"xy-acceleration = {self._acceleration_xy}; z-lift = {self.z_lift}")
+
     def has_chip_stored_calibration(self, chip: Type[Chip]) -> bool:
         """
         Checks if for given chip exists a stored calibration.
@@ -702,7 +762,7 @@ class MoverNew:
         if chip is None or chip.name is None:
             return False
 
-        if not exists(self.CALIBRATIONS_SETTINGS_FILE):
+        if not os.path.exists(self.CALIBRATIONS_SETTINGS_FILE):
             return False
 
         with open(self.CALIBRATIONS_SETTINGS_FILE, "r") as fp:

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -540,6 +540,10 @@ class SinglePointOffset(Transformation):
 
     def __init__(self, axes_rotation: Type[AxesRotation]) -> None:
         self.axes_rotation: Type[AxesRotation] = axes_rotation
+
+        if not self.axes_rotation.is_valid:
+            raise RuntimeError("The given axes rotation is invalid.")
+
         self.initialize()
 
     def initialize(self):
@@ -704,10 +708,15 @@ class KabschRotation(Transformation):
 
         return kabsch_rotation
 
-    def __init__(self, axes_rotation: Type[AxesRotation] = None) -> None:
-        self.initialize(axes_rotation)
+    def __init__(self, axes_rotation: Type[AxesRotation]) -> None:
+        self.axes_rotation = axes_rotation
 
-    def initialize(self, axes_rotation: Type[AxesRotation] = None) -> None:
+        if not self.axes_rotation.is_valid:
+            raise RuntimeError("The given axes rotation is invalid.")
+
+        self.initialize()
+
+    def initialize(self) -> None:
         """
         Initalises the transformation by unsetting all coordinates and offsets.
         """
@@ -722,12 +731,6 @@ class KabschRotation(Transformation):
 
         self.rotation_to_stage = None
         self.translation_to_stage = None
-
-        # Take the given axes rotation or sets it to a identity rotation
-        self.axes_rotation = axes_rotation if axes_rotation else AxesRotation()
-
-        if not self.axes_rotation.is_valid:
-            raise RuntimeError("The given axes rotation is invalid.")
 
     def __str__(self) -> str:
         if not self.is_valid:

--- a/LabExT/Tests/Movement/Transformations_test.py
+++ b/LabExT/Tests/Movement/Transformations_test.py
@@ -548,7 +548,8 @@ class RigidTransformationTest(unittest.TestCase):
 
 class KabschRotationTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.transformation = KabschRotation()
+        self.axes_rotation = AxesRotation()
+        self.transformation = KabschRotation(self.axes_rotation)
         self.calibration = Mock(spec=Calibration)
         return super().setUp()
 

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -55,8 +55,8 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             self.mover,
             self.chip,
             self.on_finish,
-            with_input_stage,
-            with_output_stage)
+            with_input_stage=with_input_stage,
+            with_output_stage=with_output_stage)
 
     def test_raises_error_if_no_chip_is_imported(self):
         with self.assertRaises(ValueError):

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -224,7 +224,8 @@ class MListener:
         self.calibration_setup_toplevel = CalibrationWizard(
             self._root,
             self._experiment_manager.mover,
-            self._experiment_manager.chip)
+            self._experiment_manager.chip,
+            experiment_manager=self._experiment_manager)
 
     def client_configure_stages(self):
         """

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -30,6 +30,7 @@ class CoordinatePairingsWindow(Toplevel):
             mover: Type[MoverNew],
             chip: Type[Chip],
             on_finish: Type[Callable],
+            experiment_manager=None,
             with_input_stage: bool = True,
             with_output_stage: bool = True) -> None:
         """
@@ -45,6 +46,8 @@ class CoordinatePairingsWindow(Toplevel):
             Instance of the current imported Chip.
         on_finish : Callable
             Callback function, when user completed the pairing.
+        experiment_manager : ExperimentManager = None
+            Optional reference to experiment manager to perform SfP and Live Viewer
         with_input_stage : bool = True
             Specifies whether the input stage is to be used.
         with_output_stage : bool = True
@@ -60,6 +63,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         self.chip: Type[Chip] = chip
         self.mover: Type[MoverNew] = mover
+        self.experiment_manager = experiment_manager
+
         self.on_finish = on_finish
         self.with_input_stage = with_input_stage
         self.with_output_stage = with_output_stage
@@ -161,6 +166,24 @@ class CoordinatePairingsWindow(Toplevel):
                 frame, self.mover.output_calibration).pack(
                 side=TOP, fill=X)
 
+        if self.experiment_manager:
+            shortcuts_frame = CustomFrame(self._main_frame)
+            shortcuts_frame.pack(side=TOP, fill=X, pady=5)
+
+            search_for_peak_button = Button(
+                shortcuts_frame,
+                text="Perform Search for Peak...",
+                command=self.experiment_manager.main_window.open_peak_searcher)
+            search_for_peak_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
+            live_viewer_button = Button(
+                shortcuts_frame,
+                text="Open Live Viewer...",
+                command=self.experiment_manager.main_window.open_live_viewer)
+            live_viewer_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
     def __reload__(self) -> None:
         """
         Reloads window.
@@ -252,8 +275,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         run_with_wait_window(
             self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(self.chip, self._device))
-
+                self._device.id), function=lambda: self.mover.move_to_device(
+                self.chip, self._device))
     #
     #   Helpers
     #

--- a/LabExT/View/Movement/LoadStoredCalibrationWindow.py
+++ b/LabExT/View/Movement/LoadStoredCalibrationWindow.py
@@ -179,7 +179,7 @@ class LoadStoredCalibrationWindow(Toplevel):
             calibration_assignment[stage] = _stored_calibration
 
         # Apply calibrations
-        self.mover.reset()
+        self.mover.reset_calibrations()
         for stage, stored_calibration in calibration_assignment.items():
             try:
                 calibration = self.mover.restore_stage_calibration(
@@ -189,7 +189,7 @@ class LoadStoredCalibrationWindow(Toplevel):
                     "Error",
                     f"Failed to restored calibration: {err}",
                     parent=self)
-                self.mover.reset()
+                self.mover.reset_calibrations()
                 return
 
             run_with_wait_window(

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -72,34 +72,25 @@ class StageWizard(Wizard):
                 "Proceed?",
                 "You have already created stages. If you continue, they will be reset, including the calibrations. Proceed?",
                     parent=self):
-                self.mover.reset()
+                self.mover.reset_calibrations()
             else:
                 return False
 
         for stage, assignment in self.stage_assignment_step.assignment.items():
             try:
-                calibration = self.mover.add_stage_calibration(
-                    stage, *assignment)
                 run_with_wait_window(
                     self,
                     f"Connecting to stage {stage}",
-                    lambda: calibration.connect_to_stage())
+                    lambda: self.mover.add_stage_calibration(
+                        stage,
+                        *assignment))
             except (ValueError, MoverError, StageError) as e:
-                self.mover.reset()
+                self.mover.reset_calibrations()
                 messagebox.showerror(
                     "Error",
                     f"Connecting to stages failed: {e}",
                     parent=self)
                 return False
-
-        try:
-            self.mover.set_default_settings()
-        except Exception as err:
-            messagebox.showerror(
-                "Error",
-                f"Failed to set default setting: {err}",
-                parent=self)
-            return False
 
         messagebox.showinfo(
             "Stage Setup completed.",
@@ -216,9 +207,10 @@ class MoverWizard(Wizard):
 
 
 class CalibrationWizard(Wizard):
-    def __init__(self, master, mover, chip):
+    def __init__(self, master, mover, chip, experiment_manager=None):
         self.mover: Type[MoverNew] = mover
         self.chip: Type[Chip] = chip
+        self.experiment_manager = experiment_manager
 
         if len(self.mover.calibrations) == 0:
             raise RuntimeError(
@@ -801,8 +793,10 @@ class CoordinatePairingStep(Step):
         self.mover: Type[MoverNew] = mover
         self.chip: Type[Chip] = chip
 
-        self._use_input_stage_var = BooleanVar(self.wizard, True)
-        self._use_output_stage_var = BooleanVar(self.wizard, True)
+        self._use_input_stage_var = BooleanVar(
+            self.wizard, self.mover.has_input_calibration)
+        self._use_output_stage_var = BooleanVar(
+            self.wizard, self.mover.has_output_calibration)
         self._full_calibration_new_pairing_button = None
 
         self._coordinate_pairing_window = None
@@ -913,16 +907,18 @@ class CoordinatePairingStep(Step):
         new_pairing_frame.title = "Create New Pairing"
         new_pairing_frame.pack(side=TOP, fill=X, pady=5)
 
-        Checkbutton(
-            new_pairing_frame,
-            text="Use Input-Stage for Pairing",
-            variable=self._use_input_stage_var
-        ).pack(side=LEFT)
-        Checkbutton(
-            new_pairing_frame,
-            text="Use Output-Stage for Pairing",
-            variable=self._use_output_stage_var
-        ).pack(side=LEFT)
+        if self.mover.has_input_calibration:
+            Checkbutton(
+                new_pairing_frame,
+                text="Use Input-Stage for Pairing",
+                variable=self._use_input_stage_var
+            ).pack(side=LEFT)
+        if self.mover.has_output_calibration:
+            Checkbutton(
+                new_pairing_frame,
+                text="Use Output-Stage for Pairing",
+                variable=self._use_output_stage_var
+            ).pack(side=LEFT)
 
         self._full_calibration_new_pairing_button = Button(
             new_pairing_frame,
@@ -961,14 +957,26 @@ class CoordinatePairingStep(Step):
         if self._check_for_exisiting_coordinate_window():
             return
 
+        with_input_stage = self._use_input_stage_var.get()
+        with_output_stage = self._use_output_stage_var.get()
+
+        if not with_input_stage and not with_output_stage:
+            messagebox.showwarning(
+                "No Stages selected",
+                "No stages have been selected with which to create a coordinate pairing. "
+                "At least one stage must be selected.",
+                parent=self.wizard)
+            return
+
         try:
             self._coordinate_pairing_window = CoordinatePairingsWindow(
                 self.wizard,
                 self.mover,
                 self.chip,
+                experiment_manager=self.wizard.experiment_manager,
                 on_finish=self._save_coordinate_pairing,
-                with_input_stage=self._use_input_stage_var.get(),
-                with_output_stage=self._use_output_stage_var.get())
+                with_input_stage=with_input_stage,
+                with_output_stage=with_output_stage)
         except Exception as e:
             messagebox.showerror(
                 "Error",


### PR DESCRIPTION
Fixes bug of resetting axes rotation after declining calibration loading.

Before we created a new `AxesRotation` after declining which was not updated during the calibration process such that Kabsch did not correct the unit vectors during calibration.