### PR TITLE
Introduce property to turn on and off live position updates

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -251,6 +251,16 @@ class Calibration:
         """
         return self._is_lifted
 
+    @property
+    def supports_live_position(self) -> bool:
+        """
+        Returns True if stage supports live position.
+        """
+        if not self.stage:
+            return False
+
+        return self.stage.live_position_refreshing_rate > 0
+
     #
     #   Coordinate System Control
     #

--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -62,6 +62,8 @@ class Stage(ABC):
     driver_loaded = False
     meta = StageMeta("", False)
 
+    live_position_refreshing_rate: int = -1
+
     @classmethod
     def find_stage_classes(cls, subdir="Stages") -> list:
         """

--- a/LabExT/Movement/Stages/DummyStage.py
+++ b/LabExT/Movement/Stages/DummyStage.py
@@ -23,6 +23,8 @@ class DummyStage(Stage):
         driver_specifiable=False
     )
 
+    live_position_refreshing_rate = -1
+
     @classmethod
     def find_stage_addresses(cls):
         return [

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -58,6 +58,8 @@ class Stage3DSmarAct(Stage):
         driver_specifiable=True
     )
 
+    live_position_refreshing_rate = 1000
+
     @classmethod
     def load_driver(cls, parent) -> bool:
         """

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -27,7 +27,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
         available_stages_mock.return_value = []
         stage_classes_mock.return_value = []
 
-        self.device = Device("101", [0,0], [1,1], "My Device 1")
+        self.device = Device("101", [0, 0], [1, 1], "My Device 1")
         self.chip = Chip("My Chip", [self.device])
         self.mover = MoverNew(None)
 
@@ -35,6 +35,8 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
         self.stage_2 = Mock(spec=Stage)
         self.stage_1.connected = True
         self.stage_2.connected = True
+        self.stage_2.live_position_refreshing_rate = -1
+        self.stage_1.live_position_refreshing_rate = -1
 
         self.stage_1_position = [23744.60, -9172.55, 18956.10]
         self.stage_2_position = [23236.35, -7888.67, 18956.06]

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -84,7 +84,7 @@ class CoordinatePairingsWindow(Toplevel):
 
         # Set up window
         self.title("New Chip-Stage-Coordinates Pairings")
-        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1000, 600, 200, 200))
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1100, 600, 200, 200))
         self.protocol('WM_DELETE_WINDOW', self.cancel)
 
         # Build window
@@ -165,6 +165,11 @@ class CoordinatePairingsWindow(Toplevel):
             self._calibration_pairing_widget(
                 frame, self.mover.output_calibration).pack(
                 side=TOP, fill=X)
+
+        position_hint = Label(
+            frame, text="When you click on 'Finish' to save the pairing, "
+            "the stage position is reread to guarantee the most current position of the stage.")
+        position_hint.pack(side=TOP, fill=X, pady=5)
 
         if self.experiment_manager:
             shortcuts_frame = CustomFrame(self._main_frame)


### PR DESCRIPTION
Added class property `live_position_refreshing_rate` to Stages to turn on and off live positions. Any int greater than 0 will turn on the feature.

Goal: To avoid overloading an older stage, the refreshing rate should first be adaptable to the stage and, if necessary, be completely switchable off.