### PR TITLE
[Movement v1] Fix stage checkboxes for pairing for single stages

### DIFF
--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -283,6 +283,20 @@ class MoverNew:
     def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
         port=DevicePort.OUTPUT)
 
+    @property
+    def has_input_calibration(self) -> bool:
+        """
+        Returns True if input calibration is defined.
+        """
+        return self.input_calibration is not None
+
+    @property
+    def has_output_calibration(self) -> bool:
+        """
+        Returns True if output calibration is defined.
+        """
+        return self.output_calibration is not None
+
     #
     #   Add new stage
     #

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -55,8 +55,8 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             self.mover,
             self.chip,
             self.on_finish,
-            with_input_stage,
-            with_output_stage)
+            with_input_stage=with_input_stage,
+            with_output_stage=with_output_stage)
 
     def test_raises_error_if_no_chip_is_imported(self):
         with self.assertRaises(ValueError):

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -224,7 +224,8 @@ class MListener:
         self.calibration_setup_toplevel = CalibrationWizard(
             self._root,
             self._experiment_manager.mover,
-            self._experiment_manager.chip)
+            self._experiment_manager.chip,
+            experiment_manager=self._experiment_manager)
 
     def client_configure_stages(self):
         """

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -30,6 +30,7 @@ class CoordinatePairingsWindow(Toplevel):
             mover: Type[MoverNew],
             chip: Type[Chip],
             on_finish: Type[Callable],
+            experiment_manager=None,
             with_input_stage: bool = True,
             with_output_stage: bool = True) -> None:
         """
@@ -45,6 +46,8 @@ class CoordinatePairingsWindow(Toplevel):
             Instance of the current imported Chip.
         on_finish : Callable
             Callback function, when user completed the pairing.
+        experiment_manager : ExperimentManager = None
+            Optional reference to experiment manager to perform SfP and Live Viewer
         with_input_stage : bool = True
             Specifies whether the input stage is to be used.
         with_output_stage : bool = True
@@ -60,6 +63,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         self.chip: Type[Chip] = chip
         self.mover: Type[MoverNew] = mover
+        self.experiment_manager = experiment_manager
+
         self.on_finish = on_finish
         self.with_input_stage = with_input_stage
         self.with_output_stage = with_output_stage
@@ -161,6 +166,24 @@ class CoordinatePairingsWindow(Toplevel):
                 frame, self.mover.output_calibration).pack(
                 side=TOP, fill=X)
 
+        if self.experiment_manager:
+            shortcuts_frame = CustomFrame(self._main_frame)
+            shortcuts_frame.pack(side=TOP, fill=X, pady=5)
+
+            search_for_peak_button = Button(
+                shortcuts_frame,
+                text="Perform Search for Peak...",
+                command=self.experiment_manager.main_window.open_peak_searcher)
+            search_for_peak_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
+            live_viewer_button = Button(
+                shortcuts_frame,
+                text="Open Live Viewer...",
+                command=self.experiment_manager.main_window.open_live_viewer)
+            live_viewer_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
     def __reload__(self) -> None:
         """
         Reloads window.
@@ -252,8 +275,8 @@ class CoordinatePairingsWindow(Toplevel):
 
         run_with_wait_window(
             self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(self.chip, self._device))
-
+                self._device.id), function=lambda: self.mover.move_to_device(
+                self.chip, self._device))
     #
     #   Helpers
     #

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -792,8 +792,10 @@ class CoordinatePairingStep(Step):
         self.mover: Type[MoverNew] = mover
         self.chip: Type[Chip] = chip
 
-        self._use_input_stage_var = BooleanVar(self.wizard, True)
-        self._use_output_stage_var = BooleanVar(self.wizard, True)
+        self._use_input_stage_var = BooleanVar(
+            self.wizard, self.mover.has_input_calibration)
+        self._use_output_stage_var = BooleanVar(
+            self.wizard, self.mover.has_output_calibration)
         self._full_calibration_new_pairing_button = None
 
         self._coordinate_pairing_window = None
@@ -904,16 +906,18 @@ class CoordinatePairingStep(Step):
         new_pairing_frame.title = "Create New Pairing"
         new_pairing_frame.pack(side=TOP, fill=X, pady=5)
 
-        Checkbutton(
-            new_pairing_frame,
-            text="Use Input-Stage for Pairing",
-            variable=self._use_input_stage_var
-        ).pack(side=LEFT)
-        Checkbutton(
-            new_pairing_frame,
-            text="Use Output-Stage for Pairing",
-            variable=self._use_output_stage_var
-        ).pack(side=LEFT)
+        if self.mover.has_input_calibration:
+            Checkbutton(
+                new_pairing_frame,
+                text="Use Input-Stage for Pairing",
+                variable=self._use_input_stage_var
+            ).pack(side=LEFT)
+        if self.mover.has_output_calibration:
+            Checkbutton(
+                new_pairing_frame,
+                text="Use Output-Stage for Pairing",
+                variable=self._use_output_stage_var
+            ).pack(side=LEFT)
 
         self._full_calibration_new_pairing_button = Button(
             new_pairing_frame,
@@ -952,14 +956,25 @@ class CoordinatePairingStep(Step):
         if self._check_for_exisiting_coordinate_window():
             return
 
+        with_input_stage = self._use_input_stage_var.get()
+        with_output_stage = self._use_output_stage_var.get()
+
+        if not with_input_stage and not with_output_stage:
+            messagebox.showwarning(
+                "No Stages selected",
+                "No stages have been selected with which to create a coordinate pairing. "
+                "At least one stage must be selected.",
+                parent=self.wizard)
+            return
+
         try:
             self._coordinate_pairing_window = CoordinatePairingsWindow(
                 self.wizard,
                 self.mover,
                 self.chip,
                 on_finish=self._save_coordinate_pairing,
-                with_input_stage=self._use_input_stage_var.get(),
-                with_output_stage=self._use_output_stage_var.get())
+                with_input_stage=with_input_stage,
+                with_output_stage=with_output_stage)
         except Exception as e:
             messagebox.showerror(
                 "Error",

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -207,9 +207,10 @@ class MoverWizard(Wizard):
 
 
 class CalibrationWizard(Wizard):
-    def __init__(self, master, mover, chip):
+    def __init__(self, master, mover, chip, experiment_manager=None):
         self.mover: Type[MoverNew] = mover
         self.chip: Type[Chip] = chip
+        self.experiment_manager = experiment_manager
 
         if len(self.mover.calibrations) == 0:
             raise RuntimeError(
@@ -972,6 +973,7 @@ class CoordinatePairingStep(Step):
                 self.wizard,
                 self.mover,
                 self.chip,
+                experiment_manager=self.wizard.experiment_manager,
                 on_finish=self._save_coordinate_pairing,
                 with_input_stage=with_input_stage,
                 with_output_stage=with_output_stage)


### PR DESCRIPTION
Small cosmetic fix: If only one stage was connected, checkboxes for using input and output calibration were still displayed in the coordinate pairing step. These are now only displayed if such a calibration exists.