### PR TITLE
Quality-of-life improvements for Keysight Laser / OPM

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -7,6 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import json
 import logging
+import shutil
 import webbrowser
 from os.path import isfile, dirname, join
 from threading import Thread
@@ -232,10 +233,7 @@ class ExperimentManager:
         """ Makes sure that a default set of instrument configuration is present in the LabExT config dir """
         instr_config_path = get_configuration_file_path('instruments.config')
         if not isfile(instr_config_path):
-            with open(join(dirname(__file__), 'Instruments', 'instruments.config.default'), 'r') as fp:
-                cfg_data = json.load(fp)
-            with open(instr_config_path, 'w') as fp:
-                json.dump(cfg_data, fp)
+            shutil.copy(join(dirname(__file__), 'Instruments', 'instruments.config.default'), instr_config_path)
             return True
         else:
             return False

--- a/LabExT/Instruments/LaserMainframeKeysight.py
+++ b/LabExT/Instruments/LaserMainframeKeysight.py
@@ -20,6 +20,8 @@ class LaserMainframeKeysight(Instrument):
     This class provides an interface to a Keysight 816x laser mainframe. Aside from the basic instrument properties,
     methods for swept wavelength measurements are included, see Keysight App Note 5992-1125EN.pdf.
 
+    This class is verified to work on the Keysight 8164A mainframe as well as the Keysight N7776C and N7778C lasers.
+
     #### Properties
 
     handbook page refers to: Keysight 8164A/B Lightwave Measurement System Programming Guide (9018-01647.pdf)
@@ -63,9 +65,13 @@ class LaserMainframeKeysight(Instrument):
             'max_lambda'
         ])
 
+        self._instrument_unlock_pin = kwargs.get('pin', "1234")  # default pin for Keysight lasers
+        if type(self._instrument_unlock_pin) is not str:
+            raise ValueError("Instrument constructor argument 'pin' must be of type string!")
+
         self.sweep_configured = False
         self.send_hardware_trigger = False
-        self.trigger_at_open = ''  # saves state of triggering upon connecting so we can restore on disconnect
+        self.trigger_at_open = ''  # saves state of triggering upon connecting such that we can restore on disconnect
 
     def open(self):
         """
@@ -101,13 +107,13 @@ class LaserMainframeKeysight(Instrument):
     #   mainframe options
     #
 
-    def unlock_laser(self, pin="1234"):
+    def unlock_laser(self):
         """
         set lock for the instrument
 
         :param pin: string of the pin to unlock the device
         """
-        self.command('LOCK 0,{:s}'.format(pin))
+        self.command('LOCK 0,{:s}'.format(self._instrument_unlock_pin))
 
     def idn(self):
         """

--- a/LabExT/Instruments/PowerMeterN7744A.py
+++ b/LabExT/Instruments/PowerMeterN7744A.py
@@ -16,6 +16,9 @@ class PowerMeterN7744A(PowerMeterGenericKeysight):
     This class extends the [PowerMeterGenericKeysight](./PowerMeterGenericKeysight.md)
     class by the `autogain` property only present on the newer N77xxA models of power meters.
 
+    This class was tested with the Keysight N7744A and N7745C power meters, and is very likely working with most other
+    multichannel N77xx power meters from keysight, too.
+
     #### Properties
 
     handbook page refers to: Keysight N77xx Series Programming Guide (9018-02434.pdf)
@@ -33,9 +36,7 @@ class PowerMeterN7744A(PowerMeterGenericKeysight):
         """
         # call Instrument constructor, creates VISA instrument
         super().__init__(*args, **kwargs)
-        # check channel number
-        if self.channel not in [1, 2, 3, 4]:
-            raise ValueError('Argument channel must be 1, 2, 3, or 4.')
+       
         # the N7744A is smart and returns sweep data in the chosen unit
         self._always_returns_sweep_in_Watt = False
 


### PR DESCRIPTION
# Goal
Small improvements regarding the supplied Keysight TLS and OPM classes.

# Compatibility
Actually increases compatibility! N7744A class is actually compatible with all N774x keysight multichannel OPMs. The LaserMainframeKeysight class is compatible with all 8164 and 7776/7778 lasers.