### PR TITLE
(1/8) Extend Addons for Mover and refactor plugin loading

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -150,21 +150,15 @@ class ExperimentManager:
         lvcards_addon_stats = '\n'.join(['    imported {:d} lvcards from {:s}'.format(
             n, path) for path, n in self.lvcards_import_stats.items()])
         stages_addon_stats = '\n'.join(['    imported {:d} stages from {:s}'.format(
-            n, path) for path, n in self.mover.api._stage_classes_import_stats.items()])
+            n, path) for path, n in self.mover.stage_api.import_stats.items()])
         stage_polygons_addon_stats = '\n'.join(['    imported {:d} stage polygons from {:s}'.format(
-            n, path) for path, n in self.mover.api._stage_polygon_import_stats.items()])
-        peak_searcher_addon_stats = '\n'.join(['    imported {:d} peak searcher from {:s}'.format(
-            n, path) for path, n in self.mover.api._peak_searcher_import_stats.items()])
-        path_planning_addon_stats = '\n'.join(['    imported {:d} path planner from {:s}'.format(
-            n, path) for path, n in self.mover.api._path_planner_import_stats.items()])
+            n, path) for path, n in self.mover.polygon_api.import_stats.items()])
         self.logger.info('Plugins loaded:\n' +
                          '  Measurements\n' + meas_addon_stats + '\n' +
                          '  Instruments\n' + instr_addon_stats + '\n' +
                          '  LVCards\n' + lvcards_addon_stats + '\n' +
                          '  Stages\n' + stages_addon_stats + '\n' +
-                         '  Stage Polygons\n' + stage_polygons_addon_stats + '\n' +
-                         '  Peak Seacher\n' + peak_searcher_addon_stats + '\n' +
-                         '  Path Planner\n' + path_planning_addon_stats)
+                         '  Stage Polygons\n' + stage_polygons_addon_stats)
 
         if instruments_are_default:
             self.logger.warning(
@@ -223,8 +217,7 @@ class ExperimentManager:
         # then we load all Instruments
         self.instrument_api.load_all_instruments()
         # then we load all stage classes and mover settings
-        self.mover.api.import_all()
-        self.mover.discover_stages()
+        self.mover.import_api_classes()
         self.mover.load_settings()
         # finally, we load all cards for the liveviewer
         self.live_viewer_cards, self.lvcards_import_stats = LiveViewerController.load_all_cards(

--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -150,12 +150,21 @@ class ExperimentManager:
         lvcards_addon_stats = '\n'.join(['    imported {:d} lvcards from {:s}'.format(
             n, path) for path, n in self.lvcards_import_stats.items()])
         stages_addon_stats = '\n'.join(['    imported {:d} stages from {:s}'.format(
-            n, path) for path, n in self.mover.plugin_loader_stats.items()])
+            n, path) for path, n in self.mover._stage_classes_import_stats.items()])
+        stage_polygons_addon_stats = '\n'.join(['    imported {:d} stage polygons from {:s}'.format(
+            n, path) for path, n in self.mover._stage_polygon_import_stats.items()])
+        peak_searcher_addon_stats = '\n'.join(['    imported {:d} peak searcher from {:s}'.format(
+            n, path) for path, n in self.mover._peak_searcher_import_stats.items()])
+        path_planning_addon_stats = '\n'.join(['    imported {:d} path planner from {:s}'.format(
+            n, path) for path, n in self.mover._path_planner_import_stats.items()])
         self.logger.info('Plugins loaded:\n' +
                          '  Measurements\n' + meas_addon_stats + '\n' +
                          '  Instruments\n' + instr_addon_stats + '\n' +
                          '  LVCards\n' + lvcards_addon_stats + '\n' +
-                         '  Stages\n' + stages_addon_stats)
+                         '  Stages\n' + stages_addon_stats + '\n' +
+                         '  Stage Polygons\n' + stage_polygons_addon_stats + '\n' +
+                         '  Peak Seacher\n' + peak_searcher_addon_stats + '\n' +
+                         '  Path Planner\n' + path_planning_addon_stats)
 
         if instruments_are_default:
             self.logger.warning(
@@ -214,7 +223,7 @@ class ExperimentManager:
         # then we load all Instruments
         self.instrument_api.load_all_instruments()
         # then we load all stage classes and mover settings
-        self.mover.import_stage_classes()
+        self.mover.import_api_classes()
         self.mover.load_settings()
         # finally, we load all cards for the liveviewer
         self.live_viewer_cards, self.lvcards_import_stats = LiveViewerController.load_all_cards(

--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -150,13 +150,13 @@ class ExperimentManager:
         lvcards_addon_stats = '\n'.join(['    imported {:d} lvcards from {:s}'.format(
             n, path) for path, n in self.lvcards_import_stats.items()])
         stages_addon_stats = '\n'.join(['    imported {:d} stages from {:s}'.format(
-            n, path) for path, n in self.mover._stage_classes_import_stats.items()])
+            n, path) for path, n in self.mover.api._stage_classes_import_stats.items()])
         stage_polygons_addon_stats = '\n'.join(['    imported {:d} stage polygons from {:s}'.format(
-            n, path) for path, n in self.mover._stage_polygon_import_stats.items()])
+            n, path) for path, n in self.mover.api._stage_polygon_import_stats.items()])
         peak_searcher_addon_stats = '\n'.join(['    imported {:d} peak searcher from {:s}'.format(
-            n, path) for path, n in self.mover._peak_searcher_import_stats.items()])
+            n, path) for path, n in self.mover.api._peak_searcher_import_stats.items()])
         path_planning_addon_stats = '\n'.join(['    imported {:d} path planner from {:s}'.format(
-            n, path) for path, n in self.mover._path_planner_import_stats.items()])
+            n, path) for path, n in self.mover.api._path_planner_import_stats.items()])
         self.logger.info('Plugins loaded:\n' +
                          '  Measurements\n' + meas_addon_stats + '\n' +
                          '  Instruments\n' + instr_addon_stats + '\n' +
@@ -223,7 +223,8 @@ class ExperimentManager:
         # then we load all Instruments
         self.instrument_api.load_all_instruments()
         # then we load all stage classes and mover settings
-        self.mover.import_api_classes()
+        self.mover.api.import_all()
+        self.mover.discover_stages()
         self.mover.load_settings()
         # finally, we load all cards for the liveviewer
         self.live_viewer_cards, self.lvcards_import_stats = LiveViewerController.load_all_cards(

--- a/LabExT/Instruments/InstrumentAPI/InstrumentAPI.py
+++ b/LabExT/Instruments/InstrumentAPI/InstrumentAPI.py
@@ -10,30 +10,23 @@ from os.path import dirname
 
 from LabExT.Instruments.InstrumentAPI._Instrument import Instrument
 from LabExT.Instruments.InstrumentAPI.InstrumentSetup import create_instrument_obj_impl
-from LabExT.PluginLoader import PluginLoader
+from LabExT.PluginLoader import import_plugins_from_paths
 
 
 class InstrumentAPI:
     def __init__(self, experiment_manager):
         self._experiment_manager = experiment_manager
         self.logger = logging.getLogger()
-        self.plugin_loader = PluginLoader()
         self.plugin_loader_stats = {}
         self.instruments = {}
 
     def load_all_instruments(self):
         """ executes the loading of additional Instrument classes from all configured addon directories """
-        # we keep stats only for last import call
-        self.plugin_loader_stats.clear()
-
         instrs_search_paths = [dirname(dirname(__file__))]  # include Instrs. from LabExT core first
         instrs_search_paths += self._experiment_manager.addon_settings['addon_search_directories']
 
-        for isp in instrs_search_paths:
-            plugins = self.plugin_loader.load_plugins(isp, plugin_base_class=Instrument, recursive=True)
-            unique_plugins = {k: v for k, v in plugins.items() if k not in self.instruments}
-            self.plugin_loader_stats[isp] = len(unique_plugins)
-            self.instruments.update(unique_plugins)
+        self.instruments, self.plugin_loader_stats = import_plugins_from_paths(
+            base_class=Instrument, search_paths=instrs_search_paths)
 
         self.logger.debug('Available instruments loaded. Found: %s', [k for k in self.instruments.keys()])
 

--- a/LabExT/PluginLoader.py
+++ b/LabExT/PluginLoader.py
@@ -18,7 +18,7 @@ import os
 import pkgutil
 import sys
 from importlib import import_module
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Dict
 
 
 def import_plugins_from_paths(
@@ -60,6 +60,47 @@ def import_plugins_from_paths(
         imported_plugins.update(unique_classes)
 
     return imported_plugins, search_stats
+
+
+class PluginAPI:
+    """
+    Simple registry and interface for Plugin classes.
+    """
+
+    def __init__(
+        self,
+        base_class: Any,
+        core_search_path: str
+    ) -> None:
+        self._base_class = base_class
+        self._core_search_path = core_search_path
+
+        self._imported_classes: Dict[str, Any] = {}
+        self._import_stats: Dict[str, int] = {}
+
+    def import_classes(self, search_paths: list = []) -> None:
+        """
+        Imports all Mover API classes.
+
+        Parameters:
+        -----------
+        search_paths: list = []
+            List of search paths to import from.
+        """
+        self._imported_classes, self._import_stats = import_plugins_from_paths(
+            base_class=self._base_class, search_paths=[self._core_search_path] + search_paths)
+
+    @property
+    def imported_classes(self) -> Dict[str, Any]:
+        """
+        Returns a duct of all imported classes.
+        Read-only.
+        """
+        return self._imported_classes
+
+    @property
+    def import_stats(self) -> Dict[str, int]:
+        return self._import_stats
 
 
 class PluginLoader:

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -9,20 +9,21 @@ import json
 import logging
 import os
 import time
-from typing import Type
+from typing import Type, TYPE_CHECKING
 
 import numpy as np
 from scipy.optimize import curve_fit
 
 from LabExT.Measurements.MeasAPI import *
 from LabExT.Movement.MotorProfiles import trapezoidal_velocity_profile_by_integration
-from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.config import CoordinateSystem
 from LabExT.Movement.Transformations import StageCoordinate
 from LabExT.Utils import get_configuration_file_path
 from LabExT.View.Controls.PlotControl import PlotData
 from LabExT.ViewModel.Utilities.ObservableList import ObservableList
 
+if TYPE_CHECKING:
+    from LabExT.Movement.MoverNew import MoverNew
 
 class PeakSearcher(Measurement):
     """
@@ -83,7 +84,7 @@ class PeakSearcher(Measurement):
     def __init__(
         self,
         *args,
-        mover: Type[MoverNew] = None,
+        mover: Type["MoverNew"] = None,
         parent=None,
         **kwargs
     ) -> None:
@@ -99,7 +100,7 @@ class PeakSearcher(Measurement):
         self._parent = parent
         self.name = "SearchForPeak-2DGaussianFit"
         self.settings_filename = "PeakSearcher_settings.json"
-        self.mover = mover
+        self.mover: Type[MoverNew] = mover
 
         self.logger = logging.getLogger()
 

--- a/LabExT/View/AddonSettingsDialog.py
+++ b/LabExT/View/AddonSettingsDialog.py
@@ -198,10 +198,10 @@ class AddonSettingsDialog:
     def _get_loaded_mover_api(self) -> list:
         ret_list = []
         for ty, imported_plugins in {
-            "Stage": self._exp_mgr.mover.stage_classes.items(),
-            "Stage Polygon": self._exp_mgr.mover.stage_polygon_classes.items(),
-            "Peak Searcher": self._exp_mgr.mover.peak_searcher_classes.items(),
-            "Path Planner": self._exp_mgr.mover.path_planning_classes.items()
+            "Stage": self._exp_mgr.mover.api.stage_classes.items(),
+            "Stage Polygon": self._exp_mgr.mover.api.stage_polygon_classes.items(),
+            "Peak Searcher": self._exp_mgr.mover.api.peak_searcher_classes.items(),
+            "Path Planner": self._exp_mgr.mover.api.path_planning_classes.items()
         }.items():
             for name, api_klass in imported_plugins:
                 ret_list.append((name, ty, ''))

--- a/LabExT/View/AddonSettingsDialog.py
+++ b/LabExT/View/AddonSettingsDialog.py
@@ -198,10 +198,8 @@ class AddonSettingsDialog:
     def _get_loaded_mover_api(self) -> list:
         ret_list = []
         for ty, imported_plugins in {
-            "Stage": self._exp_mgr.mover.api.stage_classes.items(),
-            "Stage Polygon": self._exp_mgr.mover.api.stage_polygon_classes.items(),
-            "Peak Searcher": self._exp_mgr.mover.api.peak_searcher_classes.items(),
-            "Path Planner": self._exp_mgr.mover.api.path_planning_classes.items()
+            "Stage": self._exp_mgr.mover.stage_api.imported_classes.items(),
+            "Stage Polygon": self._exp_mgr.mover.polygon_api.imported_classes.items(),
         }.items():
             for name, api_klass in imported_plugins:
                 ret_list.append((name, ty, ''))

--- a/LabExT/View/AddonSettingsDialog.py
+++ b/LabExT/View/AddonSettingsDialog.py
@@ -139,17 +139,17 @@ class AddonSettingsDialog:
                     selectmode='none')  # custom table inserts itself into the parent frame
 
         #
-        # table with paths for all loaded stage classes
+        # table with paths for all loaded mover API classes
         #
-        loaded_stage_frame = CustomFrame(self.wizard_window)
-        loaded_stage_frame.title = " currently loaded Stage classes "
-        loaded_stage_frame.grid(row=6, column=0, padx=5, pady=5, sticky='nswe')
-        loaded_stage_frame.columnconfigure(0, weight=1)
-        loaded_stage_frame.rowconfigure(0, weight=1)
+        loaded_mover_apis_frame = CustomFrame(self.wizard_window)
+        loaded_mover_apis_frame.title = " currently loaded Mover API classes "
+        loaded_mover_apis_frame.grid(row=6, column=0, padx=5, pady=5, sticky='nswe')
+        loaded_mover_apis_frame.columnconfigure(0, weight=1)
+        loaded_mover_apis_frame.rowconfigure(0, weight=1)
 
-        CustomTable(parent=loaded_stage_frame,
-                columns=('Stage class', 'imported from'),
-                rows=self._get_loaded_stages_and_paths(),
+        CustomTable(parent=loaded_mover_apis_frame,
+                columns=('Class', 'type', 'imported from'),
+                rows=self._get_loaded_mover_api(),
                 selectmode='none')  # custom table inserts itself into the parent frame
 
         #
@@ -195,12 +195,19 @@ class AddonSettingsDialog:
                 ret_list.append(('    ->', '', vi))
         return ret_list
 
-    def _get_loaded_stages_and_paths(self) -> list:
+    def _get_loaded_mover_api(self) -> list:
         ret_list = []
-        for k, v in self._exp_mgr.mover.stage_classes.items():
-            ret_list.append((k, ''))
-            for vi in v.PluginLoader_module_path:
-                ret_list.append(('    ->', vi))
+        for ty, imported_plugins in {
+            "Stage": self._exp_mgr.mover.stage_classes.items(),
+            "Stage Polygon": self._exp_mgr.mover.stage_polygon_classes.items(),
+            "Peak Searcher": self._exp_mgr.mover.peak_searcher_classes.items(),
+            "Path Planner": self._exp_mgr.mover.path_planning_classes.items()
+        }.items():
+            for name, api_klass in imported_plugins:
+                ret_list.append((name, ty, ''))
+                for vi in api_klass.PluginLoader_module_path:
+                    ret_list.append(('    ->', '', vi))
+
         return ret_list
 
     def save_and_close(self, *args):

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -345,7 +345,7 @@ class StageDriverStep(Step):
             text="Below you can see all Stage classes available in LabExT.\nSo that all stages can be found correctly in the following step, make sure that the drivers for each class are loaded."
         ).pack(side=TOP, fill=X)
 
-        if not self.mover.api.stage_classes:
+        if not self.mover.stage_api.imported_classes:
             Label(
                 frame,
                 text="No stage classes found!",
@@ -353,7 +353,7 @@ class StageDriverStep(Step):
                 side=TOP,
                 fill=X)
 
-        for stage_name, stage_cls in self.mover.api.stage_classes.items():
+        for stage_name, stage_cls in self.mover.stage_api.imported_classes.items():
             stage_driver_frame = Frame(frame)
             stage_driver_frame.pack(side=TOP, fill=X, pady=2)
 

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -345,7 +345,7 @@ class StageDriverStep(Step):
             text="Below you can see all Stage classes available in LabExT.\nSo that all stages can be found correctly in the following step, make sure that the drivers for each class are loaded."
         ).pack(side=TOP, fill=X)
 
-        if not self.mover.stage_classes:
+        if not self.mover.api.stage_classes:
             Label(
                 frame,
                 text="No stage classes found!",
@@ -353,7 +353,7 @@ class StageDriverStep(Step):
                 side=TOP,
                 fill=X)
 
-        for stage_name, stage_cls in self.mover.stage_classes.items():
+        for stage_name, stage_cls in self.mover.api.stage_classes.items():
             stage_driver_frame = Frame(frame)
             stage_driver_frame.pack(side=TOP, fill=X, pady=2)
 


### PR DESCRIPTION
This pull request refactors code for loading plugins into LabExT core and addons. The method `import_plugins_from_paths` allows classes of a base class to import multiple paths and collect statistics of the import. This can be used in Mover, Instruments and Measurements. Redundant code was replaced. The class `PluginAPI` is a simple interface and factory to access and load the loaded plugins in a uniform way.

In the Mover it is now possible to load StagePolygon and Stages via the API. Later SfP and PathPlanner will be added.