### PR TITLE
Allow to calibrate stages after connection

### DIFF
--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -516,6 +516,10 @@ class MainWindowController:
         """ opens search for peak window by calling appropriate menu listener function """
         self.view.frame.menu_listener.client_search_for_peak()
 
+    def open_stage_calibration(self):
+        """ opens window to calibrate stages """
+        self.view.frame.menu_listener.client_calibrate_stage()
+
     def start(self):
         """Calls the experiment handler to start the experiment.
         """

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -201,7 +201,10 @@ class MListener:
         if try_to_lift_window(self.stage_setup_toplevel):
             return
         
-        self.stage_setup_toplevel = StageWizard(self._root, self._experiment_manager.mover)
+        self.stage_setup_toplevel = StageWizard(
+            self._root,
+            self._experiment_manager.mover,
+            experiment_manager=self._experiment_manager)
 
     def client_setup_mover(self):
         """

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -31,7 +31,7 @@ class StageWizard(Wizard):
     Wizard to load stage drivers and connect to stages.
     """
 
-    def __init__(self, master, mover):
+    def __init__(self, master, mover, experiment_manager=None):
         """
         Constructor for new Stage Wizard.
 
@@ -41,6 +41,8 @@ class StageWizard(Wizard):
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
+        experiment_manager : ExperimentManager = None
+            Optional instance of the current experiment manager
         """
         super().__init__(
             master,
@@ -54,6 +56,8 @@ class StageWizard(Wizard):
         )
         self.title("Configure Mover")
         self.mover: Type[MoverNew] = mover
+
+        self.experiment_manager = experiment_manager
 
         self.load_driver_step = StageDriverStep(self, self.mover)
         self.stage_assignment_step = StageAssignmentStep(self, self.mover)
@@ -92,10 +96,20 @@ class StageWizard(Wizard):
                     parent=self)
                 return False
 
-        messagebox.showinfo(
-            "Stage Setup completed.",
-            f"Successfully connected to {len(self.stage_assignment_step.assignment)} stage(s).",
-            parent=self)
+        if not self.experiment_manager:
+            messagebox.showinfo(
+                "Stage Setup completed.",
+                f"Successfully connected to {len(self.stage_assignment_step.assignment)} stage(s).",
+                parent=self)
+        else:
+            if messagebox.askyesnocancel(
+                "Stage Setup completed.",
+                f"Successfully connected to {len(self.stage_assignment_step.assignment)} stage(s)."
+                "Do you want to calibrate the stages now?",
+                    parent=self):
+                self.destroy()
+
+                self.experiment_manager.main_window.open_stage_calibration()
 
         return True
 


### PR DESCRIPTION
After successfully connecting the stages, asks the user if he wants to continue with the calibration of the stages.