### PR TITLE
(2/8) Add orientation to Single Mode Fiber stage polygon

### DIFF
--- a/LabExT/Measurements/MeasAPI/Measparam.py
+++ b/LabExT/Measurements/MeasAPI/Measparam.py
@@ -5,6 +5,7 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+from enum import Enum
 
 class MeasParam:
     """Implementation of a single measurement parameter.
@@ -136,5 +137,7 @@ def MeasParamAuto(value=None, unit=None, extra_type=None, selected=None):
         return MeasParamList(options=value, value=selected, unit=unit, extra_type=extra_type)
     elif type(value) is int:
         return MeasParamInt(value=value, unit=unit, extra_type=extra_type)
+    elif issubclass(type(value), Enum):
+            return MeasParamList(options=list(type(value)), value=value, unit=unit, extra_type=extra_type)
     else:
         return MeasParamFloat(value=value, unit=unit, extra_type=extra_type)

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -143,8 +143,14 @@ class Calibration:
 
         stage_polygon = None
         if "stage_polygon" in calibration_data:
-            stage_polygon = StagePolygon.load(
-                calibration_data["stage_polygon"])
+            polygon_cls_name = calibration_data["stage_polygon"].get("class")
+            stage_polygon_cls = mover.polygon_api.get_class(polygon_cls_name)
+            if stage_polygon_cls:
+                stage_polygon = stage_polygon_cls.load(
+                    calibration_data["stage_polygon"].get("parameters", {}))
+            else:
+                cls._logger.debug(
+                    f"Cannot set stage polygon. Polygon class '{polygon_cls_name}' not found.")
 
         return cls(
             mover,
@@ -880,7 +886,8 @@ class Calibration:
             calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
 
         if stage_polygon and self.stage_polygon is not None:
-            calibration_dump["stage_polygon"] = self.stage_polygon.dump(
-                stringify=True)
+            calibration_dump["stage_polygon"] = {
+                "class": self.stage_polygon.__class__.__name__,
+                "parameters": self.stage_polygon.dump()}
 
         return calibration_dump

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -185,7 +185,8 @@ class Calibration:
 
         self.stage_polygon = stage_polygon
         if stage_polygon is None:
-            self.stage_polygon = SingleModeFiber(orientation)
+            self.stage_polygon = SingleModeFiber(parameters={
+                "Orientation": orientation})
 
         self._axes_rotation = axes_rotation
         if axes_rotation is None:

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -768,7 +768,8 @@ class MoverNew:
                 c.stage.identifier: c.dump(
                     axes_rotation=True,
                     single_point_offset=False,
-                    kabsch_rotation=False) for c in self.calibrations.values()}, fp)
+                    kabsch_rotation=False,
+                    stage_polygon=False) for c in self.calibrations.values()}, fp)
 
     def dump_settings(self) -> None:
         """

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -52,6 +52,7 @@ class StagePolygon(ABC):
 
     default_parameters: Dict[str, Any] = {}
 
+    @classmethod
     def load(cls, data: dict) -> Type[StagePolygon]:
         """
         Returns a stage polygon reconstructed from data.
@@ -62,10 +63,7 @@ class StagePolygon(ABC):
         self,
         parameters: dict = {}
     ) -> None:
-        if parameters:
-            self.parameters = parameters
-        else:
-            self.parameters = self.default_parameters
+        self.parameters = {**self.default_parameters, **parameters}
 
     @abstractmethod
     def stage_in_meshgrid(
@@ -193,16 +191,16 @@ class SingleModeFiber(StagePolygon):
         y_max = position.y + safe_fiber_radius
 
         if self.parameters[self.ORIENTATION_KEY] == Orientation.LEFT:
-            x_min -= self.fiber_length
+            x_min -= self.parameters[self.FIBER_LENGTH_KEY]
         elif self.parameters[self.ORIENTATION_KEY] == Orientation.RIGHT:
-            x_max += self.fiber_length
+            x_max += self.parameters[self.FIBER_LENGTH_KEY]
         elif self.parameters[self.ORIENTATION_KEY] == Orientation.BOTTOM:
-            y_min -= self.fiber_length
+            y_min -= self.parameters[self.FIBER_LENGTH_KEY]
         elif self.parameters[self.ORIENTATION_KEY] == Orientation.TOP:
-            y_max += self.fiber_length
+            y_max += self.parameters[self.FIBER_LENGTH_KEY]
         else:
             raise ValueError(
-                f"No Stage Polygon defined for orientation {self.orientation}")
+                f"No Stage Polygon defined for orientation {self.parameters[self.ORIENTATION_KEY]}")
 
         # Make sure, that outline fits into meshgrid
         if np.abs(x_max - x_min) <= grid_size:

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -49,7 +49,14 @@ class StagePolygon(ABC):
     This class cannot be initialised.
     """
 
+    _CLASS_KEY = "class"
+    _PARAMETER_KEY = "parameters"
+
     default_parameter: Dict[str, Any] = {}
+
+    @abstractclassmethod
+    def from_dict(cls, data: dict):
+        pass
 
     @abstractclassmethod
     def load(cls, data: dict) -> Type[StagePolygon]:
@@ -57,9 +64,6 @@ class StagePolygon(ABC):
         Returns a stage polygon reconstructed from data.
         """
         pass
-
-    def __init__(self) -> None:
-        super().__init__()
 
     @abstractmethod
     def stage_in_meshgrid(
@@ -80,6 +84,14 @@ class StagePolygon(ABC):
         Returns polygon parameters as dict
         """
         pass
+
+    def to_dict(self) -> dict:
+        """
+        Converts polygon object to a dict, including all parameters and polygon class.
+        """
+        return {
+            self._CLASS_KEY: self.__class__.__name__,
+            self._PARAMETER_KEY: self.dump()}
 
 
 class SingleModeFiber(StagePolygon):

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -33,7 +33,7 @@ class Direction(BaseEnum):
     POSITIVE = 1
 
 
-class Orientation(BaseEnum):
+class Orientation(str, BaseEnum):
     """Enumerate different stage orientations."""
     LEFT = auto()
     RIGHT = auto()

--- a/LabExT/PluginLoader.py
+++ b/LabExT/PluginLoader.py
@@ -103,6 +103,16 @@ class PluginAPI:
         return self._import_stats
 
 
+    def get_class(
+        self,
+        class_name: str,
+        default: Any = None
+    ) -> Any:
+        """
+        Returns class for given class name.
+        """
+        return self.imported_classes.get(str(class_name), default)
+
 class PluginLoader:
     def __init__(self):
         self.__available_plugins = {}

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -55,6 +55,7 @@ class CalibrationTestCase(unittest.TestCase):
         self.stage = DummyStage('usb:123456789')
 
         self.mover = MoverNew(None)
+        self.mover.import_api_classes()
 
         self.calibration = Calibration(
             self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
@@ -682,7 +683,8 @@ class CalibrationTest(CalibrationTestCase):
 
         
     def test_dump_with_stage_polygon(self):
-        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.LEFT,
             "Fiber Radius": 100.0,
             "Safety Distance": 100.0,
             "Fiber Length": 10e4
@@ -692,9 +694,9 @@ class CalibrationTest(CalibrationTestCase):
             stage_polygon=polygon)
 
         self.assertDictEqual(calibration.dump()["stage_polygon"], {
-            "polygon_cls": "SingleModeFiber",
-            "orientation": "LEFT",
+            "class": "SingleModeFiber",
             "parameters": {
+                "Orientation": "LEFT",
                 "Fiber Radius": 100.0,
                 "Safety Distance": 100.0,
                 "Fiber Length": 10e4
@@ -809,9 +811,9 @@ class CalibrationTest(CalibrationTestCase):
             "orientation": "LEFT",
             "device_port": "INPUT",
             "stage_polygon":  {
-                "polygon_cls": "SingleModeFiber",
-                "orientation": "LEFT",
+                "class": "SingleModeFiber",
                 "parameters": {
+                    "Orientation": "LEFT",
                     "Fiber Radius": 100.0,
                     "Safety Distance": 100.0,
                     "Fiber Length": 10e4
@@ -823,9 +825,9 @@ class CalibrationTest(CalibrationTestCase):
         
         self.assertIsInstance(restored_calibration.stage_polygon, SingleModeFiber)
         self.assertDictEqual(restored_calibration.stage_polygon.parameters, {
+            "Orientation": Orientation.LEFT,
             "Fiber Radius": 100.0,
             "Safety Distance": 100.0,
             "Fiber Length": 10e4
         })
-        self.assertEqual(restored_calibration.stage_polygon.orientation, Orientation.LEFT)
 

--- a/LabExT/Tests/Movement/PathPlanning_test.py
+++ b/LabExT/Tests/Movement/PathPlanning_test.py
@@ -17,7 +17,8 @@ from LabExT.Movement.PathPlanning import SingleModeFiber, StagePolygon
 
 class SingleModeFiberTest(TestCase):
     def test_left_outline_with_default_parameters(self):
-        polygon = SingleModeFiber(Orientation.LEFT)
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.LEFT})
         x_min, x_max, y_min, y_max = polygon._create_outline(
             position=ChipCoordinate(0, 0, 0),
             grid_size=50)
@@ -28,7 +29,8 @@ class SingleModeFiberTest(TestCase):
         self.assertEqual(y_max, 150.0)
 
     def test_right_outline_with_default_parameters(self):
-        polygon = SingleModeFiber(Orientation.RIGHT)
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.RIGHT})
         x_min, x_max, y_min, y_max = polygon._create_outline(
             position=ChipCoordinate(0, 0, 0),
             grid_size=50)
@@ -39,7 +41,8 @@ class SingleModeFiberTest(TestCase):
         self.assertEqual(y_max, 150.0)
 
     def test_top_outline_with_default_parameters(self):
-        polygon = SingleModeFiber(Orientation.TOP)
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.TOP})
         x_min, x_max, y_min, y_max = polygon._create_outline(
             position=ChipCoordinate(0, 0, 0),
             grid_size=50)
@@ -50,7 +53,8 @@ class SingleModeFiberTest(TestCase):
         self.assertEqual(y_max, 80150.0)
 
     def test_bottom_outline_with_default_parameters(self):
-        polygon = SingleModeFiber(Orientation.BOTTOM)
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.BOTTOM})
         x_min, x_max, y_min, y_max = polygon._create_outline(
             position=ChipCoordinate(0, 0, 0),
             grid_size=50)
@@ -68,7 +72,8 @@ class SingleModeFiberTest(TestCase):
     ])
     def test_adjustment_to_gridsize(self, orientation):
         grid_size = 100
-        polygon = SingleModeFiber(orientation, parameters={
+        polygon = SingleModeFiber(parameters={
+            "Orientation": orientation,
             "Fiber Radius": 25.0,
             "Safety Distance": 25.0
         })
@@ -95,7 +100,8 @@ class SingleModeFiberTest(TestCase):
             grid_size)
         cx, cy = np.meshgrid(xs, ys)
 
-        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.LEFT,
             "Fiber Radius": 1,
             "Safety Distance": 0,
             "Fiber Length": 0
@@ -106,70 +112,32 @@ class SingleModeFiberTest(TestCase):
 
         self.assertTrue(mask.any())
 
-    def test_dump_with_stringify(self):
-        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+    def test_dump(self):
+        polygon = SingleModeFiber(parameters={
+            "Orientation": Orientation.LEFT,
             "Fiber Radius": 100.0,
             "Safety Distance": 100.0,
             "Fiber Length": 10e4
         })
 
-        self.assertDictEqual(polygon.dump(stringify=True), {
-            "polygon_cls": "SingleModeFiber",
-            "orientation": "LEFT",
-            "parameters": {
-                "Fiber Radius": 100.0,
-                "Safety Distance": 100.0,
-                "Fiber Length": 10e4
-            }
-        })
-
-    def test_dump_without_stringify(self):
-        polygon = SingleModeFiber(Orientation.LEFT, parameters={
+        self.assertDictEqual(polygon.dump(), {
+            "Orientation": "LEFT",
             "Fiber Radius": 100.0,
             "Safety Distance": 100.0,
             "Fiber Length": 10e4
         })
 
-        self.assertDictEqual(polygon.dump(stringify=False), {
-            "polygon_cls": SingleModeFiber,
-            "orientation": "LEFT",
-            "parameters": {
-                "Fiber Radius": 100.0,
-                "Safety Distance": 100.0,
-                "Fiber Length": 10e4
-            }
-        })
-
-    def test_dump_load_with_stringify(self):
-        polygon_org = SingleModeFiber(Orientation.LEFT, parameters={
+    def test_dump_load(self):
+        polygon_org = SingleModeFiber(parameters={
+            "Orientation": "LEFT",
             "Fiber Radius": 100.0,
             "Safety Distance": 100.0,
             "Fiber Length": 10e4
         })
 
-        polygon_reconstructed = StagePolygon.load(
-            polygon_data=polygon_org.dump(stringify=True))
+        polygon_reconstructed = SingleModeFiber.load(polygon_org.dump())
 
         self.assertIsInstance(
             polygon_reconstructed, SingleModeFiber)
         self.assertDictEqual(
             polygon_org.parameters, polygon_reconstructed.parameters)
-        self.assertEqual(
-            polygon_org.orientation, polygon_org.orientation)
-
-    def test_dump_load_without_stringify(self):
-        polygon_org = SingleModeFiber(Orientation.LEFT, parameters={
-            "Fiber Radius": 100.0,
-            "Safety Distance": 100.0,
-            "Fiber Length": 10e4
-        })
-
-        polygon_reconstructed = StagePolygon.load(
-            polygon_data=polygon_org.dump(stringify=False))
-
-        self.assertIsInstance(
-            polygon_reconstructed, SingleModeFiber)
-        self.assertDictEqual(
-            polygon_org.parameters, polygon_reconstructed.parameters)
-        self.assertEqual(
-            polygon_org.orientation, polygon_org.orientation)


### PR DESCRIPTION
This pull request adds the orientation property as a StagePolygon property. Furthermore, StagePolygon is automatically saved and loaded on disk for class names by MoverAPI.