### PR TITLE
Allow changes to chip name if no chip imported

### DIFF
--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -135,6 +135,8 @@ class MainWindowModel:
         self.commands[0].can_execute = True  # enable the start button
         self.commands[1].can_execute = False  # disable the stop button
         # enable change in save file parameters
+        if not self.experiment_manager.chip:
+            self.allow_change_chip_params.set(True)
         self.allow_change_save_params.set(True)
 
     def exctrl_vars_changed(self, *args):


### PR DESCRIPTION
This is a super small change. Basically it allows the user to change the name of the chip in the main window after a measurement is executed. Meaning, one can perform two measurements with different chip names in the same LabExT session without closing and reopening the GUI. 
Only if a chip is imported, the chip name cannot be changed anymore. This holds also true if a chip is loaded from the last session.