### PR TITLE
[Movement v1] Safety: Check for stage identifier before restore

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -805,6 +805,7 @@ class Calibration:
         Returns a dict of all calibration properties.
         """
         calibration_dump = {
+            "stage_identifier": self.stage.identifier,
             "orientation": self.orientation.value,
             "device_port": self._device_port.value}
 

--- a/LabExT/View/Movement/LoadStoredCalibrationWindow.py
+++ b/LabExT/View/Movement/LoadStoredCalibrationWindow.py
@@ -176,6 +176,15 @@ class LoadStoredCalibrationWindow(Toplevel):
                     parent=self)
                 return
 
+            if _stored_calibration["stage_identifier"] != stage.identifier:
+                if not messagebox.askyesno(
+                    "Caution: Different stage identifiers",
+                    f"Confirmation needed: The selected calibration was created with a stage with the identifier '{_stored_calibration['stage_identifier']}'. "
+                    f"You are now trying to assign this calibration to the stage with the identifier '{stage.identifier}'. "
+                    "Are you sure you want to apply this calibration to this stage?",
+                        parent=self):
+                    return
+
             calibration_assignment[stage] = _stored_calibration
 
         # Apply calibrations


### PR DESCRIPTION
As discussed with @delmedico and @boris-vukovic in the lab, another check makes sense to see if the calibrations to be restored were made with the same stages. If this is not the case, a warning is issued and we require explicit consent from the user.