### PR TITLE
(7/8) Add load and dump for Stages

### DIFF
--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -10,7 +10,7 @@ import logging
 
 from functools import wraps
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Type
 
 
 class StageError(RuntimeError):
@@ -67,6 +67,13 @@ class Stage(ABC):
     description: str = ""
 
     _logger = logging.getLogger()
+
+    @classmethod
+    def load(cls, data: dict) -> Type[Stage]:
+        """
+        Loads stage from stored properties.
+        """
+        return cls(address=data.get("address"))
 
     @classmethod
     def find_stage_addresses(cls) -> list:
@@ -330,3 +337,11 @@ class Stage(ABC):
             i.e., all axes are stopped.
         """
         pass
+
+    def dump(self) -> dict:
+        """
+        Returns stage properties as dict
+        """
+        return {
+            "address": self.address
+        }

--- a/LabExT/Movement/Stages/Stage3DSmarAct.py
+++ b/LabExT/Movement/Stages/Stage3DSmarAct.py
@@ -4,13 +4,15 @@
 LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
+from __future__ import annotations
+
 import sys
 import json
 import time
 import ctypes as ct
 
 from enum import Enum
-from typing import List
+from typing import List, Type
 
 from LabExT.Movement.config import Axis
 from LabExT.Movement.Stage import Stage, StageError, assert_stage_connected, assert_driver_loaded
@@ -55,6 +57,23 @@ class Stage3DSmarAct(Stage):
     driver_path_dialog = None
     driver_specifiable = True
     description = "SmarAct Modular Control System"
+
+    @classmethod
+    def load(cls, data: dict) -> Type[Stage3DSmarAct]:
+        """
+        Loads a SmarAct stage with given properties.
+        """
+        address = str(data.get("address"))
+        if not address:
+            raise ValueError(
+                "Cannot load SmarAct stage without address.")
+
+        available_addresses = cls.find_stage_addresses()
+        if address not in available_addresses:
+            raise ValueError(
+                f"Cannot load SmarAct stage with address {address}. Address is not available.")
+
+        return Stage3DSmarAct(address=address)
 
     @classmethod
     def load_driver(cls, parent) -> bool:
@@ -598,6 +617,14 @@ class Stage3DSmarAct(Stage):
 
         if wait_for_stopping:
             self._wait_for_stopping()
+
+    def dump(self) -> dict:
+        """
+        Returns a SmarAct stage as dict.
+        """
+        return {
+            "address": self.address.decode('utf-8')
+        }
 
     # Helper methods
 

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -624,6 +624,17 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_xy_mock.assert_has_calls(
             [call(5000), call(current_speed_xy)])
 
+    def test_dump_includes_stage(self):
+        calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
+        calibration_dump = calibration.dump()
+
+        self.assertEqual(calibration_dump["stage"], {
+            "class": "DummyStage",
+            "parameters": {
+                "address": "usb:123456789"
+            }
+        })
+
     def test_dump_includes_port(self):
         calibration = Calibration(self.mover, self.stage, DevicePort.INPUT)
         calibration_dump = calibration.dump()
@@ -703,10 +714,14 @@ class CalibrationTest(CalibrationTestCase):
 
 
     def test_load_with_axes_rotation(self):
-        self.stage.connect()
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -714,11 +729,11 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        restored_calibration = Calibration.load(self.mover, calibration_data)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
 
     def test_load_with_single_point_offset(self):
-        self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
             devices=[
@@ -726,8 +741,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -740,7 +760,8 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip=chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip=chip)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
 
     def test_load_with_kabsch_rotation(self):
@@ -755,8 +776,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "axes_rotation": {
                 'X': ('NEGATIVE', 'Z'),
                 'Y': ('POSITIVE', 'X'),
@@ -791,7 +817,8 @@ class CalibrationTest(CalibrationTestCase):
             ]
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip)
+        restored_calibration.connect_to_stage()
         self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
 
     def test_load_with_stage_polygon(self):
@@ -806,8 +833,13 @@ class CalibrationTest(CalibrationTestCase):
             ])
 
         calibration_data = {
-            "orientation": "LEFT",
             "device_port": "INPUT",
+            "stage": {
+                "class": "DummyStage",
+                "parameters": {
+                    "address": "tcp:192.168.0.42:1234"
+                }
+            },
             "stage_polygon":  {
                 "class": "SingleModeFiber",
                 "parameters": {
@@ -819,7 +851,8 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.mover, calibration_data, chip)
+        restored_calibration.connect_to_stage()
         
         self.assertIsInstance(restored_calibration.stage_polygon, SingleModeFiber)
         self.assertDictEqual(restored_calibration.stage_polygon.parameters, {


### PR DESCRIPTION
Add methods to save stage properties to disk and load them again. Use the new MoverAPI to load available stage classes/implementations.