### PR TITLE
[Movement v1] Restore Mover settings from file

### DIFF
--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -283,6 +283,20 @@ class MoverNew:
     def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.OUTPUT)
 
+    @property
+    def has_input_calibration(self) -> bool:
+        """
+        Returns True if input calibration is defined.
+        """
+        return self.input_calibration is not None
+
+    @property
+    def has_output_calibration(self) -> bool:
+        """
+        Returns True if output calibration is defined.
+        """
+        return self.output_calibration is not None
+
     #
     #   Add new stage
     #

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -6,6 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import json
+import logging
 
 from time import sleep, time
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
@@ -87,32 +88,51 @@ class MoverNew:
         chip : Chip = None
             Current instance of imported chip.
         """
+        self.logger = logging.getLogger()
+
         self.experiment_manager = experiment_manager
         self._chip: Type[Chip] = chip
 
         self._stage_classes: List[Stage] = []
         self._available_stages: List[Type[Stage]] = []
 
-        # Mover state
+        # Mover calibrations
         self._calibrations = bidict()
         self._port_by_orientation = bidict()
-        self._speed_xy = None
-        self._speed_z = None
-        self._acceleration_xy = None
-        self._z_lift = None
 
+        # Mover settings
+        self._speed_xy = self.DEFAULT_SPEED_XY
+        self._speed_z = self.DEFAULT_SPEED_Z
+        self._acceleration_xy = self.DEFAULT_ACCELERATION_XY
+        self._z_lift = self.DEFAULT_Z_LIFT
+
+        # Check for loaded stage classes and connected stages
         self.reload_stages()
         self.reload_stage_classes()
 
+        # Check for mover settings
+        self.load_settings()
+
     def reset(self):
         """
-        Resets Mover state.
+        Resets complete mover stage.
         """
+        self.reset_calibrations()
+
+        self._speed_xy = self.DEFAULT_SPEED_XY
+        self._speed_z = self.DEFAULT_SPEED_Z
+        self._acceleration_xy = self.DEFAULT_ACCELERATION_XY
+        self._z_lift = self.DEFAULT_Z_LIFT
+
+    def reset_calibrations(self):
+        """
+        Resets all calibrations
+        """
+        for s in self.connected_stages:
+            s.disconnect()
+
         self._calibrations = bidict()
         self._port_by_orientation = bidict()
-        self._speed_xy = None
-        self._speed_z = None
-        self._acceleration_xy = None
 
     #
     #   Set chip
@@ -308,6 +328,13 @@ class MoverNew:
         self._calibrations.put(
             (orientation, port), calibration, OnDup(
                 key=RAISE))
+
+        # Stage successfully as stage registered
+        # Setting stage settings
+        stage.set_speed_xy(self._speed_xy)
+        stage.set_speed_z(self._speed_z)
+        stage.set_acceleration_xy(self._acceleration_xy)
+
         return calibration
 
     def restore_stage_calibration(
@@ -364,16 +391,6 @@ class MoverNew:
     #
     #   Stage Settings Methods
     #
-
-    @assert_connected_stages
-    def set_default_settings(self) -> None:
-        """
-        Set mover default settings
-        """
-        self.speed_xy = self.DEFAULT_SPEED_XY
-        self.speed_z = self.DEFAULT_SPEED_Z
-        self.acceleration_xy = self.DEFAULT_ACCELERATION_XY
-        self.z_lift = self.DEFAULT_Z_LIFT
 
     @property
     @assert_connected_stages
@@ -694,6 +711,34 @@ class MoverNew:
                 "acceleration_xy": self._acceleration_xy,
                 "z_lift": self._z_lift
             }, fp)
+
+    def load_settings(self) -> None:
+        """
+        Loads mover settings from file if available.
+
+        Updates internal state of stage speed, lift and acceleration.
+        Sets these properties for all connected stages.
+        """
+        if not exists(self.MOVER_SETTINGS_FILE):
+            return
+
+        try:
+            with open(self.MOVER_SETTINGS_FILE) as fp:
+                mover_settings = json.load(fp)
+        except (OSError, json.decoder.JSONDecodeError) as err:
+            self.logger.error(
+                f"Failed to load/decode settings file {self.MOVER_SETTINGS_FILE}: {err}")
+            return
+
+        self._speed_xy = mover_settings.get("speed_xy", self.DEFAULT_SPEED_XY)
+        self._speed_z = mover_settings.get("speed_z", self.DEFAULT_SPEED_Z)
+        self._acceleration_xy = mover_settings.get(
+            "acceleration_xy", self.DEFAULT_ACCELERATION_XY)
+        self._z_lift = mover_settings.get("z_lift", self.DEFAULT_SPEED_Z)
+
+        self.logger.debug(
+            f"Restored mover settings: xy-speed = {self._speed_xy}; z-speed = {self._speed_z}; "
+            f"xy-acceleration = {self._acceleration_xy}; z-lift = {self.z_lift}")
 
     def has_chip_stored_calibration(self, chip: Type[Chip]) -> bool:
         """

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -6,13 +6,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import json
+import os
 import logging
 
 from time import sleep, time
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
 from typing import Dict, Tuple, Type, List
 from functools import wraps
-from os.path import exists
 from datetime import datetime
 from contextlib import contextmanager
 
@@ -330,6 +330,7 @@ class MoverNew:
                 key=RAISE))
 
         # Stage successfully as stage registered
+        calibration.connect_to_stage()
         # Setting stage settings
         stage.set_speed_xy(self._speed_xy)
         stage.set_speed_z(self._speed_z)
@@ -719,7 +720,7 @@ class MoverNew:
         Updates internal state of stage speed, lift and acceleration.
         Sets these properties for all connected stages.
         """
-        if not exists(self.MOVER_SETTINGS_FILE):
+        if not os.path.exists(self.MOVER_SETTINGS_FILE):
             return
 
         try:
@@ -747,7 +748,7 @@ class MoverNew:
         if chip is None or chip.name is None:
             return False
 
-        if not exists(self.CALIBRATIONS_SETTINGS_FILE):
+        if not os.path.exists(self.CALIBRATIONS_SETTINGS_FILE):
             return False
 
         with open(self.CALIBRATIONS_SETTINGS_FILE, "r") as fp:

--- a/LabExT/Tests/Movement/MoverNew_test.py
+++ b/LabExT/Tests/Movement/MoverNew_test.py
@@ -72,6 +72,14 @@ class AddStageCalibrationTest(unittest.TestCase):
 
         return super().setUp()
 
+    def test_default_mover_settings_after_initialization(self):
+        self.assertEqual(self.mover._speed_xy, self.mover.DEFAULT_SPEED_XY)
+        self.assertEqual(self.mover._speed_z, self.mover.DEFAULT_SPEED_Z)
+        self.assertEqual(
+            self.mover._acceleration_xy,
+            self.mover.DEFAULT_ACCELERATION_XY)
+        self.assertEqual(self.mover._z_lift, self.mover.DEFAULT_Z_LIFT)
+
     def test_add_stage_calibration_reject_invalid_orientations(self):
         current_calibrations = self.mover.calibrations
 
@@ -180,6 +188,20 @@ class AddStageCalibrationTest(unittest.TestCase):
             self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
         self.assertEqual(calibration, self.mover.bottom_calibration)
         self.assertEqual(calibration, self.mover.output_calibration)
+
+    def test_set_stage_settings_successfully(self):
+        self.assertIsNone(self.stage.get_speed_xy())
+        self.assertIsNone(self.stage.get_speed_xy())
+        self.assertIsNone(self.stage.get_acceleration_xy())
+
+        self.mover.add_stage_calibration(
+            self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
+
+        self.assertEqual(self.stage.get_speed_xy(), self.mover._speed_xy)
+        self.assertEqual(self.stage.get_speed_z(), self.mover._speed_z)
+        self.assertEqual(
+            self.stage.get_acceleration_xy(),
+            self.mover._acceleration_xy)
 
 
 class MoverStageSettingsTest(unittest.TestCase):

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -55,8 +55,8 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             self.mover,
             self.chip,
             self.on_finish,
-            with_input_stage,
-            with_output_stage)
+            with_input_stage=with_input_stage,
+            with_output_stage=with_output_stage)
 
     def test_raises_error_if_no_chip_is_imported(self):
         with self.assertRaises(ValueError):

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -224,7 +224,8 @@ class MListener:
         self.calibration_setup_toplevel = CalibrationWizard(
             self._root,
             self._experiment_manager.mover,
-            self._experiment_manager.chip)
+            self._experiment_manager.chip,
+            experiment_manager=self._experiment_manager)
 
     def client_configure_stages(self):
         """

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -30,6 +30,7 @@ class CoordinatePairingsWindow(Toplevel):
             mover: Type[MoverNew],
             chip: Type[Chip],
             on_finish: Type[Callable],
+            experiment_manager=None,
             with_input_stage: bool = True,
             with_output_stage: bool = True) -> None:
         """
@@ -45,6 +46,8 @@ class CoordinatePairingsWindow(Toplevel):
             Instance of the current imported Chip.
         on_finish : Callable
             Callback function, when user completed the pairing.
+        experiment_manager : ExperimentManager = None
+            Optional reference to experiment manager to perform SfP and Live Viewer
         with_input_stage : bool = True
             Specifies whether the input stage is to be used.
         with_output_stage : bool = True
@@ -60,6 +63,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         self.chip: Type[Chip] = chip
         self.mover: Type[MoverNew] = mover
+        self.experiment_manager = experiment_manager
+
         self.on_finish = on_finish
         self.with_input_stage = with_input_stage
         self.with_output_stage = with_output_stage
@@ -161,6 +166,24 @@ class CoordinatePairingsWindow(Toplevel):
                 frame, self.mover.output_calibration).pack(
                 side=TOP, fill=X)
 
+        if self.experiment_manager:
+            shortcuts_frame = CustomFrame(self._main_frame)
+            shortcuts_frame.pack(side=TOP, fill=X, pady=5)
+
+            search_for_peak_button = Button(
+                shortcuts_frame,
+                text="Perform Search for Peak...",
+                command=self.experiment_manager.main_window.open_peak_searcher)
+            search_for_peak_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
+            live_viewer_button = Button(
+                shortcuts_frame,
+                text="Open Live Viewer...",
+                command=self.experiment_manager.main_window.open_live_viewer)
+            live_viewer_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
     def __reload__(self) -> None:
         """
         Reloads window.
@@ -252,8 +275,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         run_with_wait_window(
             self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(self.chip, self._device))
-
+                self._device.id), function=lambda: self.mover.move_to_device(
+                self.chip, self._device))
     #
     #   Helpers
     #

--- a/LabExT/View/Movement/LoadStoredCalibrationWindow.py
+++ b/LabExT/View/Movement/LoadStoredCalibrationWindow.py
@@ -179,7 +179,7 @@ class LoadStoredCalibrationWindow(Toplevel):
             calibration_assignment[stage] = _stored_calibration
 
         # Apply calibrations
-        self.mover.reset()
+        self.mover.reset_calibrations()
         for stage, stored_calibration in calibration_assignment.items():
             try:
                 calibration = self.mover.restore_stage_calibration(
@@ -189,7 +189,7 @@ class LoadStoredCalibrationWindow(Toplevel):
                     "Error",
                     f"Failed to restored calibration: {err}",
                     parent=self)
-                self.mover.reset()
+                self.mover.reset_calibrations()
                 return
 
             run_with_wait_window(

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -72,7 +72,7 @@ class StageWizard(Wizard):
                 "Proceed?",
                 "You have already created stages. If you continue, they will be reset, including the calibrations. Proceed?",
                     parent=self):
-                self.mover.reset()
+                self.mover.reset_calibrations()
             else:
                 return False
 
@@ -85,21 +85,12 @@ class StageWizard(Wizard):
                     f"Connecting to stage {stage}",
                     lambda: calibration.connect_to_stage())
             except (ValueError, MoverError, StageError) as e:
-                self.mover.reset()
+                self.mover.reset_calibrations()
                 messagebox.showerror(
                     "Error",
                     f"Connecting to stages failed: {e}",
                     parent=self)
                 return False
-
-        try:
-            self.mover.set_default_settings()
-        except Exception as err:
-            messagebox.showerror(
-                "Error",
-                f"Failed to set default setting: {err}",
-                parent=self)
-            return False
 
         messagebox.showinfo(
             "Stage Setup completed.",

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -78,12 +78,12 @@ class StageWizard(Wizard):
 
         for stage, assignment in self.stage_assignment_step.assignment.items():
             try:
-                calibration = self.mover.add_stage_calibration(
-                    stage, *assignment)
                 run_with_wait_window(
                     self,
                     f"Connecting to stage {stage}",
-                    lambda: calibration.connect_to_stage())
+                    lambda: self.mover.add_stage_calibration(
+                        stage,
+                        *assignment))
             except (ValueError, MoverError, StageError) as e:
                 self.mover.reset_calibrations()
                 messagebox.showerror(


### PR DESCRIPTION
Restores Mover settings (lift, acceleration, speed) after LabExT restart.

After initialisation of the mover, it is checked whether a Mover Settings file exists. If so, the values are loaded from the file and saved in the internal mover state (`_speed_xy`, `_acceleration_xy`, `_z_lift`, `_speed_z`). If a new stage is registered in the mover as a calibration, the internal state is automatically set as a setting after connecting to the stage. This guarantees that every stage known to the Mover has the same settings.

If the file is not found, the constant default values are used as before.