### PR TITLE
[Movement v2] Fix device description overflow in coordinate pairing table

### DIFF
--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -872,11 +872,13 @@ class CoordinatePairingStep(Step):
                 'Stage Cooridnate',
                 'Device',
                 'Chip Coordinate'),
-            rows=[
-                (idx,
-                 ) + p for idx,
-                p in enumerate(
-                    self.pairings)])
+            rows=[(
+                str(idx),
+                str(p.calibration),
+                str(p.stage_coordinate),
+                str(p.device.short_str),
+                str(p.chip_coordinate)
+            ) for idx, p in enumerate(self.pairings)])
 
         # Render frame to show current calibration state
         calibration_summary_frame = CustomFrame(frame)

--- a/LabExT/Wafer/Device.py
+++ b/LabExT/Wafer/Device.py
@@ -35,6 +35,12 @@ class Device:
     type: str = ''
     parameters: dict = field(default_factory=dict)
 
+    @property
+    def short_str(self) -> str:
+        """ Return string representation for device """
+        return "ID {} - IN: {} OUT: {}".format(
+            self.id, self.input_coordinate, self.output_coordinate)
+
     def as_dict(self):
         """ Return device as a dictionary. """
         return asdict(self)


### PR DESCRIPTION
Fixes the error that the string representation of a device in the Coordinate Pairing Table is too long. This has now been replaced by a shorter string.