### PR TITLE
[Movement v2] Path Planning Abstraction

### DIFF
--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -602,7 +602,6 @@ class MoverNew:
                 if with_lifted_stages:
                     calibration.lift_stage(self.z_lift)
 
-                target.z = calibration.get_position().z
                 resolved_calibrations[orientation] = calibration
 
                 target.z = calibration.get_position().z

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -20,7 +20,7 @@ from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, Devic
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import ChipCoordinate, AxesRotation
-from LabExT.Movement.PathPlanning import CollisionAvoidancePlanning, SingleStagePlanning
+from LabExT.Movement.PathPlanning import PathPlanning, CollisionAvoidancePlanning, SingleStagePlanning
 
 from LabExT.Utils import get_configuration_file_path
 from LabExT.Wafer.Chip import Chip
@@ -538,6 +538,19 @@ class MoverNew:
     #   Movement Methods
     #
 
+    def get_path_planning_strategy(self) -> Type[PathPlanning]:
+        """
+        Returns a PathPlanning based on number of stages
+        """
+        if len(self.connected_stages) == 1:
+            return SingleStagePlanning(
+                max_lift_correction=100,
+                correction_tolerance=10)
+        else:
+            return CollisionAvoidancePlanning(
+                chip=self._chip,
+                abort_local_minimum=3)
+
     @assert_connected_stages
     def move_absolute(
         self,
@@ -574,7 +587,7 @@ class MoverNew:
             return
 
         with self.set_stages_coordinate_system(CoordinateSystem.CHIP):
-            path_planning = SingleStagePlanning()
+            path_planning = self.get_path_planning_strategy()
 
             # Resolves movement commands
             # Checks if for each orientation a calibration exits

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -20,7 +20,7 @@ from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, Devic
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import ChipCoordinate, AxesRotation
-from LabExT.Movement.PathPlanning import PathPlanning
+from LabExT.Movement.PathPlanning import CollisionAvoidancePlanning
 
 from LabExT.Utils import get_configuration_file_path
 from LabExT.Wafer.Chip import Chip
@@ -574,7 +574,8 @@ class MoverNew:
             return
 
         with self.set_stages_coordinate_system(CoordinateSystem.CHIP):
-            path_planning = PathPlanning(chip)
+            path_planning = CollisionAvoidancePlanning(
+                chip, abort_local_minimum=3)
 
             # Resolves movement commands
             # Checks if for each orientation a calibration exits
@@ -597,7 +598,9 @@ class MoverNew:
             # Move stages on safe trajectory
             for calibration_waypoints in path_planning.trajectory():
                 for calibration, waypoint in calibration_waypoints.items():
-                    calibration.move_absolute(waypoint, wait_for_stopping)
+                    calibration.move_absolute(
+                        coordinate=waypoint.coordinate, wait_for_stopping=(
+                            wait_for_stopping or waypoint.wait_for_stopping))
 
                 # Wait for all stages to stop if stages move simultaneously.
                 if not wait_for_stopping:

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -20,7 +20,7 @@ from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, Devic
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import ChipCoordinate, AxesRotation
-from LabExT.Movement.PathPlanning import CollisionAvoidancePlanning
+from LabExT.Movement.PathPlanning import CollisionAvoidancePlanning, SingleStagePlanning
 
 from LabExT.Utils import get_configuration_file_path
 from LabExT.Wafer.Chip import Chip
@@ -574,8 +574,7 @@ class MoverNew:
             return
 
         with self.set_stages_coordinate_system(CoordinateSystem.CHIP):
-            path_planning = CollisionAvoidancePlanning(
-                chip, abort_local_minimum=3)
+            path_planning = SingleStagePlanning()
 
             # Resolves movement commands
             # Checks if for each orientation a calibration exits
@@ -590,6 +589,7 @@ class MoverNew:
                 if with_lifted_stages:
                     calibration.lift_stage(self.z_lift)
 
+                target.z = calibration.get_position().z
                 resolved_calibrations[orientation] = calibration
 
                 target.z = calibration.get_position().z

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -551,9 +551,9 @@ class SingleStagePlanning(PathPlanning):
         Parameters
         ----------
         max_lift_correction: float = 100 [um]
-            TODO
+            Upper limit for z level correction.
         correction_tolerance: float = 10 [um]
-            TODO
+            Additional correction: Will be added to the delta of the Z-level.
         """
         super().__init__()
         self.max_lift_correction = max_lift_correction
@@ -586,15 +586,6 @@ class SingleStagePlanning(PathPlanning):
             self.start_chip_coordinate = self.calibration.get_position()
 
         self.target_chip_coordinate = target
-
-        if not np.isclose(
-                self.start_chip_coordinate.z,
-                self.target_chip_coordinate.z,
-                rtol=1.e-5,
-                atol=10e-3):
-            raise ValueError(
-                f"Start z level {self.start_chip_coordinate.z} is not close to target z level {self.target_chip_coordinate.z}. "
-                "The Path Planning algorithm assumes that start and target are on the same z level.")
 
         self.start_stage_coordinate = calibration.transform_chip_to_stage_coordinate(
             chip_coordinate=self.start_chip_coordinate)

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -475,8 +475,7 @@ class CollisionAvoidancePlanning(PathPlanning):
 
                 next_move[calibration] = potential_field.next_waypoint()
 
-            if self._last_moves_equal(
-                    self.last_moves[-self.abort_local_minimum:], next_move):
+            if self._last_waypoints_equal(next_move):
                 raise PathPlanningError(
                     f"Path-finding algorithm makes no progress. The last {self.abort_local_minimum} movements were identical!")
 
@@ -517,23 +516,21 @@ class CollisionAvoidancePlanning(PathPlanning):
 
         return grid_size, outline
 
-    def _last_moves_equal(self, last_moves: list, new_move: dict) -> bool:
+    def _last_waypoints_equal(self, next_command: WaypointCommand) -> bool:
         """
         Returns True if all last moves are equal to the new move.
 
         Parameters
         ----------
-        last_moves: list
-            List of last moves
-        new_moves: dict
-            Dict of the new move
+        next_command: WaypointCommand
+            next waypoint commands
         """
-        if len(last_moves) == 0:
+        if len(self.last_moves) == 0:
             return False
 
-        for last_move in last_moves:
+        for last_move in self.last_moves[-self.abort_local_minimum:]:
             for calibration, waypoint in last_move.items():
-                if new_move[calibration] != waypoint:
+                if next_command[calibration].coordinate != waypoint.coordinate:
                     return False
 
         return True

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -534,3 +534,132 @@ class CollisionAvoidancePlanning(PathPlanning):
                     return False
 
         return True
+
+
+class SingleStagePlanning(PathPlanning):
+    """
+    Path planning for single stage movements.
+    """
+
+    def __init__(
+        self,
+        max_lift_correction: float = 100,
+        correction_tolerance: float = 10
+    ) -> None:
+        """
+        Constructor for the single stage path planning.
+        Parameters
+        ----------
+        max_lift_correction: float = 100 [um]
+            TODO
+        correction_tolerance: float = 10 [um]
+            TODO
+        """
+        super().__init__()
+        self.max_lift_correction = max_lift_correction
+        self.correction_tolerance = correction_tolerance
+
+        self.calibration = None
+
+        self.target_chip_coordinate = None
+        self.target_stage_coordinate = None
+
+        self.start_chip_coordinate = None
+        self.start_stage_coordinate = None
+
+    def set_stage_target(
+        self,
+        calibration: Type["Calibration"],
+        target: Type[ChipCoordinate]
+    ) -> None:
+        """
+        Sets the traget coordinate for given calibrations.
+        """
+        if self.calibration is not None:
+            raise PathPlanningError(
+                "A calibration and target coordinate is already set. This Path Planning does support only one stage.")
+
+        self.calibration = calibration
+
+        # Get current stage position in chip system
+        with self.calibration.perform_in_system(CoordinateSystem.CHIP):
+            self.start_chip_coordinate = self.calibration.get_position()
+
+        self.target_chip_coordinate = target
+
+        if not np.isclose(
+                self.start_chip_coordinate.z,
+                self.target_chip_coordinate.z,
+                rtol=1.e-5,
+                atol=10e-3):
+            raise ValueError(
+                f"Start z level {self.start_chip_coordinate.z} is not close to target z level {self.target_chip_coordinate.z}. "
+                "The Path Planning algorithm assumes that start and target are on the same z level.")
+
+        self.start_stage_coordinate = calibration.transform_chip_to_stage_coordinate(
+            chip_coordinate=self.start_chip_coordinate)
+        self.target_stage_coordinate = calibration.transform_chip_to_stage_coordinate(
+            chip_coordinate=self.target_chip_coordinate)
+
+    def trajectory(self) -> Generator[WaypointCommand, Any, Any]:
+        """
+        Calculates waypoints for a simple stage from start to finish as a generator.
+        Checks beforehand whether the current z-lift is sufficient to compensate for the chip inclination without danger.
+        If not, the stage is first moved upwards and then lowered again.
+        """
+        z_level_correction = self._z_level_correction()
+        for waypoint in [
+            Waypoint(
+                self.calibration,
+                ChipCoordinate(
+                    x=self.start_chip_coordinate.x,
+                    y=self.start_chip_coordinate.y,
+                    z=self.start_chip_coordinate.z +
+                    z_level_correction),
+                wait_for_stopping=True),
+            Waypoint(
+                self.calibration,
+                ChipCoordinate(
+                    x=self.target_chip_coordinate.x,
+                    y=self.target_chip_coordinate.y,
+                    z=self.target_chip_coordinate.z +
+                    z_level_correction),
+                wait_for_stopping=True),
+            Waypoint(
+                self.calibration,
+                self.target_chip_coordinate,
+                wait_for_stopping=True)]:
+            yield {
+                self.calibration: waypoint}
+
+    def _z_level_correction(self) -> float:
+        """
+        Calculates a new z-level height.
+        If the current lift of the stage is lower than the Z difference between the start and target,
+        we are in danger of driving into the chip.
+        We calculate a z level equal to the delta in Z between the start and target plus tolerance.
+        The height is limited upwards by max_lift_correction
+        Returns
+        ------
+        z_correction : float
+            New z level height
+        Raises
+        ------
+        PathPlanningError
+            If new z level height is greater than max_lift_correction
+        """
+        start_target_z_delta = np.ceil(np.abs(
+            self.target_stage_coordinate.z - self.start_stage_coordinate.z))
+
+        self.logger.debug(
+            f"[{self.calibration}] Z-delta between start and target: {start_target_z_delta} um")
+
+        z_correction = start_target_z_delta + self.correction_tolerance
+        self.logger.debug(
+            f"[{self.calibration}] Calculated z correction of {z_correction} (Tolerance: {self.correction_tolerance})")
+
+        if z_correction > self.max_lift_correction:
+            raise PathPlanningError(
+                f"Correction lift of {z_correction} exceed max lift correction of {self.max_lift_correction}")
+
+        return z_correction


### PR DESCRIPTION
Introduction of an interface for path planning in the Mover.

## The interface is defined by:
- `set_stage_target`: Given a calibration instance and a chip coordinate as a target, we define which calibration has which target.
- `trajectory`: Generator that iteratively creates a waypoint command. Why generator: Generators are more general than simple lists, and allow the calculation of waypoints that are not yet known at the time of the call. The `CollisionAvoidancePlanning` with potential field (previously `PathPlanning`) uses this. 

Furthermore, `PathPlanning` has been renamed `CollisionAvoidancePlanning`. The algorithm is the same.

## Introduction of a waypoint tuple:
The `Waypoint` NamedTuple defines the calibration, coordinate, and `wait_for_stopping` for a calculated waypoint. Not really a big change than before, except that we get more unity within the class. With `wait_for_stopping` we can tell the stages that they should wait for this waypoint to be executed.

## Introduction of a type alias:
`WaypointCommand` is a type alias for a dict from `Calibration` to `Waypoint`. This dict is to be created by the generator in each step and specifies which calibration is to be run to which waypoint.
The introduction should provide unity.