### PR TITLE
[Movement v1] Introduce identifier for stages

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -54,8 +54,9 @@ def assert_minimum_state_for_coordinate_system(
             if calibration.coordinate_system == CoordinateSystem.CHIP:
                 if chip_coordinate_system is None:
                     raise CalibrationError(
-                        "Function {} does not support the chip coordinate system.".format(func.__name__))
-                
+                        "Function {} does not support the chip coordinate system.".format(
+                            func.__name__))
+
                 if calibration.state < chip_coordinate_system:
                     raise CalibrationError(
                         "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
@@ -64,8 +65,9 @@ def assert_minimum_state_for_coordinate_system(
             if calibration.coordinate_system == CoordinateSystem.STAGE:
                 if stage_coordinate_system is None:
                     raise CalibrationError(
-                        "Function {} does not support the stage coordinate system.".format(func.__name__))
-                
+                        "Function {} does not support the stage coordinate system.".format(
+                            func.__name__))
+
                 if calibration.state < stage_coordinate_system:
                     raise CalibrationError(
                         "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(
@@ -793,22 +795,28 @@ class Calibration:
         self.stage.set_speed_xy(current_speed_xy)
         self.stage.set_speed_z(current_speed_z)
 
-    def dump(self) -> dict:
+    def dump(
+        self,
+        axes_rotation: bool = True,
+        single_point_offset: bool = True,
+        kabsch_rotation: bool = True
+    ) -> dict:
         """
         Returns a dict of all calibration properties.
         """
         calibration_dump = {
+            "stage_identifier": self.stage.identifier,
             "orientation": self.orientation.value,
             "device_port": self._device_port.value}
 
-        if self._axes_rotation.is_valid:
+        if axes_rotation and self._axes_rotation.is_valid:
             calibration_dump["axes_rotation"] = self._axes_rotation.dump()
 
-        if self._single_point_offset.is_valid:
+        if single_point_offset and self._single_point_offset.is_valid:
             calibration_dump["single_point_offset"] = self._single_point_offset.dump(
             )
 
-        if self._kabsch_rotation.is_valid:
+        if kabsch_rotation and self._kabsch_rotation.is_valid:
             calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
 
         return calibration_dump

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -54,9 +54,8 @@ def assert_minimum_state_for_coordinate_system(
             if calibration.coordinate_system == CoordinateSystem.CHIP:
                 if chip_coordinate_system is None:
                     raise CalibrationError(
-                        "Function {} does not support the chip coordinate system.".format(
-                            func.__name__))
-
+                        "Function {} does not support the chip coordinate system.".format(func.__name__))
+                
                 if calibration.state < chip_coordinate_system:
                     raise CalibrationError(
                         "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
@@ -65,9 +64,8 @@ def assert_minimum_state_for_coordinate_system(
             if calibration.coordinate_system == CoordinateSystem.STAGE:
                 if stage_coordinate_system is None:
                     raise CalibrationError(
-                        "Function {} does not support the stage coordinate system.".format(
-                            func.__name__))
-
+                        "Function {} does not support the stage coordinate system.".format(func.__name__))
+                
                 if calibration.state < stage_coordinate_system:
                     raise CalibrationError(
                         "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(

--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -127,6 +127,10 @@ class Stage(ABC):
     def address_string(self) -> str:
         raise NotImplementedError
 
+    @property
+    def identifier(self) -> str:
+        raise NotImplementedError
+
     @abstractmethod
     def connect(self) -> bool:
         pass

--- a/LabExT/Movement/Stages/DummyStage.py
+++ b/LabExT/Movement/Stages/DummyStage.py
@@ -50,6 +50,10 @@ class DummyStage(Stage):
     def address_string(self) -> str:
         return self.address
 
+    @property
+    def identifier(self) -> str:
+        return self.address_string
+
     def connect(self) -> bool:
         self.connected = True
         return True

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -389,6 +389,13 @@ class Stage3DSmarAct(Stage):
     def address_string(self) -> str:
         return self.address.decode('utf-8')
 
+    @property
+    def identifier(self) -> str:
+        """
+        Returns the address as identifier for a SmartAct stage
+        """
+        return self.address_string
+
     @assert_driver_loaded
     def connect(self) -> bool:
         """Connects to stage by calling SA_OpenSystem and initializes a system handle.
@@ -491,7 +498,7 @@ class Stage3DSmarAct(Stage):
         x_speed = self.channels[Axis.X].speed
         y_speed = self.channels[Axis.Y].speed
 
-        if(x_speed != y_speed):
+        if (x_speed != y_speed):
             self._logger.info(
                 "Speed settings of x and y channel are not equal.")
 
@@ -523,7 +530,7 @@ class Stage3DSmarAct(Stage):
         x_acceleration = self.channels[Axis.X].acceleration
         y_acceleration = self.channels[Axis.Y].acceleration
 
-        if(x_acceleration != y_acceleration):
+        if (x_acceleration != y_acceleration):
             self._logger.info(
                 'Acceleration settings of x and y channel are not equal.')
 
@@ -731,7 +738,7 @@ class Stage3DSmarAct(Stage):
 
     @classmethod
     def _exit_if_error(self, status: int) -> bool:
-        if(status == MCSC.SA_OK):
+        if (status == MCSC.SA_OK):
             return True
 
         error_message = ct.c_char_p()

--- a/LabExT/View/Movement/LoadStoredCalibrationWindow.py
+++ b/LabExT/View/Movement/LoadStoredCalibrationWindow.py
@@ -176,6 +176,15 @@ class LoadStoredCalibrationWindow(Toplevel):
                     parent=self)
                 return
 
+            if _stored_calibration["stage_identifier"] != stage.identifier:
+                if not messagebox.askyesno(
+                    "Caution: Different stage identifiers",
+                    f"Confirmation needed: The selected calibration was created with a stage with the identifier '{_stored_calibration['stage_identifier']}'. "
+                    f"You are now trying to assign this calibration to the stage with the identifier '{stage.identifier}'. "
+                    "Are you sure you want to apply this calibration to this stage?",
+                        parent=self):
+                    return
+
             calibration_assignment[stage] = _stored_calibration
 
         # Apply calibrations

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -625,6 +625,7 @@ class AxesCalibrationStep(Step):
             wizard,
             self.build,
             on_reload=self.on_reload,
+            on_next=self.on_next,
             title="Stage Axes Calibration")
         self.mover: Type[MoverNew] = mover
         self.logger = getLogger()
@@ -717,6 +718,22 @@ class AxesCalibrationStep(Step):
         else:
             self.next_step_enabled = False
             self.wizard.set_error("Please do not assign a stage axis twice.")
+
+    def on_next(self) -> bool:
+        """
+        Callback, when user finishes axes calibration.
+        Stores rotation to file.
+        """
+        try:
+            self.mover.dump_axes_rotations()
+        except Exception as err:
+            messagebox.showerror(
+                "Error",
+                f"Failed to store axes rotation to file: {err}",
+                parent=self.wizard)
+            return False
+
+        return True
 
     def calibrate_axis(self, calibration: Type[Calibration], chip_axis: Axis):
         """


### PR DESCRIPTION
Adds identifiers for stages that remain the same after a LabExT restart. These are needed in #112 to distinguish settings for stages. 