### PR TITLE
(3/8) Remove Orientation Property from Mover

### DIFF
--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -89,8 +89,7 @@ class Calibration:
     def load(
         cls,
         mover: Type[MoverNew],
-        stage: Type[Stage],
-        calibration_data: dict,
+        data: dict,
         chip: Type[Chip] = None
     ) -> Type[Calibration]:
         """
@@ -100,9 +99,7 @@ class Calibration:
         ----------
         mover : Mover
             Instance of mover associated with this calibration.
-        stage : Stage
-            Instance of a stage
-        calibration_data : dict
+        data : dict
             Dumped calibration data
 
         Returns
@@ -110,43 +107,50 @@ class Calibration:
         Calibration
             Instance of calibration
         """
-        try:
-            device_port = DevicePort[calibration_data["device_port"]]
-        except KeyError as err:
-            raise CalibrationError(
-                f"The parameter is not defined: {err}. "
-                "Make sure to pass a valid device port.")
+        device_port = None
+        if "device_port" in data:
+            device_port = DevicePort[data["device_port"]]
+
+        stage = None
+        if "stage" in data:
+            stage_cls_name = data["stage"].get("class")
+            stage_cls = mover.stage_api.get_class(stage_cls_name)
+            if stage_cls:
+                stage = stage_cls.load(data["stage"].get("parameters", {}))
+            else:
+                cls._logger.debug(
+                    f"Cannot set stage. Stage class '{stage_cls_name}' not found.")
 
         axes_rotation = None
-        if "axes_rotation" in calibration_data:
+        if "axes_rotation" in data:
             axes_rotation = AxesRotation.load(
-                calibration_data["axes_rotation"])
+                data["axes_rotation"])
 
         single_point_offset = None
-        if "single_point_offset" in calibration_data:
+        if "single_point_offset" in data:
             if axes_rotation is not None and chip is not None:
                 single_point_offset = SinglePointOffset.load(
-                    calibration_data["single_point_offset"], chip=chip, axes_rotation=axes_rotation)
+                    data["single_point_offset"], chip=chip, axes_rotation=axes_rotation)
             else:
                 cls._logger.debug(
                     "Cannot set single point offset when axes rotation or chip is not defined")
 
         kabsch_rotation = None
-        if "kabsch_rotation" in calibration_data:
+        if "kabsch_rotation" in data:
             if axes_rotation is not None and chip is not None:
                 kabsch_rotation = KabschRotation.load(
-                    calibration_data["kabsch_rotation"], chip=chip, axes_rotation=axes_rotation)
+                    data["kabsch_rotation"], chip=chip, axes_rotation=axes_rotation)
             else:
                 cls._logger.debug(
                     "Cannot set kabsch rotation when axes rotation or chip is not defined")
 
         stage_polygon = None
-        if "stage_polygon" in calibration_data:
-            polygon_cls_name = calibration_data["stage_polygon"].get("class")
+        if "stage_polygon" in data:
+            polygon_cls_name = data["stage_polygon"].get("class")
             stage_polygon_cls = mover.polygon_api.get_class(polygon_cls_name)
             if stage_polygon_cls:
                 stage_polygon = stage_polygon_cls.load(
-                    calibration_data["stage_polygon"].get("parameters", {}))
+                    data["stage_polygon"].get("parameters", {}))
             else:
                 cls._logger.debug(
                     f"Cannot set stage polygon. Polygon class '{polygon_cls_name}' not found.")
@@ -163,7 +167,7 @@ class Calibration:
     def __init__(
         self,
         mover: Type[MoverNew],
-        stage: Type[Stage],
+        stage: Type[Stage] = None,
         device_port: DevicePort = None,
         stage_polygon: Type[StagePolygon] = None,
         axes_rotation: Type[AxesRotation] = None,
@@ -171,7 +175,7 @@ class Calibration:
         kabsch_rotation: Type[KabschRotation] = None
     ) -> None:
         self.mover = mover
-        self.stage: Type[Stage] = stage
+        self._stage: Type[Stage] = stage
 
         self.device_port = device_port
 
@@ -226,6 +230,22 @@ class Calibration:
         Returns the current calibration state.
         """
         return self._state
+
+    @property
+    def stage(self) -> Type[Stage]:
+        """
+        Returns the assigned stage.
+        """
+        return self._stage
+
+    @stage.setter
+    def stage(self, new_stage: Type[Stage]) -> None:
+        """
+        Sets a new stage.
+        Determines new state.
+        """
+        self._stage = new_stage
+        self.determine_state(skip_connection=False)
 
     @property
     def is_input_stage(self):
@@ -860,6 +880,7 @@ class Calibration:
 
     def dump(
         self,
+        stage: bool = True,
         axes_rotation: bool = True,
         single_point_offset: bool = True,
         kabsch_rotation: bool = True,
@@ -868,9 +889,15 @@ class Calibration:
         """
         Returns a dict of all calibration properties.
         """
-        calibration_dump = {
-            "stage_identifier": self.stage.identifier,
-            "device_port": self.device_port.value}
+        calibration_dump = {}
+
+        if self.device_port is not None:
+            calibration_dump["device_port"] = self.device_port.value
+
+        if stage and self.stage:
+            calibration_dump["stage"] = {
+                "class": self.stage.__class__.__name__,
+                "parameters": self.stage.dump()}
 
         if axes_rotation and self._axes_rotation.is_valid:
             calibration_dump["axes_rotation"] = self._axes_rotation.dump()

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -164,7 +164,7 @@ class Calibration:
         self,
         mover: Type[MoverNew],
         stage: Type[Stage],
-        device_port: DevicePort,
+        device_port: DevicePort = None,
         stage_polygon: Type[StagePolygon] = None,
         axes_rotation: Type[AxesRotation] = None,
         single_point_offset: Type[SinglePointOffset] = None,
@@ -870,7 +870,7 @@ class Calibration:
         """
         calibration_dump = {
             "stage_identifier": self.stage.identifier,
-            "device_port": self._device_port.value}
+            "device_port": self.device_port.value}
 
         if axes_rotation and self._axes_rotation.is_valid:
             calibration_dump["axes_rotation"] = self._axes_rotation.dump()

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -4,13 +4,15 @@
 LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
+from __future__ import annotations
+
 import sys
 import json
 import time
 import ctypes as ct
 
 from enum import Enum
-from typing import List
+from typing import List, Type
 
 from LabExT.Movement.config import Axis
 from LabExT.Movement.Stage import Stage, StageError, assert_stage_connected, assert_driver_loaded
@@ -55,6 +57,23 @@ class Stage3DSmarAct(Stage):
     driver_path_dialog = None
     driver_specifiable = True
     description = "SmarAct Modular Control System"
+
+    @classmethod
+    def load(cls, data: dict) -> Type[Stage3DSmarAct]:
+        """
+        Loads a SmarAct stage with given properties.
+        """
+        address = str(data.get("address"))
+        if not address:
+            raise ValueError(
+                "Cannot load SmarAct stage without address.")
+
+        available_addresses = cls.find_stage_addresses()
+        if address not in available_addresses:
+            raise ValueError(
+                f"Cannot load SmarAct stage with address {address}. Address is not available.")
+
+        return Stage3DSmarAct(address=address)
 
     @classmethod
     def load_driver(cls, parent) -> bool:
@@ -598,6 +617,14 @@ class Stage3DSmarAct(Stage):
 
         if wait_for_stopping:
             self._wait_for_stopping()
+
+    def dump(self) -> dict:
+        """
+        Returns a SmarAct stage as dict.
+        """
+        return {
+            "address": self.address.decode('utf-8')
+        }
 
     # Helper methods
 

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -58,7 +58,7 @@ class CalibrationTestCase(unittest.TestCase):
         self.mover.import_api_classes()
 
         self.calibration = Calibration(
-            self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
+            self.mover, self.stage, DevicePort.INPUT)
 
     def set_valid_axes_rotation(self):
         for chip_axis, direction, stage_axis in VALID_AXES_MAPPING:
@@ -624,13 +624,11 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_xy_mock.assert_has_calls(
             [call(5000), call(current_speed_xy)])
 
-    def test_dump_includes_orientation_and_port(self):
-        calibration = Calibration(self.mover, self.stage, Orientation.BOTTOM, DevicePort.INPUT)
+    def test_dump_includes_port(self):
+        calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
         calibration_dump = calibration.dump()
 
-        self.assertEqual(calibration_dump["orientation"], "BOTTOM")
         self.assertEqual(calibration_dump["device_port"], "INPUT")
-
 
     def test_dump_with_no_single_point_offset(self):
         self.assertFalse(self.calibration._single_point_offset.is_valid)
@@ -690,7 +688,7 @@ class CalibrationTest(CalibrationTestCase):
             "Fiber Length": 10e4
         })
         calibration = Calibration(
-            self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT,
+            self.mover, self.stage, DevicePort.INPUT,
             stage_polygon=polygon)
 
         self.assertDictEqual(calibration.dump()["stage_polygon"], {

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -624,6 +624,17 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_xy_mock.assert_has_calls(
             [call(5000), call(current_speed_xy)])
 
+    def test_dump_includes_stage(self):
+        calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
+        calibration_dump = calibration.dump()
+
+        self.assertEqual(calibration_dump["stage"], {
+            "class": "DummyStage",
+            "parameters": {
+                "address": "usb:123456789"
+            }
+        })
+
     def test_dump_includes_port(self):
         calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
         calibration_dump = calibration.dump()
@@ -703,10 +714,14 @@ class CalibrationTest(CalibrationTestCase):
 
 
     def test_load_with_axes_rotation(self):
-        self.stage.connect()
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -714,11 +729,11 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        restored_calibration = Calibration.load(self.mover, calibration_data)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
 
     def test_load_with_single_point_offset(self):
-        self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
             devices=[
@@ -726,8 +741,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -740,7 +760,8 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip=chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip=chip)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
 
     def test_load_with_kabsch_rotation(self):
@@ -755,8 +776,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -791,7 +817,8 @@ class CalibrationTest(CalibrationTestCase):
             ]
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
 
     def test_load_with_stage_polygon(self):
@@ -806,8 +833,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "stage_polygon":  {
                 "class": "SingleModeFiber",
                 "parameters": {
@@ -819,7 +851,8 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip)
+        restored_calibration.connect_to_stage()
         
         self.assertIsInstance(restored_calibration.stage_polygon, SingleModeFiber)
         self.assertDictEqual(restored_calibration.stage_polygon.parameters, {

--- a/LabExT/Tests/Movement/MoverNew_test.py
+++ b/LabExT/Tests/Movement/MoverNew_test.py
@@ -11,11 +11,11 @@ import json
 from unittest.mock import Mock, patch, call, mock_open
 from parameterized import parameterized
 from LabExT.Movement.Stages.DummyStage import DummyStage
-from LabExT.Movement.Calibration import DevicePort, Orientation
+from LabExT.Movement.Calibration import Calibration
 
 from LabExT.Movement.MoverNew import MoverError, MoverNew, assert_connected_stages
 from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.config import Axis, Direction, CoordinateSystem
+from LabExT.Movement.config import DevicePort, Orientation, Axis, Direction, CoordinateSystem
 
 
 class AssertConnectedStagesTest(unittest.TestCase):
@@ -31,8 +31,8 @@ class AssertConnectedStagesTest(unittest.TestCase):
 
     def test_assert_connected_stages_raises_error_if_no_stage_is_connected(
             self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.mover.register_stage_calibration(Calibration(
+            self.mover, self.stage, DevicePort.INPUT))
         self.stage.disconnect()
 
         func = Mock()
@@ -45,8 +45,8 @@ class AssertConnectedStagesTest(unittest.TestCase):
 
     def test_assert_connected_stages_calls_function_if_stage_is_connected(
             self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.mover.register_stage_calibration(Calibration(
+            self.mover, self.stage, DevicePort.INPUT))
         self.stage.connect()
 
         func = Mock()
@@ -56,9 +56,9 @@ class AssertConnectedStagesTest(unittest.TestCase):
         func.assert_called_once()
 
 
-class AddStageCalibrationTest(unittest.TestCase):
+class RegisterStageCalibrationTest(unittest.TestCase):
     """
-    Tests adding new calibrations.
+    Tests register new calibrations.
     """
 
     def setUp(self) -> None:
@@ -79,113 +79,68 @@ class AddStageCalibrationTest(unittest.TestCase):
             self.mover.DEFAULT_ACCELERATION_XY)
         self.assertEqual(self.mover._z_lift, self.mover.DEFAULT_Z_LIFT)
 
-    def test_add_stage_calibration_reject_invalid_orientations(self):
+    def test_register_reject_double_ports(self):
+        valid_calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(valid_calibration)
         current_calibrations = self.mover.calibrations
 
-        with self.assertRaises(ValueError):
-            self.mover.add_stage_calibration(
-                self.stage, 1, DevicePort.INPUT)
-
-        self.assertEqual(current_calibrations, self.mover.calibrations)
-
-    def test_add_stage_calibration_reject_invalid_port(self):
-        current_calibrations = self.mover.calibrations
-
-        with self.assertRaises(ValueError):
-            self.mover.add_stage_calibration(self.stage, Orientation.LEFT, 1)
-
-        self.assertEqual(current_calibrations, self.mover.calibrations)
-
-    def test_add_stage_calibration_reject_double_orientations(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        current_calibrations = self.mover.calibrations
-
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
+        self.assertIn(valid_calibration, self.mover.calibrations)
+        self.assertEqual(
+            self.mover.get_port_assigned_calibration(DevicePort.INPUT),
+            valid_calibration)
 
         with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage2, Orientation.LEFT, DevicePort.OUTPUT)
-
-        with self.assertRaises(KeyError):
-            self.mover.calibrations[(Orientation.LEFT, DevicePort.OUTPUT)]
+            self.mover.register_stage_calibration(Calibration(
+                self.mover, self.stage2, DevicePort.INPUT))
 
         self.assertEqual(
-            "A stage has already been assigned for Left.", str(
+            "A Stage has already been assigned for device port Input", str(
                 error_context.exception))
         self.assertEqual(current_calibrations, self.mover.calibrations)
         self.assertEqual(1, len(self.mover.calibrations))
 
-    def test_add_stage_calibration_reject_double_ports(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+    def test_register_stage_calibration_reject_double_stages(self):
+        valid_calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(valid_calibration)
         current_calibrations = self.mover.calibrations
 
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
-
-        with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage2, Orientation.RIGHT, DevicePort.INPUT)
-
-        with self.assertRaises(KeyError):
-            self.mover.calibrations[(Orientation.RIGHT, DevicePort.INPUT)]
-
+        self.assertIn(valid_calibration, self.mover.calibrations)
         self.assertEqual(
-            "A stage has already been assigned for the Input port.", str(
-                error_context.exception))
-        self.assertEqual(current_calibrations, self.mover.calibrations)
-        self.assertEqual(1, len(self.mover.calibrations))
-
-    def test_add_stage_calibration_reject_double_stages(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        current_calibrations = self.mover.calibrations
-
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
+            self.mover.get_port_assigned_calibration(DevicePort.INPUT),
+            valid_calibration)
 
         with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage, Orientation.TOP, DevicePort.OUTPUT)
+            self.mover.register_stage_calibration(Calibration(
+                self.mover, self.stage, DevicePort.OUTPUT))
 
-        self.assertEqual("Stage {} has already an assignment.".format(
+        self.assertEqual("The stage '{}' has already been registered.".format(
             str(self.stage)), str(error_context.exception))
         self.assertEqual(current_calibrations, self.mover.calibrations)
         self.assertEqual(1, len(self.mover.calibrations))
 
     def test_active_stage_includes_new_stage(self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.mover.register_stage_calibration(Calibration(
+            self.mover, self.stage, DevicePort.INPUT))
+        self.mover.register_stage_calibration(Calibration(
+            self.mover, self.stage2, DevicePort.OUTPUT))
 
         self.assertIn(self.stage, self.mover.active_stages)
         self.assertIn(self.stage2, self.mover.active_stages)
 
     def test_left_and_input_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.assertEqual(calibration, self.mover.left_calibration)
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(calibration)
+
         self.assertEqual(calibration, self.mover.input_calibration)
 
     def test_right_and_output_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.RIGHT, DevicePort.OUTPUT)
-        self.assertEqual(calibration, self.mover.right_calibration)
-        self.assertEqual(calibration, self.mover.output_calibration)
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.OUTPUT)
+        self.mover.register_stage_calibration(calibration)
 
-    def test_top_and_input_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.TOP, DevicePort.INPUT)
-        self.assertEqual(calibration, self.mover.top_calibration)
-        self.assertEqual(calibration, self.mover.input_calibration)
-
-    def test_bottom_and_output_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
-        self.assertEqual(calibration, self.mover.bottom_calibration)
         self.assertEqual(calibration, self.mover.output_calibration)
 
     def test_set_stage_settings_successfully(self):
@@ -193,14 +148,71 @@ class AddStageCalibrationTest(unittest.TestCase):
         self.assertIsNone(self.stage.get_speed_xy())
         self.assertIsNone(self.stage.get_acceleration_xy())
 
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(calibration)
 
         self.assertEqual(self.stage.get_speed_xy(), self.mover._speed_xy)
         self.assertEqual(self.stage.get_speed_z(), self.mover._speed_z)
         self.assertEqual(
             self.stage.get_acceleration_xy(),
             self.mover._acceleration_xy)
+
+    def test_deregister_stage_calibration_if_missing(self):
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+
+        self.assertNotIn(calibration, self.mover.calibrations)
+
+        with self.assertRaises(MoverError):
+            self.mover.deregister_stage_calibration(calibration)
+
+    def test_deregister_stage_calibration(self):
+        calibration = Calibration(self.mover, self.stage)
+        self.mover.register_stage_calibration(calibration)
+
+        self.assertIn(calibration, self.mover.calibrations)
+
+        self.mover.deregister_stage_calibration(calibration)
+
+        self.assertNotIn(calibration, self.mover.calibrations)
+
+    def test_deregister_stage_calibration_with_port(self):
+        calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
+        calibration2 = Calibration(self.mover, self.stage2, DevicePort.OUTPUT)
+        self.mover.register_stage_calibration(calibration)
+        self.mover.register_stage_calibration(calibration2)
+
+        self.assertTrue(calibration.is_automatic_movement_enabled)
+        self.assertTrue(calibration2.is_automatic_movement_enabled)
+
+        self.assertIn(calibration, self.mover.calibrations)
+        self.assertIn(calibration2, self.mover.calibrations)
+        self.assertEqual(
+            self.mover.get_port_assigned_calibration(DevicePort.INPUT),
+            calibration)
+        self.assertEqual(
+            self.mover.get_port_assigned_calibration(DevicePort.OUTPUT),
+            calibration2)
+
+        # Deregister input calibration
+        self.mover.deregister_stage_calibration(calibration)
+
+        self.assertNotIn(calibration, self.mover.calibrations)
+        self.assertIsNone(
+            self.mover.get_port_assigned_calibration(
+                DevicePort.INPUT))
+        self.assertEqual(
+            self.mover.get_port_assigned_calibration(DevicePort.OUTPUT),
+            calibration2)
+
+        # Deregister output calibration
+        self.mover.deregister_stage_calibration(calibration2)
+
+        self.assertNotIn(calibration2, self.mover.calibrations)
+        self.assertIsNone(
+            self.mover.get_port_assigned_calibration(
+                DevicePort.OUTPUT))
 
 
 class MoverStageSettingsTest(unittest.TestCase):
@@ -215,10 +227,11 @@ class MoverStageSettingsTest(unittest.TestCase):
         with patch.object(MoverNew, "MOVER_SETTINGS_FILE", "/mocked/mover_settings.json"):
             self.mover = MoverNew(None)
 
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        calibration1 = Calibration(self.mover, self.stage, DevicePort.INPUT)
+        calibration2 = Calibration(self.mover, self.stage2, DevicePort.OUTPUT)
+
+        self.mover.register_stage_calibration(calibration1)
+        self.mover.register_stage_calibration(calibration2)
 
         self.stage.connect()
         self.stage2.connect()
@@ -418,8 +431,9 @@ class CanMoveRelativelyTest(unittest.TestCase):
         self.assertFalse(self.mover.can_move_relatively)
 
     def test_with_one_valid_calibration(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(calibration)
         calibration.connect_to_stage()
 
         self.assertTrue(
@@ -428,8 +442,9 @@ class CanMoveRelativelyTest(unittest.TestCase):
         self.assertTrue(self.mover.can_move_relatively)
 
     def test_with_one_invalid_calibration(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(calibration)
         calibration.connect_to_stage()
 
         calibration.update_axes_rotation(Axis.X, Direction.NEGATIVE, Axis.Y)
@@ -439,15 +454,17 @@ class CanMoveRelativelyTest(unittest.TestCase):
         self.assertFalse(self.mover.can_move_relatively)
 
     def test_with_one_valid_and_one_invalid_calibration(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        valid_calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.mover.register_stage_calibration(valid_calibration)
         valid_calibration.connect_to_stage()
 
         self.assertTrue(
             valid_calibration._axes_rotation.is_valid)
 
-        invalid_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        invalid_calibration = Calibration(
+            self.mover, self.stage2, DevicePort.OUTPUT)
+        self.mover.register_stage_calibration(invalid_calibration)
         invalid_calibration.connect_to_stage()
 
         invalid_calibration.update_axes_rotation(
@@ -466,84 +483,76 @@ class RelativeMovementTest(unittest.TestCase):
 
         self.mover = MoverNew(None)
 
-        self.left_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.right_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.input_calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.output_calibration = Calibration(
+            self.mover, self.stage2, DevicePort.OUTPUT)
 
-        self.left_calibration.connect_to_stage()
-        self.right_calibration.connect_to_stage()
+        self.mover.register_stage_calibration(self.input_calibration)
+        self.mover.register_stage_calibration(self.output_calibration)
+
+        self.input_calibration.connect_to_stage()
+        self.output_calibration.connect_to_stage()
 
     def test_raises_error_if_axes_rotation_in_valid(self):
-        self.left_calibration.update_axes_rotation(
+        self.input_calibration.update_axes_rotation(
             Axis.X, Direction.NEGATIVE, Axis.Y)
-        self.assertFalse(self.left_calibration._axes_rotation.is_valid)
+        self.assertFalse(self.input_calibration._axes_rotation.is_valid)
 
         movement_command = {Orientation.LEFT: ChipCoordinate(1, 2, 3)}
         with self.assertRaises(MoverError):
             self.mover.move_relative(movement_command)
 
     def test_raises_error_if_stage_is_disconnected(self):
-        self.right_calibration.disconnect_to_stage()
+        self.output_calibration.disconnect_to_stage()
 
         movement_command = {Orientation.RIGHT: ChipCoordinate(1, 2, 3)}
         with self.assertRaises(MoverError):
             self.mover.move_relative(movement_command)
 
-    def test_raises_error_if_requested_stage_is_unavailable(self):
-        movement_commands = {Orientation.TOP: ChipCoordinate(1, 2, 3)}
-        with self.assertRaises(MoverError):
-            self.mover.move_relative(movement_commands)
-
     @patch.object(DummyStage, "move_relative")
     def test_move_relative_with_ordering(self, move_relative_mock):
-        self.left_calibration.update_axes_rotation(
+        self.input_calibration.update_axes_rotation(
             Axis.X, Direction.NEGATIVE, Axis.Z)
-        self.left_calibration.update_axes_rotation(
+        self.input_calibration.update_axes_rotation(
             Axis.Y, Direction.POSITIVE, Axis.X)
-        self.left_calibration.update_axes_rotation(
+        self.input_calibration.update_axes_rotation(
             Axis.Z, Direction.NEGATIVE, Axis.Y)
 
-        self.assertTrue(self.left_calibration._axes_rotation.is_valid)
+        self.assertTrue(self.input_calibration._axes_rotation.is_valid)
 
-        self.right_calibration.update_axes_rotation(
+        self.output_calibration.update_axes_rotation(
             Axis.X, Direction.POSITIVE, Axis.Y)
-        self.right_calibration.update_axes_rotation(
+        self.output_calibration.update_axes_rotation(
             Axis.Y, Direction.POSITIVE, Axis.Z)
-        self.right_calibration.update_axes_rotation(
+        self.output_calibration.update_axes_rotation(
             Axis.Z, Direction.NEGATIVE, Axis.X)
 
-        self.assertTrue(self.right_calibration._axes_rotation.is_valid)
+        self.assertTrue(self.output_calibration._axes_rotation.is_valid)
 
-        left_requested_offset = ChipCoordinate(42, 8, -17)
-        right_requested_offset = ChipCoordinate(72, -42, 31)
+        input_requested_offset = ChipCoordinate(42, 8, -17)
+        output_requested_offset = ChipCoordinate(72, -42, 31)
 
-        expected_left_offset = self.left_calibration._axes_rotation.chip_to_stage(
-            left_requested_offset)
-        expected_right_offset = self.right_calibration._axes_rotation.chip_to_stage(
-            right_requested_offset)
+        expected_input_offset = self.input_calibration._axes_rotation.chip_to_stage(
+            input_requested_offset)
+        expected_output_offset = self.output_calibration._axes_rotation.chip_to_stage(
+            output_requested_offset)
 
-        requested_ordering = [
-            Orientation.BOTTOM,
-            Orientation.RIGHT,
-            Orientation.TOP,
-            Orientation.LEFT]
-
-        self.mover.move_relative(
-            {Orientation.LEFT: left_requested_offset, Orientation.RIGHT: right_requested_offset},
-            requested_ordering)
+        self.mover.move_relative({
+            self.input_calibration: input_requested_offset,
+            self.output_calibration: output_requested_offset})
 
         move_relative_mock.assert_has_calls(
             [
                 call(
-                    x=expected_right_offset.x,
-                    y=expected_right_offset.y,
-                    z=expected_right_offset.z,
+                    x=expected_input_offset.x,
+                    y=expected_input_offset.y,
+                    z=expected_input_offset.z,
                     wait_for_stopping=True),
                 call(
-                    x=expected_left_offset.x,
-                    y=expected_left_offset.y,
-                    z=expected_left_offset.z,
+                    x=expected_output_offset.x,
+                    y=expected_output_offset.y,
+                    z=expected_output_offset.z,
                     wait_for_stopping=True),
             ],
             any_order=False)
@@ -556,73 +565,79 @@ class CoordinateSystemControlTest(unittest.TestCase):
 
         self.mover = MoverNew(None)
 
-        self.left_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.right_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.input_calibration = Calibration(
+            self.mover, self.stage, DevicePort.INPUT)
+        self.output_calibration = Calibration(
+            self.mover, self.stage2, DevicePort.OUTPUT)
 
-        self.left_calibration.connect_to_stage()
-        self.right_calibration.connect_to_stage()
+        self.mover.register_stage_calibration(self.input_calibration)
+        self.mover.register_stage_calibration(self.output_calibration)
+
+        self.input_calibration.connect_to_stage()
+        self.output_calibration.connect_to_stage()
 
     @parameterized.expand([(CoordinateSystem.CHIP,),
                           (CoordinateSystem.STAGE,), (CoordinateSystem.UNKNOWN,)])
     def test_set_valid_coordinate_system(self, valid_system):
 
-        left_calibration_prior = self.left_calibration.coordinate_system
-        right_calibration_prior = self.right_calibration.coordinate_system
+        left_calibration_prior = self.input_calibration.coordinate_system
+        right_calibration_prior = self.output_calibration.coordinate_system
 
         with self.mover.set_stages_coordinate_system(valid_system):
             self.assertEqual(
-                self.left_calibration.coordinate_system, valid_system)
+                self.input_calibration.coordinate_system, valid_system)
             self.assertEqual(
-                self.right_calibration.coordinate_system, valid_system)
+                self.output_calibration.coordinate_system, valid_system)
 
         self.assertEqual(
-            self.left_calibration.coordinate_system, left_calibration_prior)
+            self.input_calibration.coordinate_system, left_calibration_prior)
         self.assertEqual(
-            self.right_calibration.coordinate_system, right_calibration_prior)
+            self.output_calibration.coordinate_system, right_calibration_prior)
 
     def test_set_valid_coordinate_system_with_block_error(self):
         func = Mock(side_effect=RuntimeError)
 
-        left_calibration_prior = self.left_calibration.coordinate_system
-        right_calibration_prior = self.right_calibration.coordinate_system
+        left_calibration_prior = self.input_calibration.coordinate_system
+        right_calibration_prior = self.output_calibration.coordinate_system
 
         with self.assertRaises(RuntimeError):
             with self.mover.set_stages_coordinate_system(CoordinateSystem.CHIP):
                 func()
 
         self.assertEqual(
-            self.left_calibration.coordinate_system, left_calibration_prior)
+            self.input_calibration.coordinate_system, left_calibration_prior)
         self.assertEqual(
-            self.right_calibration.coordinate_system, right_calibration_prior)
+            self.output_calibration.coordinate_system, right_calibration_prior)
 
     def test_set_nested_coordinate_system(self):
-        self.left_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
-        self.right_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
+        self.input_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
+        self.output_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
 
         with self.mover.set_stages_coordinate_system(CoordinateSystem.CHIP):
             self.assertEqual(
-                self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
+                self.input_calibration.coordinate_system,
+                CoordinateSystem.CHIP)
             self.assertEqual(
-                self.right_calibration.coordinate_system,
+                self.output_calibration.coordinate_system,
                 CoordinateSystem.CHIP)
 
             with self.mover.set_stages_coordinate_system(CoordinateSystem.STAGE):
                 self.assertEqual(
-                    self.left_calibration.coordinate_system,
+                    self.input_calibration.coordinate_system,
                     CoordinateSystem.STAGE)
                 self.assertEqual(
-                    self.right_calibration.coordinate_system,
+                    self.output_calibration.coordinate_system,
                     CoordinateSystem.STAGE)
 
             self.assertEqual(
-                self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
+                self.input_calibration.coordinate_system,
+                CoordinateSystem.CHIP)
             self.assertEqual(
-                self.right_calibration.coordinate_system,
+                self.output_calibration.coordinate_system,
                 CoordinateSystem.CHIP)
 
         self.assertEqual(
-            self.left_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
+            self.input_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
         self.assertEqual(
-            self.right_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
+            self.output_calibration.coordinate_system,
+            CoordinateSystem.UNKNOWN)

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -13,6 +13,8 @@ from LabExT.Movement.config import DevicePort, Orientation
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Stage import Stage
 from LabExT.Tests.Utils import TKinterTestCase
+
+from LabExT.Movement.Calibration import Calibration
 from LabExT.View.Movement.CoordinatePairingsWindow import CoordinatePairingsWindow
 
 from LabExT.Wafer.Device import Device
@@ -41,10 +43,11 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
         self.on_finish = Mock()
 
     def setup_calibrations(self):
-        self.in_calibration = self.mover.add_stage_calibration(
-            self.stage_1, Orientation.LEFT, DevicePort.INPUT)
-        self.out_calibration = self.mover.add_stage_calibration(
-            self.stage_2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.in_calibration = Calibration(self.mover, self.stage_1, DevicePort.INPUT)
+        self.out_calibration = Calibration(self.mover, self.stage_2, DevicePort.OUTPUT)
+
+        self.mover.register_stage_calibration(self.in_calibration)
+        self.mover.register_stage_calibration(self.out_calibration)
 
     def setup_window(self, with_input_stage=True, with_output_stage=True):
         return CoordinatePairingsWindow(

--- a/LabExT/Tests/View/StageRegistrationWindow_test.py
+++ b/LabExT/Tests/View/StageRegistrationWindow_test.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from unittest.mock import Mock, patch
+from flaky import flaky
+from LabExT.Measurements.MeasAPI.Measparam import MeasParamAuto
+from LabExT.Movement.PathPlanning import SingleModeFiber
+
+from LabExT.Movement.config import DevicePort, Orientation
+
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.Movement.Stages.DummyStage import DummyStage
+from LabExT.Tests.Utils import TKinterTestCase
+
+from LabExT.Movement.Calibration import Calibration
+from LabExT.View.Movement.StageRegistrationWindow import StageRegistrationWindow
+
+
+@flaky(max_runs=3)
+class StageRegistrationWindowTest(TKinterTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.available_stages = [
+            (DummyStage, 'usb:123456789'),
+            (DummyStage, 'usb:987654321')
+        ]
+
+        self.mover = MoverNew(None)
+        self.mover.polygon_api.import_classes()
+
+        self.on_finish = Mock()
+
+    def setup_window(self):
+        return StageRegistrationWindow(
+            self.root,
+            self.mover,
+            on_finish=self.on_finish)
+
+    def assert_called_with_new_calibration(
+        self,
+        stage_cls,
+        stage_address,
+        port,
+        stage_polygon,
+        stage_parameters
+    ) -> None:
+        self.on_finish.assert_called_once()
+
+        args, _ = self.on_finish.call_args
+        calibration = args[0]
+
+        self.assertIsInstance(calibration, Calibration)
+
+        self.assertIsInstance(calibration.stage, stage_cls)
+        self.assertEqual(calibration.stage.address, stage_address)
+
+        self.assertEqual(calibration.device_port, port)
+
+        if stage_polygon:
+            self.assertIsInstance(calibration.stage_polygon, stage_polygon)
+            self.assertEqual(
+                calibration.stage_polygon.parameters,
+                stage_parameters)
+        else:
+            self.assertIsNone(calibration.stage_polygon)
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_if_no_stages_available(self, available_stages):
+        available_stages.return_value = []
+        window = self.setup_window()
+
+        self.assertEqual(
+            window._select_stage_button["state"],
+            "disabled")
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_select_stage(self, available_stages):
+        available_stages.return_value = [
+            (DummyStage, 'usb:123456789'), (DummyStage, 'usb:987654321')]
+        window = self.setup_window()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:123456789')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:123456789')
+
+        window._clear_stage_button.invoke()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:987654321')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:987654321')
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_select_stage_without_automatic_movement(self, available_stages):
+        available_stages.return_value = [
+            (DummyStage, 'usb:123456789'), (DummyStage, 'usb:987654321')]
+        window = self.setup_window()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:123456789')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:123456789')
+
+        window._stage_port_var.set(window.NO_PORT_OPTION)
+
+        self.assertEqual(window._finish_button["state"], "normal")
+
+        window._finish_button.invoke()
+
+        self.assert_called_with_new_calibration(
+            DummyStage, 'usb:123456789', None, None, None)
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_select_stage_with_input_port(self, available_stages):
+        available_stages.return_value = [
+            (DummyStage, 'usb:123456789'), (DummyStage, 'usb:987654321')]
+        window = self.setup_window()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:987654321')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:987654321')
+
+        window._stage_port_var.set(
+            window.PORT_OPTION_TEMPLATE.format(
+                port=DevicePort.INPUT))
+        self.assertEqual(window._finish_button["state"], "normal")
+        self.assertEqual(window._port, DevicePort.INPUT)
+        self.assertEqual(window._stage_polygon_cls, window.DEFAULT_POLYGON)
+        self.assertEqual(
+            window._stage_polygon_parameters,
+            window.DEFAULT_POLYGON.default_parameters)
+
+        window._finish_button.invoke()
+
+        self.assert_called_with_new_calibration(
+            DummyStage,
+            'usb:987654321',
+            DevicePort.INPUT,
+            window.DEFAULT_POLYGON,
+            window.DEFAULT_POLYGON.default_parameters)
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_select_stage_with_output_port(self, available_stages):
+        available_stages.return_value = [
+            (DummyStage, 'usb:123456789'), (DummyStage, 'usb:987654321')]
+        window = self.setup_window()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:123456789')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:123456789')
+
+        window._stage_port_var.set(
+            window.PORT_OPTION_TEMPLATE.format(
+                port=DevicePort.OUTPUT))
+        self.assertEqual(window._finish_button["state"], "normal")
+        self.assertEqual(window._port, DevicePort.OUTPUT)
+        self.assertEqual(window._stage_polygon_cls, window.DEFAULT_POLYGON)
+        self.assertEqual(
+            window._stage_polygon_parameters,
+            window.DEFAULT_POLYGON.default_parameters)
+
+        window._finish_button.invoke()
+
+        self.assert_called_with_new_calibration(
+            DummyStage,
+            'usb:123456789',
+            DevicePort.OUTPUT,
+            window.DEFAULT_POLYGON,
+            window.DEFAULT_POLYGON.default_parameters)
+
+    @patch.object(MoverNew, "get_available_stages")
+    def test_select_stage_with_single_mode_fiber(self, available_stages):
+        available_stages.return_value = [
+            (DummyStage, 'usb:123456789'), (DummyStage, 'usb:987654321')]
+        window = self.setup_window()
+
+        window._stage_table.set_selected_stage(DummyStage, 'usb:123456789')
+        window._select_stage_button.invoke()
+        self.assertIsInstance(window._stage, DummyStage)
+        self.assertEqual(window._stage.address, 'usb:123456789')
+
+        window._stage_port_var.set(
+            window.PORT_OPTION_TEMPLATE.format(
+                port=DevicePort.INPUT))
+        self.assertEqual(window._finish_button["state"], "normal")
+        self.assertEqual(window._port, DevicePort.INPUT)
+
+        window._stage_polygon_var.set("SingleModeFiber")
+        self.assertEqual(window._stage_polygon_cls, SingleModeFiber)
+        self.assertEqual(
+            window._stage_polygon_parameters,
+            SingleModeFiber.default_parameters)
+
+        window._polygon_cfg_table.parameter_source = {
+            "Orientation": MeasParamAuto(Orientation.RIGHT),
+            "Fiber Length": MeasParamAuto(10000),
+            "Fiber Radius": MeasParamAuto(200),
+            "Safety Distance": MeasParamAuto(100)
+        }
+
+        window._finish_button.invoke()
+
+        self.assert_called_with_new_calibration(
+            DummyStage,
+            'usb:123456789',
+            DevicePort.INPUT,
+            SingleModeFiber,
+            {
+                "Orientation": Orientation.RIGHT,
+                "Fiber Length": 10000,
+                "Fiber Radius": 200,
+                "Safety Distance": 100})

--- a/LabExT/View/Controls/StageTable.py
+++ b/LabExT/View/Controls/StageTable.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2023  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import logging
+from typing import Type, Any
+from tkinter import Frame, Label, TOP
+
+from LabExT.View.Controls.CustomTable import CustomTable
+from LabExT.Movement.Stage import Stage
+from LabExT.Movement.MoverNew import MoverNew
+
+
+class StageTable(Frame):
+    """
+    Frame which contains a table to select a stage.
+    """
+
+    def __init__(
+        self,
+        parent,
+        mover: Type[MoverNew],
+        exclude_active_stages: bool = True
+    ) -> None:
+        """
+        Constructor
+
+        Parameters
+        ----------
+        parent : Tk
+            Window in which frame will be placed.
+        mover : MoverNew
+            Instance of current Mover.
+        exclude_active_stages : bool = True
+            Active stages (already registered) are not displayed
+        """
+        super(StageTable, self).__init__(parent)
+
+        self.mover = mover
+        self.logger = logging.getLogger()
+
+        # Run discovering for available stages.
+        self._all_available_stages = self.mover.get_available_stages()
+        if exclude_active_stages:
+            self._used_stages = [(s.__class__, s.address)
+                                 for s in self.mover.active_stages]
+            self._available_stages = [
+                s for s in self._all_available_stages if s not in self._used_stages]
+        else:
+            self._available_stages = self._all_available_stages
+
+        self._stage_table = None
+
+        self.__setup__()
+
+    def __setup__(self) -> None:
+        """
+        Setup stage table.
+        """
+        # Setup table containing all stages
+        if self.has_stages_to_select:
+            self._stage_table = CustomTable(
+                self,
+                columns=['ID', 'Description', 'Stage Class', 'Address'],
+                rows=[(
+                    idx,
+                    str(cls.description),
+                    str(cls.__name__),
+                    str(address)
+                ) for idx, (cls, address) in enumerate(self._available_stages)],
+                col_width=20,
+                selectmode='browse')
+        else:
+            Label(
+                self,
+                text="No stages available.",
+                foreground="#FF3333"
+            ).pack(side=TOP)
+
+    @property
+    def has_stages_to_select(self) -> bool:
+        """
+        Returns True if there are stages to select
+        """
+        return len(self._available_stages) > 0
+
+    def get_selected_stage_cls(self) -> Stage:
+        """
+        Return the currently selected stage class.
+        """
+        selected_stage_tuple = self._get_selected_stage_tuple()
+        if selected_stage_tuple:
+            return selected_stage_tuple[0]
+
+    def get_selected_stage_address(self) -> Any:
+        """
+        Return the currently selected stage address.
+        """
+        selected_stage_tuple = self._get_selected_stage_tuple()
+        if selected_stage_tuple:
+            return selected_stage_tuple[1]
+
+    def set_selected_stage(
+        self,
+        stage_cls: Stage,
+        stage_address: Any,
+        add_if_missing: bool = False
+    ) -> None:
+        """
+        Set the current selected entry by the stage idx
+        """
+        stage_tuple = (stage_cls, stage_address)
+        try:
+            stage_idx = self._available_stages.index(stage_tuple)
+        except ValueError:
+            if add_if_missing and stage_tuple in self._all_available_stages:
+                self._available_stages.insert(0, stage_tuple)
+                stage_idx = 0
+
+                # Reload table
+                for child in self.winfo_children():
+                    child.forget()
+
+                self.__setup__()
+            else:
+                stage_idx = -1
+
+        if self._stage_table and stage_idx >= 0:
+            self._stage_table.select_by_id(stage_idx)
+
+    def _get_selected_stage_tuple(self) -> tuple:
+        """
+        Helper method to return the current selected stage tuple
+        by table ID.
+        """
+        selected_id = self._stage_table._tree.focus()
+        if not selected_id:
+            return None
+
+        stage_idx = int(self._stage_table._tree.set(selected_id, 0))
+        self.logger.debug('Selected stage ID: %s', stage_idx)
+        try:
+            return self._available_stages[stage_idx]
+        except IndexError as e:
+            self.logger.error(
+                f"Could not find stage idx {stage_idx} in stage table: {e}")

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -71,7 +71,7 @@ class MainWindowContextMenu(Menu):
             self._movement.add_command(
                 label=f"{len(self._mover.calibrations)} connected stage(s):",
                 state=DISABLED)
-            for c in self._mover.calibrations.values():
+            for c in self._mover.calibrations:
                 self._movement.add_cascade(
                     label=str(c),
                     menu=self._make_calibration_menu(c))
@@ -136,10 +136,10 @@ class MainWindowContextMenu(Menu):
             label=f"State: {calibration.state}",
             state=DISABLED)
         calibration_menu.add_command(
-            label=f"Orientation: {calibration._orientation}",
+            label=f"Automatice movement enabled: {calibration.is_automatic_movement_enabled}",
             state=DISABLED)
         calibration_menu.add_command(
-            label=f"Device Port: {calibration._device_port}",
+            label=f"Device Port: {calibration.device_port}",
             state=DISABLED)
 
         return calibration_menu

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -310,7 +310,7 @@ class CoordinatePairingsWindow(Toplevel):
         Builds and returns a frame to display the current pairing state.
         """
         pairing_frame = CustomFrame(parent)
-        pairing_frame.title = calibration.short_str
+        pairing_frame.title = str(calibration)
         pairing_frame.pack(side=TOP, fill=X, pady=5)
 
         if self._device:

--- a/LabExT/View/Movement/StageRegistrationWindow.py
+++ b/LabExT/View/Movement/StageRegistrationWindow.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import logging
+
+from tkinter import StringVar, OptionMenu, Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y, W
+from typing import Callable, Type
+from bidict import bidict
+
+from LabExT.Measurements.MeasAPI.Measparam import MeasParamAuto
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.ParameterTable import ParameterTable
+from LabExT.View.Controls.StageTable import StageTable
+
+from LabExT.Movement.MoverNew import MoverNew
+from LabExT.Movement.PathPlanning import SingleModeFiber
+from LabExT.Movement.Calibration import Calibration
+from LabExT.Movement.config import DevicePort
+
+
+class StageRegistrationWindow(Toplevel):
+    """
+    Window to register or edit a stage
+    """
+
+    NO_PORT_OPTION = "No, do not activate this stage for Move-to-Device."
+    PORT_OPTION_TEMPLATE = "Yes, activate this stage for the {port} port of a device."
+
+    DEFAULT_POLYGON = SingleModeFiber
+
+    def __init__(
+        self,
+        master,
+        mover: Type[MoverNew],
+        on_finish: Type[Callable],
+        calibration: Type[Calibration] = None,
+        exclude_active_stages: bool = True
+    ) -> None:
+        """
+        Constructor for new stage registration window.
+
+        Parameters
+        ----------
+        master : Tk
+            Tk instance of the master toplevel
+        mover : Mover
+            Instance of the current mover.
+        on_finish : Callable
+            Callback when finish wizard
+        calibration : Calibration = None
+            Instance of a calibration. Optional, only when editing a calibration.
+        exclude_active_stages : bool = True
+            Active stages (already registered) are not displayed
+        """
+        super(StageRegistrationWindow, self).__init__(master)
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.mover: Type[MoverNew] = mover
+        self.on_finish = on_finish
+        self.exclude_active_stages = exclude_active_stages
+        self.edit_calibration = calibration is not None
+
+        if self.edit_calibration:
+            self._calibration = calibration
+        else:
+            self._calibration = Calibration(self.mover)
+
+        # calibration properties: store them during editing
+        self._stage = self._calibration.stage
+        self._port = self._calibration.device_port
+        if self._calibration.stage_polygon:
+            self._stage_polygon_cls = self._calibration.stage_polygon.__class__
+            self._stage_polygon_parameters = self._calibration.stage_polygon.parameters
+        else:
+            self._stage_polygon_cls = self.DEFAULT_POLYGON
+            self._stage_polygon_parameters = self.DEFAULT_POLYGON.default_parameters
+
+        self._stage_selection_enabled = self._stage is None
+
+        # port menu options
+        self._port_menu_options = bidict({
+            self.PORT_OPTION_TEMPLATE.format(port=port): port
+            for port in DevicePort})
+        self._port_menu_options[self.NO_PORT_OPTION] = None
+
+        # TKinter vars
+        self._stage_table = None
+        self._polygon_cfg_table = None
+        self._stage_port_var = StringVar(
+            self, self._port_menu_options.inverse[self._port])
+        self._stage_port_var.trace(W, self._on_stage_usage_selection)
+        self._stage_polygon_var = StringVar(
+            self, str(self._stage_polygon_cls.__name__))
+        self._stage_polygon_var.trace(W, self._on_stage_polygon_selection)
+
+        # Set up window
+        self.title(
+            f"Edit {self._calibration}" if self.edit_calibration else "New Stage Registration")
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(900, 600, 200, 200))
+        self.protocol('WM_DELETE_WINDOW', self.destroy)
+
+        # Build window
+        self._main_frame = Frame(self, borderwidth=0, relief=FLAT)
+        self._main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
+
+        self._buttons_frame = Frame(
+            self,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0)
+        self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
+
+        self._finish_button = Button(
+            self._buttons_frame,
+            text="Save and Close",
+            width=15,
+            state=DISABLED,
+            command=self.finish)
+        self._finish_button.pack(
+            side=RIGHT, fill=Y, expand=0)
+
+        self.__setup__()
+
+    def __setup__(self) -> None:
+        """
+        Builds all widgets based on current state.
+        """
+        if self.edit_calibration:
+            hint = f"Edit the stage registration for the stage '{self._calibration}'."
+        else:
+            hint = "Register a new stage to be able to use it in LabExT afterward. Press F1 for help."
+
+        top_hint = Label(self._main_frame, text=hint)
+        top_hint.pack(side=TOP, fill=X)
+
+        # STEP 1: Select a stage
+        self._stage_selection_step()
+
+        # STEP 2: Use stage for move to device?
+        self._stage_usage_step()
+
+        # STEP 3: Set up polygon (optional)
+        self._stage_polygon_step()
+
+    def _stage_selection_step(self):
+        """
+        Builds a frame to select a stage.
+        """
+        stage_selection_frame = CustomFrame(self._main_frame)
+        stage_selection_frame.title = "Stage Selection"
+        stage_selection_frame.pack(side=TOP, fill=X, pady=5)
+
+        if self._stage_selection_enabled:
+            step_hint = Label(
+                stage_selection_frame,
+                text="Below you can see all the stages found by LabExT.\n "
+                "If stages are missing, go back one step and check if all drivers are loaded.")
+            step_hint.pack(side=TOP, fill=X, pady=5)
+
+            self._stage_table = StageTable(
+                stage_selection_frame,
+                self.mover,
+                self.exclude_active_stages)
+            self._stage_table.pack(side=TOP, fill=X, expand=True)
+
+            self._select_stage_button = Button(
+                stage_selection_frame,
+                text="Select marked stage",
+                state=NORMAL if self._stage_table.has_stages_to_select else DISABLED,
+                command=self._on_stage_selection)
+            self._select_stage_button.pack(side=LEFT, pady=2)
+
+            if self._stage:
+                self._stage_table.set_selected_stage(
+                    stage_cls=self._stage.__class__,
+                    stage_address=self._stage.address,
+                    add_if_missing=True)
+        else:
+            Label(
+                stage_selection_frame,
+                text=str(self._stage),
+            ).pack(side=LEFT, fill=X)
+
+            self._clear_stage_button = Button(
+                stage_selection_frame,
+                text="Clear selection",
+                command=self._on_stage_selection_clear)
+            self._clear_stage_button.pack(side=RIGHT, padx=5)
+
+    def _stage_usage_step(self):
+        """
+        Builds a frame to choose the stage usage.
+        """
+        if self._stage_selection_enabled:
+            return
+
+        stage_usage_frame = CustomFrame(self._main_frame)
+        stage_usage_frame.title = f"Enable Move-to-Device for '{self._stage}'"
+        stage_usage_frame.pack(side=TOP, fill=X, pady=5)
+
+        step_hint = Label(
+            stage_usage_frame, text=f"You can use the stage '{self._stage}' to automatically move to device inputs or outputs. \n"
+            "If this is desired, select below whether the stage should be used for a device's input or output port. \n"
+            "This selection is optional; if you do not specify this, the stage can still be used for everything except the move-to-device feature.")
+        step_hint.pack(side=TOP, fill=X, pady=5)
+
+        Label(
+            stage_usage_frame,
+            text="Enable Move-to-Device for the Stage?:", anchor="w"
+        ).pack(side=LEFT, fill=X, padx=(0, 5))
+
+        self._port_menu = OptionMenu(
+            stage_usage_frame,
+            self._stage_port_var,
+            *(list(self._port_menu_options.keys())))
+        self._port_menu.pack(side=LEFT, padx=5, pady=5)
+
+    def _stage_polygon_step(self):
+        """
+        Builds a frame to select a stage polygon and properties.
+        """
+        if self._port is None or self._stage_selection_enabled:
+            return
+
+        stage_polygon_frame = CustomFrame(self._main_frame)
+        stage_polygon_frame.title = f"Setup Stage Polygon for '{self._stage}'"
+        stage_polygon_frame.pack(side=TOP, fill=X, pady=5)
+
+        step_hint = Label(
+            stage_polygon_frame,
+            text=f"The selected stage '{self._stage}' will automatically move to the {self._port} port during Move-to-Device. \n"
+            "To allow safe and collision-free movement of the stages, the dimensions of the stage are approximated by a polygon. \n"
+            "Select a polygon below and change the properties if necessary.")
+        step_hint.pack(side=TOP, fill=X, pady=5)
+
+        polygon_selection_frame = Frame(stage_polygon_frame)
+        polygon_selection_frame.pack(side=TOP, fill=X)
+
+        Label(
+            polygon_selection_frame,
+            text="Stage polygon:", anchor="w"
+        ).pack(side=LEFT, fill=X, padx=(0, 5))
+
+        polygon_menu = OptionMenu(
+            polygon_selection_frame,
+            self._stage_polygon_var,
+            *(list(self.mover.polygon_api.imported_classes.keys())))
+        polygon_menu.pack(side=LEFT, padx=5, pady=5)
+
+        if not self._stage_polygon_cls:
+            return
+
+        polygon_cfg_frame = Frame(stage_polygon_frame)
+        polygon_cfg_frame.pack(side=TOP, fill=X)
+
+        self._polygon_cfg_table = ParameterTable(polygon_cfg_frame)
+        self._polygon_cfg_table.title = f"Configure Polygon: {self._stage_polygon_cls.__name__}"
+        self._polygon_cfg_table.parameter_source = {l: MeasParamAuto(
+            value=v) for l, v in self._stage_polygon_parameters.items()}
+        self._polygon_cfg_table.pack(
+            side=TOP, fill=X, expand=0, padx=2, pady=2)
+
+    def __reload__(self) -> None:
+        """
+        Reloads window.
+        """
+        for child in self._main_frame.winfo_children():
+            child.forget()
+
+        if self._stage is None:
+            self._finish_button.config(state=DISABLED)
+        else:
+            if self._port is None:
+                self._finish_button.config(state=NORMAL)
+            else:
+                self._finish_button.config(
+                    state=NORMAL if self._stage_polygon_cls else DISABLED)
+
+        self.__setup__()
+        self.update_idletasks()
+
+    def finish(self) -> None:
+        """
+        Callback, when user wants to finish stage assignment.
+
+        Builds the calibration and calls the on_finish callback.
+
+        Destroys the window.
+        """
+        assert self._stage is not None, "No stage has been selected. Please select one of the available stages."
+
+        if self._port is not None:
+            assert self._stage_polygon_cls is not None, "You must select a stage polygon if the stage is to be activated for move-to-device."
+            stage_polygon_cfg = self._polygon_cfg_table.make_json_able()
+            stage_polygon = self._stage_polygon_cls.load(
+                data=stage_polygon_cfg)
+        else:
+            stage_polygon = None
+
+        self._calibration.stage = self._stage
+        self._calibration.device_port = self._port
+        self._calibration.stage_polygon = stage_polygon
+
+        self.on_finish(self._calibration)
+        self.destroy()
+
+    #
+    #   Callbacks
+    #
+
+    def _on_stage_selection(self) -> None:
+        """
+        Callback, when user hits "Select marked stage" button.
+        """
+        stage_cls = self._stage_table.get_selected_stage_cls()
+        stage_address = self._stage_table.get_selected_stage_address()
+
+        if not stage_cls or not stage_address:
+            messagebox.showerror(
+                "No stage selected",
+                "No stage has been selected. Please select one of the available stages and try again.")
+            return
+
+        if self._stage is None:
+            self.logger.info(
+                f"Creating new stage object with class {stage_cls} and address {stage_address}")
+            self._stage = stage_cls(address=stage_address)
+        elif self._stage.__class__ != stage_cls or self._stage.address != stage_address:
+            self.logger.info(
+                f"Replacing stage with new stage object with class {stage_cls} and address {stage_address}")
+            self._stage = stage_cls(address=stage_address)
+        else:
+            self.logger.info(
+                f"Keeping stage {self._stage}")
+
+        self._stage_selection_enabled = False
+        self.__reload__()
+
+    def _on_stage_selection_clear(self) -> None:
+        """
+        Callback, when user wants to clear the current stage selection.
+        """
+        self._stage_selection_enabled = True
+        self.__reload__()
+
+    def _on_stage_usage_selection(self, *args, **kwargs) -> None:
+        """
+        Callback, when user selects stage usage.
+        """
+        selected_port_option = str(self._stage_port_var.get())
+        self._port = self._port_menu_options.get(selected_port_option, None)
+
+        self.__reload__()
+
+    def _on_stage_polygon_selection(self, *args, **kwargs) -> None:
+        """
+        Callback, when user selects a stage polygon.
+        """
+        selected_polygon_option = str(self._stage_polygon_var.get())
+        self._stage_polygon_cls = self.mover.polygon_api.get_class(
+            selected_polygon_option)
+        self._stage_polygon_parameters = self._stage_polygon_cls.default_parameters
+
+        self.__reload__()


### PR DESCRIPTION
**This is the most curial part of the rewrite. Happy to discuss this remotely.**

This pull request removes the Orientation Property from Calibration and Mover Level. This is now part of the StagePolygon.

New:
- Mover now stores a normal list of calibrations (theoretically now any number).
- Mover manages a mapping from port (currently: input and output) to a calibration. These calibrations are used in Move-to-Device.
- Calibrations have a property `is_automatic_movement_enabled`. This is true if the calibrations has a port AND a stage polygon assigned. This calibration can be used for Move-to-Device.

The mover has been simplified considerably. All calibrations can be registered with Mover as long as they do not use a stage or port twice.