### PR TITLE
Update workflow for stage calibration when Chip is not imported

### DIFF
--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -508,6 +508,10 @@ class MainWindowController:
             return
         self.experiment_manager.import_chip(chip_path, chip_name)
 
+    def open_import_chip(self):
+        """ opens window to import new chip """
+        self.view.frame.menu_listener.client_import_chip()
+
     def open_live_viewer(self):
         """ opens live-viewer window by calling appropriate menu listener function """
         self.view.frame.menu_listener.client_live_view()


### PR DESCRIPTION
Currently we do not allow to open the Stage Calibration Wizard if no chip has been imported.
In particular, this does not allow you to adjust the axes, which does not require a chip.

The changes introduce an extra frame in the coordinate pairing step that shows the currently imported chip, which gives more information. If the chip is missing, we provide a shortcut to import a chip. The wizard will then be reloaded. If no chip has been imported, no coordinate pairings can be created. The buttons are therefore deactivated.

Without imported chip:
<img width="1299" alt="Screenshot 2022-12-07 at 16 18 08" src="https://user-images.githubusercontent.com/14354617/206217988-d2d3a4ec-edc9-4ee3-a2d5-5b0e5c683987.png">

With imported chip:
<img width="1299" alt="Screenshot 2022-12-07 at 16 18 18" src="https://user-images.githubusercontent.com/14354617/206218043-b70def81-934d-4998-a224-b27a85ed2605.png">
