### PR TITLE
[Movement v1] SfP and Live Viewer shortcuts

### DIFF
--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -55,8 +55,8 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             self.mover,
             self.chip,
             self.on_finish,
-            with_input_stage,
-            with_output_stage)
+            with_input_stage=with_input_stage,
+            with_output_stage=with_output_stage)
 
     def test_raises_error_if_no_chip_is_imported(self):
         with self.assertRaises(ValueError):

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -224,7 +224,8 @@ class MListener:
         self.calibration_setup_toplevel = CalibrationWizard(
             self._root,
             self._experiment_manager.mover,
-            self._experiment_manager.chip)
+            self._experiment_manager.chip,
+            experiment_manager=self._experiment_manager)
 
     def client_configure_stages(self):
         """

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -7,13 +7,10 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y
 from typing import Callable, Type
-from LabExT.Utils import run_with_wait_window, try_to_lift_window
+from LabExT.Utils import run_with_wait_window
 from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.DeviceTable import DeviceTable
 from LabExT.View.Controls.CoordinateWidget import CoordinateWidget, StagePositionWidget
-
-from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
-from LabExT.View.SearchForPeakPlotsWindow import SearchForPeakPlotsWindow
 
 from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.MoverNew import MoverNew
@@ -71,9 +68,6 @@ class CoordinatePairingsWindow(Toplevel):
         self.on_finish = on_finish
         self.with_input_stage = with_input_stage
         self.with_output_stage = with_output_stage
-
-        self._live_viewer_toplevel = None
-        self._search_for_peak_toplevel = None
 
         if self.chip is None:
             raise ValueError("Cannot create pairing without chip imported. ")
@@ -179,14 +173,14 @@ class CoordinatePairingsWindow(Toplevel):
             search_for_peak_button = Button(
                 shortcuts_frame,
                 text="Perform Search for Peak...",
-                command=self._on_perform_search_for_peak)
+                command=self.experiment_manager.main_window.open_peak_searcher)
             search_for_peak_button.pack(
                 side=RIGHT, fill=Y, pady=5, expand=0)
 
             live_viewer_button = Button(
                 shortcuts_frame,
                 text="Open Live Viewer...",
-                command=self._on_open_live_viewer)
+                command=self.experiment_manager.main_window.open_live_viewer)
             live_viewer_button.pack(
                 side=RIGHT, fill=Y, pady=5, expand=0)
 
@@ -283,35 +277,6 @@ class CoordinatePairingsWindow(Toplevel):
             self, description="Move to device {}".format(
                 self._device.id), function=lambda: self.mover.move_to_device(
                 self.chip, self._device))
-
-    def _on_open_live_viewer(self):
-        """
-        Callback when user wants to open the live viewer.
-        """
-        if not self.experiment_manager:
-            return
-
-        if try_to_lift_window(self._live_viewer_toplevel):
-            return
-
-        lv = LiveViewerController(self, self.experiment_manager)
-        self._live_viewer_toplevel = lv.current_window
-
-    def _on_perform_search_for_peak(self):
-        """
-        Callback when user wants to perform search for peak.
-        """
-        if not self.experiment_manager:
-            return
-
-        if try_to_lift_window(self._search_for_peak_toplevel):
-            return
-
-        sfpp = SearchForPeakPlotsWindow(
-            parent=self,
-            experiment_manager=self.experiment_manager)
-        self._search_for_peak_toplevel = sfpp.plot_window
-
     #
     #   Helpers
     #

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -7,10 +7,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y
 from typing import Callable, Type
-from LabExT.Utils import run_with_wait_window
+from LabExT.Utils import run_with_wait_window, try_to_lift_window
 from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.DeviceTable import DeviceTable
 from LabExT.View.Controls.CoordinateWidget import CoordinateWidget, StagePositionWidget
+
+from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
+from LabExT.View.SearchForPeakPlotsWindow import SearchForPeakPlotsWindow
 
 from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.MoverNew import MoverNew
@@ -30,6 +33,7 @@ class CoordinatePairingsWindow(Toplevel):
             mover: Type[MoverNew],
             chip: Type[Chip],
             on_finish: Type[Callable],
+            experiment_manager=None,
             with_input_stage: bool = True,
             with_output_stage: bool = True) -> None:
         """
@@ -45,6 +49,8 @@ class CoordinatePairingsWindow(Toplevel):
             Instance of the current imported Chip.
         on_finish : Callable
             Callback function, when user completed the pairing.
+        experiment_manager : ExperimentManager = None
+            Optional reference to experiment manager to perform SfP and Live Viewer
         with_input_stage : bool = True
             Specifies whether the input stage is to be used.
         with_output_stage : bool = True
@@ -60,9 +66,14 @@ class CoordinatePairingsWindow(Toplevel):
 
         self.chip: Type[Chip] = chip
         self.mover: Type[MoverNew] = mover
+        self.experiment_manager = experiment_manager
+
         self.on_finish = on_finish
         self.with_input_stage = with_input_stage
         self.with_output_stage = with_output_stage
+
+        self._live_viewer_toplevel = None
+        self._search_for_peak_toplevel = None
 
         if self.chip is None:
             raise ValueError("Cannot create pairing without chip imported. ")
@@ -161,6 +172,24 @@ class CoordinatePairingsWindow(Toplevel):
                 frame, self.mover.output_calibration).pack(
                 side=TOP, fill=X)
 
+        if self.experiment_manager:
+            shortcuts_frame = CustomFrame(self._main_frame)
+            shortcuts_frame.pack(side=TOP, fill=X, pady=5)
+
+            search_for_peak_button = Button(
+                shortcuts_frame,
+                text="Perform Search for Peak...",
+                command=self._on_perform_search_for_peak)
+            search_for_peak_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
+            live_viewer_button = Button(
+                shortcuts_frame,
+                text="Open Live Viewer...",
+                command=self._on_open_live_viewer)
+            live_viewer_button.pack(
+                side=RIGHT, fill=Y, pady=5, expand=0)
+
     def __reload__(self) -> None:
         """
         Reloads window.
@@ -252,7 +281,36 @@ class CoordinatePairingsWindow(Toplevel):
 
         run_with_wait_window(
             self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(self.chip, self._device))
+                self._device.id), function=lambda: self.mover.move_to_device(
+                self.chip, self._device))
+
+    def _on_open_live_viewer(self):
+        """
+        Callback when user wants to open the live viewer.
+        """
+        if not self.experiment_manager:
+            return
+
+        if try_to_lift_window(self._live_viewer_toplevel):
+            return
+
+        lv = LiveViewerController(self, self.experiment_manager)
+        self._live_viewer_toplevel = lv.current_window
+
+    def _on_perform_search_for_peak(self):
+        """
+        Callback when user wants to perform search for peak.
+        """
+        if not self.experiment_manager:
+            return
+
+        if try_to_lift_window(self._search_for_peak_toplevel):
+            return
+
+        sfpp = SearchForPeakPlotsWindow(
+            parent=self,
+            experiment_manager=self.experiment_manager)
+        self._search_for_peak_toplevel = sfpp.plot_window
 
     #
     #   Helpers

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -207,9 +207,10 @@ class MoverWizard(Wizard):
 
 
 class CalibrationWizard(Wizard):
-    def __init__(self, master, mover, chip):
+    def __init__(self, master, mover, chip, experiment_manager=None):
         self.mover: Type[MoverNew] = mover
         self.chip: Type[Chip] = chip
+        self.experiment_manager = experiment_manager
 
         if len(self.mover.calibrations) == 0:
             raise RuntimeError(
@@ -972,6 +973,7 @@ class CoordinatePairingStep(Step):
                 self.wizard,
                 self.mover,
                 self.chip,
+                experiment_manager=self.wizard.experiment_manager,
                 on_finish=self._save_coordinate_pairing,
                 with_input_stage=with_input_stage,
                 with_output_stage=with_output_stage)


### PR DESCRIPTION
This PR adds two optional shortcuts in the Coordinate Pairing Window for Search for Peak and Live Viewer. This makes pairing creation easier.

<img width="1000" alt="Screenshot 2022-11-30 at 14 33 46" src="https://user-images.githubusercontent.com/14354617/204810391-427fa7a8-2870-401d-8e1d-e7ad58425133.png">

In the future, when we define the new interface for SfP, we can directly set the required stages to perform the SfP Algorithm.
