### PR TITLE
[Movement v2] Plane angle

### DIFF
--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -919,6 +919,14 @@ class CoordinatePairingStep(Step):
                 pady=2,
                 sticky=W)
 
+            if calibration._kabsch_rotation.is_valid:
+                rad, deg, per = calibration._kabsch_rotation.get_z_plane_angles()
+                Label(
+                    stage_calibration_frame,
+                    text="Angle between XY Plane: "
+                    "{:.2f} rad - {:.2f}° - {:.2f}%".format(rad, deg, per)
+                ).grid(row=2, column=1, padx=2, pady=2, sticky=W)
+
         # FRAME FOR NEW PAIRING
         new_pairing_frame = CustomFrame(frame)
         new_pairing_frame.title = "Create New Pairing"


### PR DESCRIPTION
Adds the angle between the chip plane and the XY plane in the calibration window. The angle is given in radians, degrees and percentages.

<img width="1297" alt="Screenshot 2022-12-02 at 23 54 21" src="https://user-images.githubusercontent.com/14354617/205403600-c6c7394f-d6ca-48ea-9bdc-e8ed32b4cc9d.png">
