### PR TITLE
Remove lifting and lowering on stage level

### DIFF
--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -168,18 +168,6 @@ class Stage(ABC):
         pass
 
     @abstractmethod
-    def wiggle_z_axis_positioner(self):
-        pass
-
-    @abstractmethod
-    def lift_stage(self):
-        pass
-
-    @abstractmethod
-    def lower_stage(self):
-        pass
-
-    @abstractmethod
     def get_current_position(self):
         pass
 

--- a/LabExT/Movement/Stages/DummyStage.py
+++ b/LabExT/Movement/Stages/DummyStage.py
@@ -40,8 +40,6 @@ class DummyStage(Stage):
         self._speed_xy = None
         self._speed_z = None
         self._acceleration_xy = None
-        self._z_lift = None
-        self._z_axis_direction = 1
 
     def __str__(self) -> str:
         return "Dummy Stage at {}".format(self.address_string)
@@ -61,27 +59,6 @@ class DummyStage(Stage):
     def disconnect(self) -> bool:
         self.connected = False
         return True
-
-    @property
-    def z_axis_direction(self):
-        return self._z_axis_direction
-
-    @property
-    def z_axis_inverted(self):
-        return self.z_axis_direction == -1
-
-    @z_axis_direction.setter
-    def z_axis_direction(self, newdir):
-        if newdir not in [-1, 1]:
-            raise ValueError("Z axis direction can only be 1 or -1.")
-        self._z_axis_direction = newdir
-
-    def toggle_z_axis_direction(self):
-        self.z_axis_direction *= -1
-
-    @property
-    def z_axis_inverted(self):
-        return self.z_axis_direction == -1
 
     def set_speed_xy(self, umps: float):
         self._speed_xy = umps
@@ -107,21 +84,6 @@ class DummyStage(Stage):
     @property
     def is_stopped(self) -> bool:
         return all(s == 'STOP' for s in self.get_status())
-
-    def wiggle_z_axis_positioner(self):
-        pass
-
-    def lift_stage(self):
-        pass
-
-    def lower_stage(self):
-        pass
-
-    def set_lift_distance(self, um: float):
-        self._z_lift = um
-
-    def get_lift_distance(self) -> float:
-        return self._z_lift
 
     def get_current_position(self):
         return [0, 0]

--- a/LabExT/Tests/Movement/PiezoStage_test.py
+++ b/LabExT/Tests/Movement/PiezoStage_test.py
@@ -64,14 +64,6 @@ class Test_PiezoStage(unittest.TestCase):
         # reset stage speed
         self.stage.set_acceleration_xy(xy_acc)
 
-    def test_params(self):
-        # z-axis direction
-        self.stage.z_axis_direction = 1
-        self.assertEqual(1, self.stage.z_axis_direction)
-
-        self.stage.z_axis_direction = -1
-        self.assertEqual(-1, self.stage.z_axis_direction)
-
     def test_current_position(self):
 
         pos = self.stage.get_current_position()
@@ -99,32 +91,4 @@ class Test_PiezoStage(unittest.TestCase):
             if self.user_input_required:
                 self.assertTrue(ask_user_yes_no(f"Has the Piezo-Stage moved to absolute position {positions[i, :] * 1e3}?",
                                                 default_answer=True))
-
-    def test_lower_lift_stage(self):
-
-        pos0 = self.stage.get_current_position()
-        z_lift_0 = self.stage.get_lift_distance()
-        lift = 1000
-        self.stage.set_speed_z(500)
-        # user has to set the correct z axis direction here
-        self.stage.z_axis_direction = self.z_axis_direction
-
-        self.stage.set_lift_distance(lift)
-        self.stage.lift_stage()
-        if self.user_input_required:
-            self.assertTrue(ask_user_yes_no(f"Has the stage moved up by {lift}um"))
-
-        self.stage.lower_stage()
-
-        if self.user_input_required:
-            self.assertTrue(ask_user_yes_no(f"Has the stage lowered down by {lift}um"))
-
-    def test_wiggle_z_axis_positioner(self):
-
-        self.stage.wiggle_z_axis_positioner()
-        # user has to set the correct z axis direction here
-        self.stage.z_axis_direction = self.z_axis_direction
-
-        if self.user_input_required:
-            self.assertTrue(ask_user_yes_no("Has the stage wiggled (first up then down or vice versa?)"))
 


### PR DESCRIPTION
Lifting, lowering and axis invert is now the responsibility of the a Calibration. This PR removes the legacy support to lift, lower stages on Stage level.