### PR TITLE
Enable Swept Parameters

### DIFF
--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
@@ -272,7 +272,8 @@ class EditMeasurementWizardView:
         stage_frame.grid(row=stage, column=0, padx=5, pady=5, sticky='we')
 
         self.s3_measurement_param_table = ParameterTable(stage_frame,
-                                                         store_callback=self.model.s1_measurement.store_new_param)
+                                                         store_callback=self.model.s1_measurement.store_new_param,
+                                                         show_sweep_column=True)
         self.s3_measurement_param_table.title = 'Parameters of ' + str(self.model.s1_measurement.name)
         self.s3_measurement_param_table.parameter_source = self.model.s1_measurement.get_default_parameter()
         stage_frame.add_widget(self.s3_measurement_param_table, row=0, column=0, padx=5, pady=5, sticky='we')

--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
@@ -6,7 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import logging
-from tkinter import Toplevel, Button, StringVar, OptionMenu, Label
+from tkinter import Toplevel, Button, StringVar, OptionMenu, Label, TclError
 
 from LabExT.View.Controls.AdhocDeviceFrame import AdhocDeviceFrame
 from LabExT.View.Controls.CustomFrame import CustomFrame
@@ -48,7 +48,10 @@ class WizardScrollableFrame(ScrollableFrame):
         self._unbound_to_mousewheel(None)
 
     def _on_mousewheel(self, event):
-        self.canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        try:
+            self.canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        except TclError:
+            self.unbound_mouse_wheel()
 
 
 class EditMeasurementWizardView:


### PR DESCRIPTION
# Goal
Enable automated generation of multiple ToDos for sweeping parameters. No need for Meta-Measurements!

# Approach
Code was added that within the EditMeasurementWizard, new GUI elements allow setting-up any nummerical parameter for sweeping. Each parameter point then creates its own ToDo. The measurement records 
given by this ToDo include an additional field in the output data which includes information about the swept parameter settings.

# Implementation
tbd

# Compatibility
Code should not raise any compatibility issues. 
