### PR TITLE
Allow to store and restore stage polygons

### DIFF
--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -58,7 +58,7 @@ class StagePolygon(ABC):
         if not polygon_name:
             raise ValueError(
                 "Cannot find and load stage polygon without polygon class name. "
-                "Please provide a key 'polygon_cls' in polygon data.")
+                "Please provide a key 'polygon_cls' in polygon_data argument.")
 
         if (isinstance(polygon_name, type) and
                 issubclass(polygon_name, StagePolygon)):
@@ -84,8 +84,8 @@ class StagePolygon(ABC):
             orientation = Orientation[polygon_data["orientation"]]
         except KeyError as err:
             raise ValueError(
-                f"The parameter is not defined: {err}. "
-                "Make sure to pass a valid orientation.")
+                f"The parameter 'orientation' in polygon_data is not defined: {err}. "
+                f"Make sure to pass a valid orientation: {', '.join(map(str, list(Orientation)))}")
 
         return polygon_cls(
             orientation=orientation,
@@ -158,7 +158,6 @@ class SingleModeFiber(StagePolygon):
     Polygon for single mode fiber.
     """
 
-<<<<<<< HEAD
     @classmethod
     def get_default_parameters(cls) -> Dict[str, Any]:
         """
@@ -169,39 +168,6 @@ class SingleModeFiber(StagePolygon):
             "Fiber Radius": 75.0,       # [um]
             "Safety Distance": 75.0     # [um]
         }
-||||||| parent of 709863a (Make polygons configurable)
-    FIBER_LENGTH = 8e4  # [um] (8cm)
-    FIBER_RADIUS = 75.0  # [um]
-
-    def __init__(
-        self,
-        orientation: Orientation,
-        safety_distance: float = 75.0
-    ) -> None:
-        """
-        Constructor for new single mode fiber polygon.
-
-        Parameters
-        ----------
-        orientation: Orientation
-            Orientation of the stage in space
-        safety_distance: float
-            Safety distance around the fiber in um.
-        """
-        self.orientation = orientation
-        self.safety_distance = safety_distance
-=======
-    @classmethod
-    def get_default_parameters(cls) -> Dict[str, Any]:
-        """
-        Returns default parameter to set up a single mode fiber polygon
-        """
-        return {
-            "Fiber Length": 8e4,        # [um] (8cm)
-            "Fiber Radius": 75.0,       # [um]
-            "Safety Distance": 75.0     # [um]
-        }
->>>>>>> 709863a (Make polygons configurable)
 
     def stage_in_meshgrid(
         self,

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -129,6 +129,9 @@ class SingleModeFiber(StagePolygon):
 =======
     @classmethod
     def get_default_parameters(cls) -> Dict[str, Any]:
+        """
+        Returns default parameter to set up a single mode fiber polygon
+        """
         return {
             "Fiber Length": 8e4,        # [um] (8cm)
             "Fiber Radius": 75.0,       # [um]

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -60,11 +60,8 @@ class StagePolygon(ABC):
                 "Cannot find and load stage polygon without polygon class name. "
                 "Please provide a key 'polygon_cls' in polygon data.")
 
-        if isinstance(
-                polygon_name,
-                type) and issubclass(
-                polygon_name,
-                StagePolygon):
+        if (isinstance(polygon_name,type) and
+            issubclass(polygon_name, StagePolygon)):
             polygon_cls = polygon_name
         elif isinstance(polygon_name, str):
             available_classes = StagePolygon.find_polygon_classes()
@@ -141,12 +138,17 @@ class StagePolygon(ABC):
         """
         pass
 
-    def dump(self) -> dict:
+    def dump(self, stringify: bool = True) -> dict:
         """
         Returns polygon parameters as dict
         """
+        if stringify:
+            polygon_cls = self.__class__.__name__
+        else:
+            polygon_cls = self.__class__
+
         return {
-            "polygon_cls": self.__class__.__name__,
+            "polygon_cls": polygon_cls,
             "orientation": self.orientation.value,
             "parameters": self.parameters}
 

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -60,8 +60,8 @@ class StagePolygon(ABC):
                 "Cannot find and load stage polygon without polygon class name. "
                 "Please provide a key 'polygon_cls' in polygon data.")
 
-        if (isinstance(polygon_name,type) and
-            issubclass(polygon_name, StagePolygon)):
+        if (isinstance(polygon_name, type) and
+                issubclass(polygon_name, StagePolygon)):
             polygon_cls = polygon_name
         elif isinstance(polygon_name, str):
             available_classes = StagePolygon.find_polygon_classes()
@@ -259,9 +259,9 @@ class SingleModeFiber(StagePolygon):
         ValueError
             If no outline is defined for the given orientation.
         """
-        fiber_radius = self.parameters.get("Fiber Radius", 75.0)
-        fiber_length = self.parameters.get("Fiber Length", 8e4)
-        safety_distance = self.parameters.get("Safety Distance", 75.0)
+        fiber_radius = float(self.parameters.get("Fiber Radius", 75.0))
+        fiber_length = float(self.parameters.get("Fiber Length", 8e4))
+        safety_distance = float(self.parameters.get("Safety Distance", 75.0))
 
         safe_fiber_radius = fiber_radius + safety_distance
 

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -4,6 +4,7 @@
 LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
+from __future__ import annotations
 
 import logging
 import numpy as np
@@ -49,6 +50,58 @@ class StagePolygon(ABC):
     """
 
     @classmethod
+    def load(cls, polygon_data: dict) -> Type[StagePolygon]:
+        """
+        Returns a stage polygon reconstructed from polygon data.
+        """
+        polygon_name = polygon_data.get("polygon_cls")
+        if not polygon_name:
+            raise ValueError(
+                "Cannot find and load stage polygon without polygon class name. "
+                "Please provide a key 'polygon_cls' in polygon data.")
+
+        if isinstance(
+                polygon_name,
+                type) and issubclass(
+                polygon_name,
+                StagePolygon):
+            polygon_cls = polygon_name
+        elif isinstance(polygon_name, str):
+            available_classes = StagePolygon.find_polygon_classes()
+            try:
+                polygon_cls = next(
+                    pg for pg in available_classes if pg.__name__ == polygon_name)
+            except StopIteration:
+                available_classes_str = ", ".join(
+                    map(lambda pg: pg.__name__, available_classes))
+                raise ValueError(
+                    f"No polygon class found with name {polygon_name}. The following are available: "
+                    f"{available_classes_str}")
+        else:
+            raise ValueError(
+                f"Cannot restore stage polygon class with 'polygon_cls' equal to {polygon_name} of type {type(polygon_name)}. "
+                "Please provide a value for 'polygon_cls' of type str or StagePolygon. "
+                "If you provide a string, it must be the name of the polygon class.")
+
+        try:
+            orientation = Orientation[polygon_data["orientation"]]
+        except KeyError as err:
+            raise ValueError(
+                f"The parameter is not defined: {err}. "
+                "Make sure to pass a valid orientation.")
+
+        return polygon_cls(
+            orientation=orientation,
+            parameters=polygon_data.get("parameters", {}))
+
+    @classmethod
+    def find_polygon_classes(cls) -> List[StagePolygon]:
+        """
+        Returns a list of available polygon classes.
+        """
+        return cls.__subclasses__()
+
+    @classmethod
     def get_default_parameters(cls) -> Dict[str, Any]:
         """
         Returns default polygon configuration parameter
@@ -72,7 +125,7 @@ class StagePolygon(ABC):
         self.orientation = orientation
 
         self.parameters = parameters
-        if self.parameters is None:
+        if not self.parameters:
             self.parameters = self.get_default_parameters()
 
     @abstractmethod
@@ -87,6 +140,15 @@ class StagePolygon(ABC):
         Returns a mask if a point in the meshgrid is in the stage.
         """
         pass
+
+    def dump(self) -> dict:
+        """
+        Returns polygon parameters as dict
+        """
+        return {
+            "polygon_cls": self.__class__.__name__,
+            "orientation": self.orientation.value,
+            "parameters": self.parameters}
 
 
 class SingleModeFiber(StagePolygon):

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -94,6 +94,7 @@ class SingleModeFiber(StagePolygon):
     Polygon for single mode fiber.
     """
 
+<<<<<<< HEAD
     @classmethod
     def get_default_parameters(cls) -> Dict[str, Any]:
         """
@@ -104,6 +105,36 @@ class SingleModeFiber(StagePolygon):
             "Fiber Radius": 75.0,       # [um]
             "Safety Distance": 75.0     # [um]
         }
+||||||| parent of 709863a (Make polygons configurable)
+    FIBER_LENGTH = 8e4  # [um] (8cm)
+    FIBER_RADIUS = 75.0  # [um]
+
+    def __init__(
+        self,
+        orientation: Orientation,
+        safety_distance: float = 75.0
+    ) -> None:
+        """
+        Constructor for new single mode fiber polygon.
+
+        Parameters
+        ----------
+        orientation: Orientation
+            Orientation of the stage in space
+        safety_distance: float
+            Safety distance around the fiber in um.
+        """
+        self.orientation = orientation
+        self.safety_distance = safety_distance
+=======
+    @classmethod
+    def get_default_parameters(cls) -> Dict[str, Any]:
+        return {
+            "Fiber Length": 8e4,        # [um] (8cm)
+            "Fiber Radius": 75.0,       # [um]
+            "Safety Distance": 75.0     # [um]
+        }
+>>>>>>> 709863a (Make polygons configurable)
 
     def stage_in_meshgrid(
         self,

--- a/LabExT/Tests/Movement/PathPlanning_test.py
+++ b/LabExT/Tests/Movement/PathPlanning_test.py
@@ -12,7 +12,7 @@ from parameterized import parameterized
 
 from LabExT.Movement.config import Orientation
 from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.PathPlanning import SingleModeFiber
+from LabExT.Movement.PathPlanning import SingleModeFiber, StagePolygon
 
 
 class SingleModeFiberTest(TestCase):
@@ -105,3 +105,71 @@ class SingleModeFiberTest(TestCase):
             ChipCoordinate(0, 0, 0), cx, cy, grid_size)
 
         self.assertTrue(mask.any())
+
+    def test_dump_with_stringify(self):
+        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+            "Fiber Radius": 100.0,
+            "Safety Distance": 100.0,
+            "Fiber Length": 10e4
+        })
+
+        self.assertDictEqual(polygon.dump(stringify=True), {
+            "polygon_cls": "SingleModeFiber",
+            "orientation": "LEFT",
+            "parameters": {
+                "Fiber Radius": 100.0,
+                "Safety Distance": 100.0,
+                "Fiber Length": 10e4
+            }
+        })
+
+    def test_dump_without_stringify(self):
+        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+            "Fiber Radius": 100.0,
+            "Safety Distance": 100.0,
+            "Fiber Length": 10e4
+        })
+
+        self.assertDictEqual(polygon.dump(stringify=False), {
+            "polygon_cls": SingleModeFiber,
+            "orientation": "LEFT",
+            "parameters": {
+                "Fiber Radius": 100.0,
+                "Safety Distance": 100.0,
+                "Fiber Length": 10e4
+            }
+        })
+
+    def test_dump_load_with_stringify(self):
+        polygon_org = SingleModeFiber(Orientation.LEFT, parameters={
+            "Fiber Radius": 100.0,
+            "Safety Distance": 100.0,
+            "Fiber Length": 10e4
+        })
+
+        polygon_reconstructed = StagePolygon.load(
+            polygon_data=polygon_org.dump(stringify=True))
+
+        self.assertIsInstance(
+            polygon_reconstructed, SingleModeFiber)
+        self.assertDictEqual(
+            polygon_org.parameters, polygon_reconstructed.parameters)
+        self.assertEqual(
+            polygon_org.orientation, polygon_org.orientation)
+
+    def test_dump_load_without_stringify(self):
+        polygon_org = SingleModeFiber(Orientation.LEFT, parameters={
+            "Fiber Radius": 100.0,
+            "Safety Distance": 100.0,
+            "Fiber Length": 10e4
+        })
+
+        polygon_reconstructed = StagePolygon.load(
+            polygon_data=polygon_org.dump(stringify=False))
+
+        self.assertIsInstance(
+            polygon_reconstructed, SingleModeFiber)
+        self.assertDictEqual(
+            polygon_org.parameters, polygon_reconstructed.parameters)
+        self.assertEqual(
+            polygon_org.orientation, polygon_org.orientation)


### PR DESCRIPTION
This PR allows to save and restore polygons on the hard disk. Polygons are now saved in the calibration data.

Why do I save the orientation in the polygon: This is already a design change for a later PR. The orientation is not used anywhere except for the stage polygons. Therefore, I think they are better off as parameters for polygons than as parameters in the calibrations. I will discuss this in a later PR.