### PR TITLE
Measurement Wizard Rework

### DIFF
--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -358,7 +358,7 @@ class StandardExperiment:
         self.measurements_hashes.remove(mh)
         self.measurements.remove(meas_dict)
 
-    def create_measurement_object(self, class_name):
+    def create_measurement_object(self, class_name) -> Measurement:
         """Import, load and initialise measurement.
 
         Parameters

--- a/LabExT/Measurements/MeasAPI/Measurement.py
+++ b/LabExT/Measurements/MeasAPI/Measurement.py
@@ -7,6 +7,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import logging
 
+from typing import List
+
 
 class Measurement:
     """Super class for measurement algorithms for LabExT.
@@ -183,7 +185,7 @@ class Measurement:
         raise NotImplementedError()
 
     @staticmethod
-    def get_wanted_instrument():
+    def get_wanted_instrument() -> List[str]:
         """The list of all instrument types (strings) required in this measurement.
 
         Inside the `algorithm`, you can access the instantiated instrument driver classes by accessing the

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -75,7 +75,7 @@ class MainWindowTest(TKinterTestCase):
         self.test_mainwindow_single_IL_sweep()
 
     def test_mainwindow_single_IL_sweep(self):
-        with patch('LabExT.View.EditMeasurementWizard.EditMeasurementWizardController.get_visa_address',
+        with patch('LabExT.View.EditMeasurementWizard.WizardEntry.MeasurementSelect.get_visa_address',
                    simulator_only_instruments_descriptions):
             self.main_window_setup()
 

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -100,24 +100,24 @@ class MainWindowTest(TKinterTestCase):
                 'id': randomword(random.randint(5, 25)),
                 'type': randomword(random.randint(5, 25))
             }
-            new_meas_wizard_c.view.s0_adhoc_frame._entry_id.delete(0, "end")
-            new_meas_wizard_c.view.s0_adhoc_frame._entry_id.insert(0, str(random_dev_props['id']))
-            new_meas_wizard_c.view.s0_adhoc_frame._entry_type.delete(0, "end")
-            new_meas_wizard_c.view.s0_adhoc_frame._entry_type.insert(0, str(random_dev_props['type']))
-            with patch.object(new_meas_wizard_c.view.s0_adhoc_frame, 'serialize'):
+            new_meas_wizard_c.entry_controllers[0]._view.content._entry_id.delete(0, "end")
+            new_meas_wizard_c.entry_controllers[0]._view.content._entry_id.insert(0, str(random_dev_props['id']))
+            new_meas_wizard_c.entry_controllers[0]._view.content._entry_type.delete(0, "end")
+            new_meas_wizard_c.entry_controllers[0]._view.content._entry_type.insert(0, str(random_dev_props['type']))
+            with patch.object(new_meas_wizard_c.entry_controllers[0]._view.content, 'serialize'):
                 with patch.object(new_meas_wizard_c, 'serialize_settings', lambda: None):
-                    new_meas_wizard_c.view.section_frames[0].continue_button.invoke()
+                    new_meas_wizard_c.entry_controllers[0]._view.continue_button.invoke()
                     self.pump_events()
 
             # stage 1: meas selection
-            new_meas_wizard_c.view.s1_meas_name.set('InsertionLossSweep')
+            new_meas_wizard_c.entry_controllers[1]._view.meas_name.set('InsertionLossSweep')
             with patch.object(new_meas_wizard_c, 'serialize_settings', lambda: None):
-                new_meas_wizard_c.view.section_frames[1].continue_button.invoke()
+                new_meas_wizard_c.entry_controllers[1]._view.continue_button.invoke()
                 self.pump_events()
 
             # stage 2: instrument selection - modify saved roles
-            laser_role = new_meas_wizard_c.view.s2_instrument_selector.instrument_source['Laser']
-            opm_role = new_meas_wizard_c.view.s2_instrument_selector.instrument_source['Power Meter']
+            laser_role = new_meas_wizard_c.entry_controllers[2]._view.content.instrument_source['Laser']
+            opm_role = new_meas_wizard_c.entry_controllers[2]._view.content.instrument_source['Power Meter']
             lsim = [l for l in laser_role.choices_human_readable_desc if "LaserSimulator" in l][0]
             pmsim = [l for l in opm_role.choices_human_readable_desc if "PowerMeterSimulator" in l][0]
             laser_role.selected_instr.set(lsim)
@@ -125,9 +125,9 @@ class MainWindowTest(TKinterTestCase):
             opm_role.selected_instr.set(pmsim)
             opm_role.selected_channel.set("1")
 
-            with patch.object(new_meas_wizard_c.view.s2_instrument_selector, 'serialize', lambda _: None):
+            with patch.object(new_meas_wizard_c.entry_controllers[2]._view.content, 'serialize', lambda _: None):
                 with patch.object(new_meas_wizard_c, 'serialize_settings', lambda: None):
-                    new_meas_wizard_c.view.section_frames[2].continue_button.invoke()
+                    new_meas_wizard_c.entry_controllers[2]._view.continue_button.invoke()
                     self.pump_events()
 
             # stage 3: parameter selection with randomly generated params
@@ -140,7 +140,7 @@ class MainWindowTest(TKinterTestCase):
                 'powermeter range': random.randint(-80, -20),
                 'users comment': 'automated testing ' + randomword(random.randint(2, 40))
             }
-            ps = new_meas_wizard_c.view.s3_measurement_param_table._parameter_source
+            ps = new_meas_wizard_c.entry_controllers[3]._view.content._parameter_source
             ps['wavelength start'].value = random_meas_props['wavelength start']
             ps['wavelength stop'].value = random_meas_props['wavelength stop']
             ps['wavelength step'].value = random_meas_props['wavelength step']
@@ -150,13 +150,13 @@ class MainWindowTest(TKinterTestCase):
             ps['users comment'].value = random_meas_props['users comment']
 
             # this would otherwise save the test params to the user's settings
-            with patch.object(new_meas_wizard_c.view.s3_measurement_param_table, 'serialize'):
+            with patch.object(new_meas_wizard_c.entry_controllers[3]._view.content, 'serialize'):
                 with patch.object(new_meas_wizard_c, 'serialize_settings', lambda: None):
-                    new_meas_wizard_c.view.section_frames[3].continue_button.invoke()
+                    new_meas_wizard_c.entry_controllers[3]._view.continue_button.invoke()
                     self.pump_events()
 
             # stage 4: save
-            new_meas_wizard_c.view.section_frames[4].continue_button.invoke()
+            new_meas_wizard_c.entry_controllers[4]._view.continue_button.invoke()
             self.pump_events()
 
             # check if GUI provided values made it into the generated measurement

--- a/LabExT/View/Controls/AdhocDeviceFrame.py
+++ b/LabExT/View/Controls/AdhocDeviceFrame.py
@@ -181,3 +181,34 @@ class AdhocDeviceFrame(CustomFrame):
         self._extra_parameter_vars = [(StringVar(value=kv), StringVar(value=vv)) for kv, vv in
                                       data["extra_parameter"].items() if len(kv) > 0 or len(vv) > 0]
         self.__setup_extra_params__()
+
+    def serialize_to_dict(self, store_location: dict):
+        """Serializes data in table to dict."""
+        data = {
+            "_id": self._entry_id.get(),
+            "_inp_x": self._entry_inp_x.get() or 0,
+            "_inp_y": self._entry_inp_y.get() or 0,
+            "_oup_x": self._entry_oup_x.get() or 0,
+            "_oup_y": self._entry_oup_y.get() or 0,
+            "_type": self._entry_type.get()
+        }
+        data['extra_parameter'] = {kv.get(): vv.get() for kv, vv in self._extra_parameter_vars}
+        store_location.update(data)
+
+    def deserialize_from_dict(self, data: dict):
+        """Deserializes the table data from a given dict and loads it
+        into the cells."""
+        if len(data) == 0:
+            return
+
+        self._entry_id.insert(0, data["_id"])
+        self._entry_type.insert(0, data["_type"])
+        self._entry_inp_x.insert(0, data["_inp_x"])
+        self._entry_inp_y.insert(0, data["_inp_y"])
+        self._entry_oup_x.insert(0, data["_oup_x"])
+        self._entry_oup_y.insert(0, data["_oup_y"])
+
+        # do not save empty extra parameters
+        self._extra_parameter_vars = [(StringVar(value=kv), StringVar(value=vv)) for kv, vv in
+                                      data["extra_parameter"].items() if len(kv) > 0 or len(vv) > 0]
+        self.__setup_extra_params__()

--- a/LabExT/View/Controls/InstrumentSelector.py
+++ b/LabExT/View/Controls/InstrumentSelector.py
@@ -236,3 +236,22 @@ class InstrumentSelector(CustomFrame):
             if role_name in self._instrument_source:
                 self._instrument_source[role_name].create_and_set(data[role_name])
         self.__setup__()
+
+    def serialize_to_dict(self, settings: dict):
+        """Serializes data in table to given dict."""
+        if self._instrument_source is None:
+            return
+
+        for role_name in self._instrument_source:
+            settings[role_name] = self._instrument_source[role_name].choice
+
+    def deserialize_from_dict(self, settings: dict):
+        """Deserializes the table data from a given dict and loads it
+        into the cells."""
+        if self._instrument_source is None:
+            return
+            
+        for role_name, role in settings.items():
+            if role_name in self._instrument_source:
+                self._instrument_source[role_name].create_and_set(role)
+        self.__setup__()

--- a/LabExT/View/Controls/KeyboardShortcutButtonPress.py
+++ b/LabExT/View/Controls/KeyboardShortcutButtonPress.py
@@ -6,10 +6,11 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import logging
-from tkinter import Button, TclError
+from typing import Callable
+from tkinter import Button, TclError, Event
 
 
-def callback_if_btn_enabled(callback_fn, tk_button: Button):
+def callback_if_btn_enabled(callback_fn, tk_button: Button) -> Callable[[Event], object]:
     """
     Creates and returns a callback function which ONLY fires if the corresponding button element is in enabled state.
 

--- a/LabExT/View/Controls/ParameterTable.py
+++ b/LabExT/View/Controls/ParameterTable.py
@@ -44,7 +44,8 @@ class ConfigParameter(object):
         elif parameter_type == 'bool':
             self.variable = BooleanVar(parent, value)
         elif parameter_type == 'dropdown':
-            self.variable = StringVar(parent, value[0] if ddvar is None else ddvar)
+            self.variable = StringVar(
+                parent, value[0] if ddvar is None else ddvar)
             self.options = value
         else:
             self.variable = StringVar(parent, value)
@@ -125,7 +126,8 @@ class ParameterTable(CustomFrame):
         # add the fields for all the parameters
         r = 0
         for parameter_name in self.parameter_source:
-            parameter = self.parameter_source[parameter_name]  # get the next parameter
+            # get the next parameter
+            parameter = self.parameter_source[parameter_name]
             self.add_widget(Label(self, text='{}:'.format(parameter_name)),
                             row=r,
                             column=0,
@@ -247,6 +249,14 @@ class ParameterTable(CustomFrame):
             json_file.write(json.dumps(data))
         return True
 
+    def serialize_to_dict(self, settings: dict):
+        """Serializes data in table to dict. Takes a dict as parameter and first converts all the data
+        of this parameter table to json-able format and then writes this to the provided dict with the new key 'data'."""
+        if self._parameter_source is None:
+            return False
+        settings['data'] = self.make_json_able()
+        return True
+
     def deserialize(self, file_name):
         """Deserializes the table data from a given file and loads it
         into the cells."""
@@ -259,7 +269,29 @@ class ParameterTable(CustomFrame):
             try:
                 self._parameter_source[parameter_name].value = data[parameter_name]
             except KeyError:
-                self._logger.warning("Unknown key in save file: " + str(parameter_name) + ". Ignoring this parameter.")
+                self._logger.warning(
+                    "Unknown key in save file: " + str(parameter_name) + ". Ignoring this parameter.")
+        self.__setup__()
+        return True
+
+    def deserialize_from_dict(self, settings: dict):
+        """Deserializes the table data from a given dict and loads it
+        into the cells."""
+        if self._parameter_source is None:
+            return False
+
+        try:
+            data = settings['data']
+        except KeyError:
+            return False
+
+        for parameter_name in data:
+            try:
+                self._parameter_source[parameter_name].value = data[parameter_name]
+            except KeyError:
+                self._logger.warning(
+                    f"Unknown key in save file: {parameter_name}. Ignoring this parameter.")
+
         self.__setup__()
         return True
 
@@ -275,7 +307,8 @@ class ParameterTable(CustomFrame):
             try:
                 _ = v.value
             except TclError as e:
-                error_texts.append('"' + str(k) + '" got wrong value type: ' + str(e))
+                error_texts.append(
+                    '"' + str(k) + '" got wrong value type: ' + str(e))
         if error_texts:
             raise ValueError("\n".join(error_texts))
 
@@ -288,9 +321,11 @@ class ParameterTable(CustomFrame):
         to_ret = {}
         for k, v in self._parameter_source.items():
             if v.parameter_type == 'dropdown':
-                to_ret[k] = MeasParamAuto(value=v.options, selected=v.value, unit=v.unit, extra_type=v.parameter_type)
+                to_ret[k] = MeasParamAuto(
+                    value=v.options, selected=v.value, unit=v.unit, extra_type=v.parameter_type)
             else:
-                to_ret[k] = MeasParamAuto(value=v.value, unit=v.unit, extra_type=v.parameter_type)
+                to_ret[k] = MeasParamAuto(
+                    value=v.value, unit=v.unit, extra_type=v.parameter_type)
         return to_ret
 
     def writeback_meas_values(self, event=None):

--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardController.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardController.py
@@ -13,7 +13,7 @@ from tkinter import messagebox, TclError
 from typing import TYPE_CHECKING, List
 
 from LabExT.Experiments.ToDo import ToDo
-from LabExT.Utils import get_visa_address, get_configuration_file_path
+from LabExT.Utils import get_configuration_file_path
 from LabExT.View.Controls.InstrumentSelector import InstrumentRole
 from LabExT.View.EditMeasurementWizard.EditMeasurementWizardModel import EditMeasurementWizardModel
 from LabExT.View.EditMeasurementWizard.EditMeasurementWizardView import EditMeasurementWizardView

--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardController.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardController.py
@@ -10,11 +10,22 @@ import logging
 import os
 from tkinter import messagebox, TclError
 
+from typing import TYPE_CHECKING, List
+
 from LabExT.Experiments.ToDo import ToDo
 from LabExT.Utils import get_visa_address, get_configuration_file_path
 from LabExT.View.Controls.InstrumentSelector import InstrumentRole
 from LabExT.View.EditMeasurementWizard.EditMeasurementWizardModel import EditMeasurementWizardModel
 from LabExT.View.EditMeasurementWizard.EditMeasurementWizardView import EditMeasurementWizardView
+from LabExT.View.EditMeasurementWizard.WizardEntry.Factory import wizard_entry_controller_factory
+from LabExT.View.EditMeasurementWizard.WizardEntry.FinishedError import WizardFinishedError
+
+if TYPE_CHECKING:
+    from LabExT.ExperimentManager import ExperimentManager
+    from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryController
+else:
+    ExperimentManager = None
+    WizardEntryController = None
 
 
 class EditMeasurementWizardController:
@@ -23,7 +34,7 @@ class EditMeasurementWizardController:
     Sets up model and view classes, contains control logic, callback functions for the EditMeasurementWizard
     """
 
-    def __init__(self, parent, experiment_manager):
+    def __init__(self, parent, experiment_manager: ExperimentManager):
         self.root = parent
         self.experiment_manager = experiment_manager
         self._experiment = self.experiment_manager.exp
@@ -31,7 +42,9 @@ class EditMeasurementWizardController:
         self.logger = logging.getLogger()
 
         self.model = EditMeasurementWizardModel(self.experiment_manager)
-        self.view = EditMeasurementWizardView(self.model, self, self.root, self.experiment_manager)
+        self.view = EditMeasurementWizardView(
+            self.model, self, self.root, self.experiment_manager)
+        self.entry_controllers: List[WizardEntryController] = []
 
         # set the proper reference in the model class
         self.model.set_view(self.view)
@@ -42,187 +55,86 @@ class EditMeasurementWizardController:
         # start the GUI
         self.stage_start(0)
 
+    def escape_event(self, stage_nr: int):
+        """This method is called by the WizardEntryViews if the user hits escape.
+        
+        Ideally this would be done with an event system, where this
+        controller inherits from the (theoretical) EscapeEventListener
+        interface and adds itself to the event-creating WizardEntries.
+        However, this is out of scope for this update. Maybe in the 
+        future though :-)
+        """
+        if stage_nr == 0:
+            self.view.wizard_window.destroy()
+        else:
+            self.stage_start(stage_nr - 1)
+
     def stage_start(self, stage_number):
         """
         start stage with given number, takes care of GUI changes
         """
+        # make sure to remove trailing stages if escape 
+        # or back-button was pressed
+        for controller in self.entry_controllers[stage_number:]:
+            self.logger.debug(
+                f"Removing controller {controller} from EditMeasurementWizard")
+            controller.remove()
+        self.entry_controllers = self.entry_controllers[:stage_number]
         # disable all frames before
-        for stage_idx in range(0, stage_number):
-            section_frame = self.view.section_frames[stage_idx]
-            if section_frame is not None:
-                # disable all content in frame
-                section_frame.enabled = False
-                # relink continue button to restart own stage
-                section_frame.continue_button.config(text="Back", command=self._start_stage_wrapper(stage_idx))
+        for controller in self.entry_controllers[:stage_number]:
+            self.logger.debug(
+                f"Disabling controller {controller} in EditMeasurementWizard")
+            controller.disable()
 
-        # remove selected and all future step frames from GUI
-        for stage_idx in range(stage_number, len(self.view.section_frames)):
-            section_frame = self.view.section_frames[stage_idx]
-            if section_frame is not None:
-                section_frame.grid_remove()
-
-        # call GUI setup function of step
-        if stage_number == 0:
-            if self.model.chip_available:
-                self.view.s0_chip_device_selection_setup()
-            else:
-                self.view.s0_adhoc_device_selection_setup()
-        elif stage_number == 1:
-            self.view.s1_measurement_selection_setup()
-        elif stage_number == 2:
-            self.view.s2_instrument_selection_setup()
-        elif stage_number == 3:
-            self.view.s3_measurement_parameter_setup()
-        elif stage_number == 4:
-            self.view.s4_final_save_buttons()
-        else:
-            raise ValueError("Unknown stage with number {:d}".format(stage_number))
+        # adding new wizard entry
+        self.entry_controllers.append(wizard_entry_controller_factory(
+            stage_number, self.model.chip_available, self.view._wizard_frame, self))
 
         # call business logic after setup of stage
         self.stage_start_logic(stage_number=stage_number)
+        return
 
-    def stage_start_logic(self, stage_number):
+    def stage_start_logic(self, stage_number: int):
         """
         takes care of business logic when starting a new stage
         """
-        # first, load any settings there might already be saved
+        # first, load settings from disk
         self.deserialize_settings()
 
-        if stage_number == 0:
-            # if available: define a pre-selected device from savefilemore
-            if self.model.chip_available:
-                # chip-based device
-                if self.model.saved_s0_device_id is not None:
-                    # this fails silently if device ID is not available in table
-                    self.view.s0_device_table.set_selected_device(self.model.saved_s0_device_id)
-                    # fill info-string to user since table does not autoscroll
-                    dev = self.view.s0_device_table.get_selected_device()
-                    if dev is not None:
-                        self.view.s0_selected_device_info['text'] = "Pre-selected device: " + str(dev)
-                    else:
-                        msg = 'Device ID loaded from settings file ({}) is not available ' + \
-                              'in the current chip. Not setting a default.'
-                        self.logger.info(msg.format(self.model.saved_s0_device_id))
-            else:
-                # ad hoc device
-                self.view.s0_adhoc_frame.deserialize(self.model.adhoc_device_save_file_name)
-        elif stage_number == 1:
-            # if available: define a pre-selected measurement from save file
-            if self.model.saved_s1_measurement_name is not None:
-                if self.model.saved_s1_measurement_name in self._experiment.measurement_list:
-                    self.view.s1_meas_name.set(self.model.saved_s1_measurement_name)
-                else:
-                    msg = 'Measurement name loaded from settings file ({:s}) is not available ' + \
-                          'in the current experiment. Not setting a default.'
-                    self.logger.info(msg.format(self.model.saved_s1_measurement_name))
-            if self.model.saved_s1_measurement_nr is not None:
-                self.view.s1_meas_nr.set(self.model.saved_s1_measurement_nr)
-        elif stage_number == 2:
-            # if available: define instrument selection
-            self.view.s2_instrument_selector.deserialize(self.model.instrument_settings_file_name)
-        elif stage_number == 3:
-            # if available: define measurement parameters from savefile
-            # save the parameters to measurement
-            self.model.s1_measurement.parameters = self.view.s3_measurement_param_table.to_meas_param()
-            if self.model.s1_measurement is not None:
-                self.view.s3_measurement_param_table.deserialize(self.model.s1_measurement.settings_path)
-        elif stage_number == 4:
-            # there is nothing to load or save for the save button stage
-            pass
-        else:
-            raise ValueError("Unknown stage with number {:d}".format(stage_number))
+        # then, populate entries
+        self.entry_controllers[stage_number].deserialize(
+            self.model.settings[stage_number])
 
-    def stage_completed(self, stage_number):
+        return
+
+    def stage_completed(self, stage_number: int):
         """
         Wraps stage_completed_logic to disable / enable continue button.
         """
-        self.view.section_frames[stage_number].continue_button['state'] = 'disabled'
+        self.entry_controllers[stage_number].allow_interaction(False)
         self.stage_completed_logic(stage_number=stage_number)
         try:
-            self.view.section_frames[stage_number].continue_button['state'] = 'normal'
+            self.entry_controllers[stage_number].allow_interaction(True)
         except TclError:
             # this is expected since the button has been destroyed if the user closes the window
             pass
 
-    def stage_completed_logic(self, stage_number):
+    def stage_completed_logic(self, stage_number: int):
         """
         Called when the user presses the "Continue" button of a stage. Takes care of business logic.
         """
-        if stage_number == 0:
-            if self.model.chip_available:
-                # chip based device, save id to file
-                self.model.s0_device = self.view.s0_device_table.get_selected_device()
-                if self.model.s0_device is None:
-                    self.show_error("No device selected",
-                                    "No device selected. Please select a device to continue.")
-                    return
-                self.view.s0_selected_device_info['text'] = "Selected device: " + str(self.model.s0_device)
-            else:
-                # adhoc device, serialize
-                try:
-                    self.model.s0_device = self.view.s0_adhoc_frame.get_custom_device()
-                except ValueError as err:
-                    self.show_error('Value Error', 'Invalid data was entered: ' + str(err))
-                    return
-                self.view.s0_adhoc_frame.serialize(self.model.adhoc_device_save_file_name)
-
-        elif stage_number == 1:
-            # initialize given measurement
-            selected_meas_name = self.view.s1_meas_name.get()
-            if selected_meas_name == self.view.default_text:
-                self.show_error("No measurement selected",
-                                "No measurement selected. Please select a valid Measurement to continue.")
-                return
-            self.model.s1_measurement = self._experiment.create_measurement_object(selected_meas_name)
-            # find available instruments for given measurement
-            available_instruments = dict()
-            for role_name in self.model.s1_measurement.get_wanted_instrument():
-                io_set = get_visa_address(role_name)
-
-                available_instruments.update({role_name: InstrumentRole(self.view.wizard_window, io_set)})
-            self.model.s1_available_instruments = available_instruments
-
-        elif stage_number == 2:
-            # get the chosen experiment descriptor dicts for each role and save it to the measurement
-            for role_name, role_instrs in self.model.s1_available_instruments.items():
-                self.model.s1_measurement.selected_instruments.update({role_name: role_instrs.choice})
-            # initialize the instruments
-            try:
-                # we now do that in the controller
-                # first we start the progress bar
-                self.model.s1_measurement.init_instruments()
-            except Exception as e:
-                self.show_error("Instrument initialization error",
-                                "Could not initialize instruments. Reason: " + repr(e))
-                return
-            # finally, save the instrument choices to file
-            self.view.s2_instrument_selector.serialize(self.model.instrument_settings_file_name)
-
-        elif stage_number == 3:
-            try:
-                self.view.s3_measurement_param_table.check_parameter_validity()
-            except ValueError as e:
-                self.show_error('Value Error', 'Invalid data was entered:\n' + str(e))
-                return
-            # we serialize the user settings to file for future use
-            if self.model.s1_measurement is not None:
-                self.view.s3_measurement_param_table.serialize(self.model.s1_measurement.settings_path)
-            else:
-                msg = "Measurement is not defined. Cannot serialize measurement parameters."
-                self.logger.warning(msg)
-
-        elif stage_number == 4:
-            # save device reference and new measurement to the experiment's to_do_list and close wizard
-            self._experiment.to_do_list.append(ToDo(self.model.s0_device, self.model.s1_measurement))
-            self._experiment.update()
-            self.view.scrollable_frame.unbound_mouse_wheel()
-            self.view.wizard_window.destroy()
+        try:
+            self.model.results[stage_number] = self.entry_controllers[stage_number].results(
+            )
+        except ValueError as v:
+            self.show_error("Can't continue", str(v))
+            return
+        except WizardFinishedError:
             return
 
-        else:
-            raise ValueError("Unknown stage with number {:d}".format(stage_number))
-
-        # save user settings to file
+        # save settings
+        self.entry_controllers[stage_number].serialize(
+            self.model.settings[stage_number])
         self.serialize_settings()
 
         # launch next stage
@@ -238,40 +150,45 @@ class EditMeasurementWizardController:
 
     def show_error(self, title, message):
         self.logger.error(message)
-        messagebox.showerror(title=title, message=message, parent=self.view.wizard_window)
+        messagebox.showerror(title=title, message=message,
+                             parent=self.view.wizard_window)
 
     def serialize_settings(self):
-        """Saves user entries from s0 and s1 to file."""
+        """Saves user entries to disk."""
 
         # load old settings if available
-        settings_path = get_configuration_file_path(self.model.settings_file_name)
+        settings_path = get_configuration_file_path(
+            self.model.settings_file_name)
+
         if os.path.isfile(settings_path):
             with open(settings_path, 'r') as json_file:
-                data = json.loads(json_file.read())
+                settings = json.loads(json_file.read())
+                settings = {int(k): v for k, v in settings.items()}
         else:
-            data = {}
+            settings = {}
 
         # read current parameters to save dict
-        if self.model.s0_device is not None:
-            data['device_id'] = self.model.s0_device.id
-        if self.model.s1_measurement is not None:
-            data['measurement_name'] = self.model.s1_measurement.name
+        settings.update(self.model.settings)
 
         # store save dict to file
         with open(settings_path, 'w') as json_file:
-            json_file.write(json.dumps(data))
+            json_file.write(json.dumps(settings, indent=4))
 
     def deserialize_settings(self):
-        """Loads user entries from s0 and s1."""
+        """Loads user entries from disk."""
 
         # load settings if available
-        settings_path = get_configuration_file_path(self.model.settings_file_name)
+        settings_path = get_configuration_file_path(
+            self.model.settings_file_name)
         if os.path.isfile(settings_path):
             with open(settings_path, 'r') as json_file:
+                # read from file and convert keys to int
                 data = json.loads(json_file.read())
+                data = {int(k): v for k, v in data.items()}
 
             # read current parameters to save dict
-            if 'device_id' in data:
-                self.model.saved_s0_device_id = data['device_id']
-            if 'measurement_name' in data:
-                self.model.saved_s1_measurement_name = data['measurement_name']
+            self.model.settings.update(data)
+
+    def register_keyboard_shortcut(self, keys: str, action) -> None:
+        if keys != "<F1>":
+            self.view.register_keyboard_shortcut(keys, action)

--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardModel.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardModel.py
@@ -7,6 +7,9 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 import logging
 
+from typing import Dict
+from collections import defaultdict
+
 
 class EditMeasurementWizardModel:
     """
@@ -21,7 +24,7 @@ class EditMeasurementWizardModel:
 
         self._experiment_manager = experiment_manager
         self._experiment = self._experiment_manager.exp
-        self.chip_available = True if self._experiment_manager.chip is not None else False
+        self.chip_available = self._experiment_manager.chip is not None
 
         self.logger = logging.getLogger()
 
@@ -30,64 +33,12 @@ class EditMeasurementWizardModel:
 
         # saved user settings
         self.settings_file_name = 'EditMeasurementWizard_settings.json'
-        self.instrument_settings_file_name = 'EditMeasurementWizard_instr_settings.json'
-        self.adhoc_device_save_file_name = 'EditMeasurementWizard_adhoc_settings.json'
-        self.saved_s0_device_id = None
-        self.saved_s1_measurement_name = None
-        self.saved_s1_measurement_nr = None
 
         # user selected data
-        self.s0_device = None
-        self.s1_measurement = None
-        self.s1_available_instruments = None
-
-    @property
-    def saved_s0_device_id(self):
-        return self._saved_s0_device_id
-
-    @saved_s0_device_id.setter
-    def saved_s0_device_id(self, new_id):
-        self._saved_s0_device_id = new_id
-
-    @property
-    def saved_s1_measurement_name(self):
-        return self._saved_s1_measurement_name
-
-    @saved_s1_measurement_name.setter
-    def saved_s1_measurement_name(self, new_name):
-        self._saved_s1_measurement_name = new_name
-
-    @property
-    def saved_s1_measurement_nr(self):
-        return self._saved_s1_measurement_nr
-
-    @saved_s1_measurement_nr.setter
-    def saved_s1_measurement_nr(self, new_nr):
-        self._saved_s1_measurement_nr = new_nr
-
-    @property
-    def s0_device(self):
-        return self._s0_device
-
-    @s0_device.setter
-    def s0_device(self, new_dev):
-        self._s0_device = new_dev
-
-    @property
-    def s1_measurement(self):
-        return self._s1_measurement
-
-    @s1_measurement.setter
-    def s1_measurement(self, new_measurement):
-        self._s1_measurement = new_measurement
-
-    @property
-    def s1_available_instruments(self):
-        return self._s1_available_instruments
-
-    @s1_available_instruments.setter
-    def s1_available_instruments(self, new_instr):
-        self._s1_available_instruments = new_instr
+        self.settings: Dict[int, Dict] = defaultdict(lambda: {})
+        """Maps the stage number to the previous entries of the WizardEntry."""
+        self.results: Dict[int] = {}
+        """Maps the stage number to the results of the WizardEntry."""
 
     def set_view(self, view):
         self._view = view

--- a/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
+++ b/LabExT/View/EditMeasurementWizard/EditMeasurementWizardView.py
@@ -23,7 +23,8 @@ class WizardWindow(Toplevel):
         Toplevel.__init__(self, parent)
         self.title("New ToDo Wizard")
         screen_height = parent.winfo_screenheight()
-        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1000, screen_height - 200, 100, 50))
+        self.geometry('{:d}x{:d}+{:d}+{:d}'.format(1000,
+                      screen_height - 200, 100, 50))
         self.rowconfigure(1, weight=1)
         self.columnconfigure(0, weight=1)
         self.focus_force()
@@ -87,20 +88,6 @@ class EditMeasurementWizardView:
         # internally used variables
         self._wizard_frame = None
 
-        # user selected variables / GUI elements needed in ViewModel
-        self.s0_device_table = None
-        self.s0_selected_device_info = None
-        self.s0_adhoc_frame = None
-        self.s1_meas_name = None
-        self.s1_meas_nr = None
-        self.s1_meas_nr_label = None
-        self.meas_nr_dropdown = None
-        self.s2_instrument_selector = None
-        self.s3_measurement_param_table = None
-
-        # list to hold the contents of the wizard
-        self.section_frames = [None, None, None, None, None]
-
     def setup_main_window(self):
         """
         Setup to toplevel GUI
@@ -108,7 +95,8 @@ class EditMeasurementWizardView:
         # create wizard window, resizeable in columns, fixed with scrollbar in rows
         self.wizard_window = WizardWindow(self.root)
 
-        self.wizard_window.bind('<F1>', self._experiment_manager.show_documentation)
+        self.wizard_window.bind(
+            '<F1>', self._experiment_manager.show_documentation)
 
         # place hint
         hint = "Keyboard Shortcuts: Continue to next stage with Return. Revert to last stage with Escape." \
@@ -127,6 +115,7 @@ class EditMeasurementWizardView:
         """
         Setup stage 0: specify a custom device to measure.
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
         stage = 0
         stage_frame = CustomFrame(self._wizard_frame)
         stage_frame.title = "Select Device"
@@ -140,17 +129,20 @@ class EditMeasurementWizardView:
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Continue",
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=10)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.wizard_window.destroy())
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.wizard_window.destroy())
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.controller.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=1, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=1, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
 
@@ -158,6 +150,7 @@ class EditMeasurementWizardView:
         """
         Setup stage 0: select the device with loaded chip file to measure.
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
         stage = 0
 
         stage_frame = CustomFrame(self._wizard_frame)
@@ -165,25 +158,32 @@ class EditMeasurementWizardView:
         self.section_frames[stage] = stage_frame
         stage_frame.grid(row=stage, column=0, padx=5, pady=5, sticky='we')
 
-        self.s0_device_table = DeviceTable(stage_frame, self._experiment_manager.chip)
-        stage_frame.add_widget(self.s0_device_table, row=0, column=0, padx=5, pady=5, sticky='we')
+        self.s0_device_table = DeviceTable(
+            stage_frame, self._experiment_manager.chip)
+        stage_frame.add_widget(self.s0_device_table, row=0,
+                               column=0, padx=5, pady=5, sticky='we')
 
-        self.s0_selected_device_info = Label(stage_frame, text="Selected device: ")
-        stage_frame.add_widget(self.s0_selected_device_info, row=1, column=0, padx=5, pady=5, sticky='w')
+        self.s0_selected_device_info = Label(
+            stage_frame, text="Selected device: ")
+        stage_frame.add_widget(self.s0_selected_device_info,
+                               row=1, column=0, padx=5, pady=5, sticky='w')
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Continue",
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=10)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.wizard_window.destroy())
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.wizard_window.destroy())
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.model.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=1, rowspan=2, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=1, rowspan=2, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
 
@@ -191,6 +191,7 @@ class EditMeasurementWizardView:
         """
         Setup stage 1: select which measurement
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
         stage = 1
 
         stage_frame = CustomFrame(self._wizard_frame)
@@ -202,26 +203,31 @@ class EditMeasurementWizardView:
         measurement_list.sort()
 
         self.s1_meas_name = StringVar(self.root, self.default_text)
-        meas_dropdown = OptionMenu(stage_frame, self.s1_meas_name, *measurement_list)
+        meas_dropdown = OptionMenu(
+            stage_frame, self.s1_meas_name, *measurement_list)
         ttp = CreateToolTip(experiment_manager=self._experiment_manager,
                             widget=meas_dropdown,
                             stringvar=self.s1_meas_name)
         self.s1_meas_name.trace("w", lambda *args: ttp.change_content())
-        stage_frame.add_widget(meas_dropdown, row=0, column=0, padx=5, pady=5, sticky='w')
+        stage_frame.add_widget(meas_dropdown, row=0,
+                               column=0, padx=5, pady=5, sticky='w')
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Continue",
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=10)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.controller.stage_start(stage - 1))
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.controller.stage_start(stage - 1))
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.controller.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=3, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=3, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
 
@@ -229,6 +235,7 @@ class EditMeasurementWizardView:
         """
         Setup stage 2: select instruments according to selected measurement
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
         stage = 2
 
         stage_frame = CustomFrame(self._wizard_frame)
@@ -237,23 +244,28 @@ class EditMeasurementWizardView:
         stage_frame.grid(row=stage, column=0, padx=5, pady=5, sticky='we')
 
         self.s2_instrument_selector = InstrumentSelector(stage_frame)
-        self.s2_instrument_selector.title = 'Instruments of ' + str(self.model.s1_measurement.name)
+        self.s2_instrument_selector.title = 'Instruments of ' + \
+            str(self.model.s1_measurement.name)
         self.s2_instrument_selector.instrument_source = self.model.s1_available_instruments
-        stage_frame.add_widget(self.s2_instrument_selector, row=0, column=0, padx=5, pady=5, sticky='we')
+        stage_frame.add_widget(self.s2_instrument_selector,
+                               row=0, column=0, padx=5, pady=5, sticky='we')
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Continue",
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=10)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.controller.stage_start(stage - 1))
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.controller.stage_start(stage - 1))
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.controller.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=1, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=1, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
 
@@ -261,6 +273,7 @@ class EditMeasurementWizardView:
         """
         Setup stage 3: specify measurement parameters
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
         stage = 3
 
         stage_frame = CustomFrame(self._wizard_frame)
@@ -270,31 +283,64 @@ class EditMeasurementWizardView:
 
         self.s3_measurement_param_table = ParameterTable(stage_frame,
                                                          store_callback=self.model.s1_measurement.store_new_param)
-        self.s3_measurement_param_table.title = 'Parameters of ' + str(self.model.s1_measurement.name)
+        self.s3_measurement_param_table.title = 'Parameters of ' + \
+            str(self.model.s1_measurement.name)
         self.s3_measurement_param_table.parameter_source = self.model.s1_measurement.get_default_parameter()
-        stage_frame.add_widget(self.s3_measurement_param_table, row=0, column=0, padx=5, pady=5, sticky='we')
+        stage_frame.add_widget(
+            self.s3_measurement_param_table, row=0, column=0, padx=5, pady=5, sticky='we')
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Continue",
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=10)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.controller.stage_start(stage - 1))
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.controller.stage_start(stage - 1))
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.controller.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=1, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=1, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
 
-    def s4_final_save_buttons(self):
+    def s4_multi_parameter(self):
         """
-        Setup stage 4:
+        Setup stage 4 to select multi parameter sweep.
         """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
+        # All of this stage logic should probably be rewritten using an abstract base class
+        # for the stages. The functions with an index in the name are very un-elegant.
+        # This would also allow for more easy customization. A factory function could create
+        # the stages based on the index
         stage = 4
+
+        stage_frame = CustomFrame(self._wizard_frame)
+        stage_frame.title = "Select which parameters to sweep"
+        self.section_frames[stage] = stage_frame
+        stage_frame.grid(row=stage, column=0, padx=5, pady=5, sticky='we')
+
+        stage_frame.continue_button = Button(stage_frame,
+                                             text="Continue",
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
+                                             width=10)
+
+        stage_frame.continue_button.grid(
+            row=0, column=1, padx=5, pady=5, sticky='e')
+
+        stage_frame.columnconfigure(0, weight=1)
+
+    def s5_final_save_buttons(self):
+        """
+        Setup stage 5:
+        """
+        self.logger.warning("DEPRECATED. This method will be removed in a future version.")
+        stage = 5
 
         stage_frame = CustomFrame(self._wizard_frame)
         stage_frame.title = "Save"
@@ -306,22 +352,31 @@ class EditMeasurementWizardView:
                                              command=lambda: self.wizard_window.destroy(),
                                              width=30)
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=0, padx=5, pady=5, sticky='w')
+        stage_frame.continue_button.grid(
+            row=0, column=0, padx=5, pady=5, sticky='w')
 
         stage_frame.continue_button = Button(stage_frame,
                                              text="Save Measurement to Queue!",
                                              font=("bold",),
-                                             command=lambda: self.controller.stage_completed(stage),
+                                             command=lambda: self.controller.stage_completed(
+                                                 stage),
                                              width=30)
 
         # register keyboard shortcuts
-        self.wizard_window.bind("<Escape>", lambda event: self.controller.stage_start(stage - 1))
+        self.wizard_window.bind(
+            "<Escape>", lambda event: self.controller.stage_start(stage - 1))
         self.wizard_window.bind("<Return>",
                                 callback_if_btn_enabled(lambda event: self.controller.stage_completed(stage),
                                                         stage_frame.continue_button))
 
         # not using stage_frame.add_widget() to not automatically disable button!
-        stage_frame.continue_button.grid(row=0, column=1, padx=5, pady=5, sticky='e')
+        stage_frame.continue_button.grid(
+            row=0, column=1, padx=5, pady=5, sticky='e')
 
         stage_frame.columnconfigure(0, weight=1)
         stage_frame.columnconfigure(1, weight=1)
+
+    def register_keyboard_shortcut(self, keys: str, action) -> None:
+        """Register keyboard shortcut on window level.
+        """
+        self.wizard_window.bind(keys, action)

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/Base.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/Base.py
@@ -1,0 +1,274 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import logging
+
+from abc import ABC, abstractmethod
+
+from tkinter import Frame, Button
+
+from typing import TYPE_CHECKING, Union, Tuple
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.KeyboardShortcutButtonPress import callback_if_btn_enabled
+
+if TYPE_CHECKING:
+    from LabExT.View.EditMeasurementWizard.EditMeasurementWizardController import EditMeasurementWizardController
+else:
+    EditMeasurementWizardController = None
+
+####################
+# Controller
+####################
+
+
+class WizardEntryController(ABC):
+    """A base-class defining the method interface for the wizard entries.
+
+    When createing a ``WizardEntryController`` the ``_define_view()``
+    method is called to get the ``WizardEntryView`` used with this
+    controller.
+
+    The intended way to use this controller is to call the 
+    ``deserialize`` method after creation to populate the
+    entries of the view from a ``dict``.
+
+    After the entry is finished the results can be polled
+    with the ``results`` method.
+
+    The ``serialize`` method receives a dict where the entries 
+    of the view can be written to. This dict should be passed
+    to the ``deserialize`` method later.
+    """
+
+    @abstractmethod
+    def results(self):
+        """Returns the result of this WizardEntry.
+
+        The type of the result is defined by the subclass that
+        inherits this base-class and may vary.
+        """
+        self._logger.warning("Using default implementation of abstract method")
+
+    @abstractmethod
+    def deserialize(self, settings: dict) -> None:
+        """Takes a dict and uses it to populate the view.
+
+        Args:
+            settings: A dict that contains the data used to 
+                populate the view of this WizardEntry.
+        """
+        self._logger.warning("Using default implementation of abstract method")
+
+    @abstractmethod
+    def serialize(self, settings: dict) -> None:
+        """Writes the entries from the view to a dict for later reuse.
+
+        Args:
+            settings: A dict whose entries will be used to store the
+                data used in the view of this WizardEntry.
+        """
+        self._logger.warning("Using default implementation of abstract method")
+
+    @abstractmethod
+    def _define_view(self, parent: Frame) -> "WizardEntryView":
+        """This method defines and returns the `WizardEntryView` used by this controller.
+        """
+        self._logger.warning("Using default implementation of abstract method")
+        return None
+
+    def allow_interaction(self, allowed: bool) -> None:
+        """This method makes the continue button clickable based on `allowed`.
+
+        Args:
+            allowed: Makes the button clickable if True and greyed-out otherwise.
+        """
+        self._view.continue_button['state'] = 'normal' if allowed else 'disabled'
+
+    def disable(self) -> None:
+        """Makes the view non-interactable and changes the button to 'Back'.
+        """
+        self._view.disable()
+
+    def remove(self) -> None:
+        """Removes the view from the parent widget.
+        """
+        self._view.remove()
+
+    def __init__(self, stage: int, controller: EditMeasurementWizardController, parent: Frame) -> None:
+        """Initializes this controller.
+
+        Args:
+            stage: The index of this controller in the list of entries.
+            controller: This controller is used by subclasses to 
+                access the underlying data-model and other attributes.
+            parent: The tk Frame into which the view will be placed.
+        """
+        super().__init__()
+
+        self._logger = logging.getLogger()
+        self._main_controller = controller
+
+        self._stage = stage
+        self._view = self._define_view(parent=parent)
+
+    def __str__(self) -> str:
+        return f"WizardEntryController (stage = {self._stage}, view = {self._view})"
+
+
+####################
+# View
+####################
+
+
+class WizardEntryView(ABC):
+    """The base class for entries in a wizard window.
+
+    To create custom entries for a wizard inherit from this class
+    and override the abstract methods::
+
+        WizardEntryView.results()
+        WizardEntryView._content()
+        WizardEntryView._main_title()
+
+    This method interface allows for easy creation of wizard
+    entries with equal style.
+
+    Usage:
+        When initialized this abstract base-class automatically
+        calls the ``_content()`` and ``_main_title()`` methods
+        to retrieve the components that should be visualized in
+        the parent component.
+
+        The content itself has to be added to the ``CustomFrame``
+        containing it. This should be done in the ``_content()``
+        method using the following code::
+
+            self._content_frame.add_widget(<content>, row=0, column=0, padx=5, pady=5, sticky='we')
+
+        Here ``<content>`` needs to be replaced with the widget
+        that is defined and returned at the end of the method.
+        There can also be multiple such calls (see ``DeviceSelect.py#WizardEntryChipDeviceSelect).
+        ``self._content_frame`` can also be passed to the 
+        initializers of custom widgets if needed.
+
+    """
+
+    @abstractmethod
+    def results(self):
+        """Returns the result of the user interaction with this entry if there is one.
+        """
+        self._logger.warning(
+            "Using default implementation of abstract method.")
+        return None
+
+    @abstractmethod
+    def _content(self) -> Union[CustomFrame, Tuple]:
+        """Create and return the content displayed in this entry.
+
+        This function is responsible for calling the 
+        ``self._stage_frame.add_widget(...)`` method to place the 
+        content inside the tk parent.
+
+        The content will usually be a CustomFrame, however in theory
+        any tk widget can be used.
+        """
+        self._logger.warning(
+            "Using default implementation of abstract method.")
+        return None
+
+    @abstractmethod
+    def _main_title(self) -> str:
+        """Returns the title of the box this entry is placed in.
+        """
+        self._logger.warning(
+            "Using default implementation of abstract method.")
+        return "Undefined title"
+
+    def __init__(
+        self,
+        stage: int,
+        parent: Frame,
+        controller: EditMeasurementWizardController
+    ) -> None:
+        super().__init__()
+
+        self._logger = logging.getLogger()
+
+        self.stage = stage
+        self.parent = parent
+        self.controller = controller
+        """The main controller used for callbacks.
+        
+        This cross-dependency could be removed by using an event-
+        based system, however creating an event system just for 
+        this wizard would be out of scope. 
+        
+        Todo:
+            In the future create an event system and overhaul
+            all wizards in the codebase.
+        """
+
+        self._content_frame = CustomFrame(parent=parent)
+        self._content_frame.title = self._main_title()
+        self._content_frame.grid(
+            row=stage, column=0, padx=5, pady=5, sticky="we")
+
+        def on_continue(*args): return controller.stage_completed(stage)
+
+        self._content_frame.continue_button = Button(
+            self._content_frame, text="Continue", command=on_continue, width=10
+        )
+
+        self.content = self._content()
+        """Stores the content displayed in this Entry.
+        
+        The type may vary based on the implementation of the
+        inheriting subclass but is typically a `CustomFrame` 
+        or a tuple of tk widgets.
+        """
+
+        controller.register_keyboard_shortcut(
+            "<Escape>", lambda event: controller.escape_event(stage))
+        controller.register_keyboard_shortcut(
+            "<Return>",
+            callback_if_btn_enabled(
+                on_continue, self._content_frame.continue_button))
+
+        # this is needed because some implementations may have
+        # multiple elements in content
+        try:
+            column = len(self.content)
+        except TypeError:
+            column = 1
+        self._content_frame.continue_button.grid(
+            row=0, column=column, padx=5, pady=5, sticky="e"
+        )
+
+        self._content_frame.columnconfigure(0, weight=1)
+
+    def __str__(self) -> str:
+        return f"WizardEntryView with stage {self.stage}"
+
+    @property
+    def continue_button(self) -> Button:
+        """Returns the button to the right of this Entry
+
+        The button's default text when active is 'Continue'.
+        This changes to back, once this entry is deactivated.
+        """
+        return self._content_frame.continue_button
+
+    def remove(self):
+        """Removes this Entry from its parent component.
+        """
+        self._content_frame.grid_remove()
+
+    def disable(self):
+        """Stops interaction with this Entry and changes button's content to 'Back'.
+        """
+        self._content_frame.enabled = False
+        self.continue_button.config(
+            text='Back', command=lambda: self.controller.stage_start(self.stage))

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/DeviceSelect.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/DeviceSelect.py
@@ -1,0 +1,122 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame, Label
+from typing import TYPE_CHECKING, Tuple
+
+from LabExT.View.Controls.AdhocDeviceFrame import AdhocDeviceFrame
+from LabExT.View.Controls.DeviceTable import DeviceTable
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryView, WizardEntryController
+
+from LabExT.Wafer.Device import Device
+
+if TYPE_CHECKING:
+    from LabExT.View.EditMeasurementWizard.EditMeasurementWizardController import EditMeasurementWizardController
+else:
+    EditMeasurementWizardController = None
+
+#############
+# Controllers
+#############
+
+
+class AdhocDeviceSelectController(WizardEntryController):
+
+    def results(self):
+        return self._view.results()
+
+    def serialize(self, settings: dict) -> None:
+        content: AdhocDeviceFrame = self._view.content
+        content.serialize_to_dict(settings)
+
+    def deserialize(self, settings: dict) -> None:
+        content: AdhocDeviceFrame = self._view.content
+        content.deserialize_from_dict(settings)
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntryAdhocDeviceSelect(self._stage, parent, self._main_controller)
+
+
+class ChipDeviceSelectController(WizardEntryController):
+
+    def results(self):
+        dev: Device = self._view.results()
+
+        if dev is None:
+            raise ValueError(
+                "No device selected. Please select a device to continue.")
+
+        # content of chip device view is tuple of table and label
+        # see below
+        self._view.content[1]['text'] = "Selected device: " + str(dev)
+
+        return dev
+
+    def serialize(self, settings: dict) -> None:
+        content: DeviceTable = self._view.content[0]
+        settings['dev_id'] = int(content.get_selected_device().id)
+
+    def deserialize(self, settings: dict) -> None:
+        try:
+            dev_id = int(settings['dev_id'])
+        except KeyError:
+            return
+
+        content: DeviceTable = self._view.content[0]
+
+        # Does nothing if dev_id is not available
+        content.set_selected_device(dev_id)
+
+        dev: Device = content.get_selected_device()
+        if dev is not None:
+            self._view.content[1]['text'] = "Pre-selected device: " + str(dev)
+        else:
+            msg = 'Device ID loaded from settings file ({}) is not available ' + \
+                  'in the current chip. Not setting a default.'
+            self._logger.info(msg.format(dev_id))
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntryChipDeviceSelect(self._stage, parent, self._main_controller)
+
+    def __init__(self, stage: int, controller: EditMeasurementWizardController, parent: Frame) -> None:
+        super().__init__(stage, controller, parent)
+
+
+############
+# Views
+############
+
+
+class WizardEntryDeviceSelect(WizardEntryView):
+    def _main_title(self) -> str:
+        return "Select Device"
+
+
+class WizardEntryAdhocDeviceSelect(WizardEntryDeviceSelect):
+    def _content(self) -> CustomFrame:
+        res = self._content_frame.add_widget(
+            AdhocDeviceFrame(self._content_frame),
+            row=0, column=0, padx=0, pady=0, sticky="we")
+        res.title = "Define ad-hoc Device"
+        return res
+
+    def results(self):
+        return self.content.get_custom_device()
+
+
+class WizardEntryChipDeviceSelect(WizardEntryDeviceSelect):
+    def _content(self) -> Tuple[DeviceTable, Label]:
+        table = self._content_frame.add_widget(
+            DeviceTable(self._content_frame,
+                        self.controller.experiment_manager.chip),
+            row=0, column=0, padx=5, pady=5, sticky='we')
+        label = self._content_frame.add_widget(
+            Label(self._content_frame, text="Selected Device: "),
+            row=1, column=0, padx=5, pady=5, sticky='w')
+        return (table, label)
+
+    def results(self):
+        return self.content[0].get_selected_device()

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/Factory.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/Factory.py
@@ -1,0 +1,44 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+import logging
+
+from typing import TYPE_CHECKING
+
+from tkinter import Frame
+
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryController
+from LabExT.View.EditMeasurementWizard.WizardEntry.DeviceSelect import AdhocDeviceSelectController, ChipDeviceSelectController
+from LabExT.View.EditMeasurementWizard.WizardEntry.MeasurementSelect import MeasurementSelectController
+from LabExT.View.EditMeasurementWizard.WizardEntry.InstrumentSelect import InstrumentSelectController
+from LabExT.View.EditMeasurementWizard.WizardEntry.ParamSelect import ParameterSelectController
+from LabExT.View.EditMeasurementWizard.WizardEntry.SaveButtons import SaveButtonsController
+
+if TYPE_CHECKING:
+    from LabExT.View.EditMeasurementWizard.EditMeasurementWizardController import EditMeasurementWizardController
+else:
+    EditMeasurementWizardController = None
+
+
+def wizard_entry_controller_factory(stage_number: int, device_avail: bool, parent: Frame, controller: EditMeasurementWizardController) -> WizardEntryController:
+    if stage_number == 0:
+        if device_avail:
+            return ChipDeviceSelectController(stage_number, controller, parent)
+        else:
+            return AdhocDeviceSelectController(stage_number, controller, parent)
+    elif stage_number == 1:
+        return MeasurementSelectController(stage_number, controller, parent)
+    elif stage_number == 2:
+        return InstrumentSelectController(stage_number, controller, parent)
+    elif stage_number == 3:
+        return ParameterSelectController(stage_number, controller, parent)
+    elif stage_number == 4:
+        return SaveButtonsController(stage_number, controller, parent)
+    elif stage_number >= 5:
+        raise ValueError("Stages complete.")
+    else:
+        logging.debug(
+            "This should not be possible unless there is a negative stage_number.")
+        raise ValueError(f"Unknown stage with number {stage_number}")

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/FinishedError.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/FinishedError.py
@@ -1,0 +1,9 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+class WizardFinishedError(Exception):
+    """This error is raised when the measurement is added to the queue.
+    """
+    pass

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/InstrumentSelect.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/InstrumentSelect.py
@@ -1,0 +1,73 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame
+from typing import TYPE_CHECKING, List, Tuple, Union, Dict
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.InstrumentSelector import InstrumentSelector
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryController, WizardEntryView
+
+
+if TYPE_CHECKING:
+    from LabExT.View.Controls.InstrumentSelector import InstrumentRole
+    from LabExT.Measurements.MeasAPI.Measurement import Measurement
+else:
+    InstrumentRole = None
+    Measurement = None
+
+
+class InstrumentSelectController(WizardEntryController):
+
+    def results(self):
+        # get the chosen experiment descriptor dicts for each role and save it to the measurement
+        previous_result = self._main_controller.model.results[self._stage - 1]
+        instruments: List[Tuple[str, InstrumentRole]
+                          ] = previous_result["available_instruments"].items()
+        measurement: Measurement = previous_result["measurement"]
+
+        for role_name, role_instrs in instruments:
+            measurement.selected_instruments[role_name] = role_instrs.choice
+
+        # initialize instruments
+        try:
+            measurement.init_instruments()
+        except Exception as e:
+            raise ValueError(
+                "Could not initialize instruments. Reason: " + repr(e))
+
+        return None
+
+    def deserialize(self, settings: dict) -> None:
+        content: InstrumentSelector = self._view.content
+        content.deserialize_from_dict(settings)
+
+    def serialize(self, settings: dict) -> None:
+        content: InstrumentSelector = self._view.content
+        content.serialize_to_dict(settings)
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntryInstrumentSelect(self._stage, parent, self._main_controller)
+
+
+class WizardEntryInstrumentSelect(WizardEntryView):
+
+    def _main_title(self) -> str:
+        return "Select Instruments"
+
+    def _content(self) -> Union[CustomFrame, Tuple]:
+        previous_result: Dict[str,
+                              Measurement] = self.controller.model.results[self.stage - 1]
+
+        selector = InstrumentSelector(self._content_frame)
+        selector.title = f'Instruments of {previous_result["measurement"].name}'
+        selector.instrument_source = previous_result['available_instruments']
+
+        self._content_frame.add_widget(
+            selector, row=0, column=0, padx=5, pady=5, sticky='we')
+
+        return selector
+
+    def results(self):
+        return None

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/MeasurementSelect.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/MeasurementSelect.py
@@ -1,0 +1,93 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame, OptionMenu, StringVar
+
+from typing import TYPE_CHECKING, Dict, Union
+
+from LabExT.Utils import get_visa_address
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.InstrumentSelector import InstrumentRole
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryView, WizardEntryController
+
+if TYPE_CHECKING:
+    from LabExT.View.EditMeasurementWizard.EditMeasurementWizardController import EditMeasurementWizardController
+    from LabExT.Measurements.MeasAPI.Measurement import Measurement
+else:
+    EditMeasurementWizardController = None
+    Measurement = None
+
+#############
+# Controllers
+#############
+
+
+class MeasurementSelectController(WizardEntryController):
+
+    def results(self):
+        selected_name: str = self._view.results()
+        results: Dict[str, Union[Dict, Measurement]] = {
+            "measurement": None, "available_instruments": {}}
+
+        if selected_name == self._default_text:
+            raise ValueError(
+                "No measurement selected. Please select a valid Measurement to continue.")
+
+        results["measurement"] = self._main_controller._experiment.create_measurement_object(
+            selected_name)
+
+        for role_name in results["measurement"].get_wanted_instrument():
+            io_set = get_visa_address(role_name)
+
+            results["available_instruments"][role_name] = InstrumentRole(
+                self._main_controller.view.wizard_window, io_set)
+
+        return results
+
+    def deserialize(self, settings: dict) -> None:
+        if 'selected_measurement' not in settings.keys():
+            return
+
+        if settings['selected_measurement'] in self._main_controller.experiment_manager.exp.measurement_list:
+            meas_name: StringVar = self._view.meas_name
+            meas_name.set(settings['selected_measurement'])
+        else:
+            msg = 'Measurement name loaded from settings file ({:s}) is not available ' + \
+                  'in the current experiment. Not setting a default.'
+            self.logger.info(msg.format(settings['selected_measurement']))
+
+    def serialize(self, settings: dict) -> None:
+        settings['selected_measurement'] = self._view.results()
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntryMeasurementSelect(self._stage, parent, self._main_controller)
+
+    def __init__(self, stage: int, controller: EditMeasurementWizardController, parent: Frame) -> None:
+        super().__init__(stage, controller, parent)
+        self._default_text = "..."
+
+####################
+# View
+####################
+
+
+class WizardEntryMeasurementSelect(WizardEntryView):
+    def _main_title(self) -> str:
+        return "Select Measurement"
+
+    def _content(self) -> CustomFrame:
+        meas_list = list(
+            self.controller.experiment_manager.exp.measurement_list.copy())
+        meas_list.sort()
+
+        self.meas_name = StringVar(self.controller.root, "...")
+        menu = self._content_frame.add_widget(
+            OptionMenu(self._content_frame, self.meas_name, *meas_list),
+            row=0, column=0, padx=5, pady=5, sticky='w')
+        return menu
+
+    def results(self):
+        return self.meas_name.get()

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/ParamSelect.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/ParamSelect.py
@@ -1,0 +1,70 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Frame
+from typing import Tuple, Union
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.ParameterTable import ParameterTable
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryController, WizardEntryView
+
+from LabExT.Measurements.MeasAPI.Measurement import Measurement
+
+
+#############
+# Controllers
+#############
+
+
+class ParameterSelectController(WizardEntryController):
+
+    def results(self):
+        try:
+            self._view.results()
+        except ValueError as ve:
+            raise ValueError(f"Invalid data was entered:\n{str(ve)}")
+
+    def deserialize(self, settings: dict) -> None:
+        content: ParameterTable = self._view.content
+        content.deserialize_from_dict(settings=settings)
+
+    def serialize(self, settings: dict) -> None:
+        prev_res: Measurement = self._main_controller.model.results[self._stage - 2]['measurement']
+
+        if prev_res is not None:
+            content: ParameterTable = self._view.content
+            content.serialize_to_dict(settings)
+        else:
+            self._logger.warning(
+                "Measurement is not defined. Cannot serialize measurement parameters.")
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntryParameterSelect(self._stage, parent, self._main_controller)
+
+
+####################
+# View
+####################
+
+
+class WizardEntryParameterSelect(WizardEntryView):
+
+    def _main_title(self) -> str:
+        return "Select Measurement Parameters"
+
+    def _content(self) -> Union[CustomFrame, Tuple]:
+        prev_res: Measurement = self.controller.model.results[self.stage - 2]['measurement']
+        table = ParameterTable(self._content_frame,
+                               store_callback=prev_res.store_new_param)
+        table.title = f'Parameters of {prev_res.name}'
+        table.parameter_source = prev_res.get_default_parameter()
+
+        return self._content_frame.add_widget(table, row=0, column=0, padx=5, pady=5, sticky='we')
+
+    def results(self):
+        content: ParameterTable = self.content
+        content.check_parameter_validity()
+
+        return None

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/SaveButtons.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/SaveButtons.py
@@ -1,0 +1,67 @@
+"""
+LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Button, Frame
+
+from LabExT.View.EditMeasurementWizard.WizardEntry.Base import WizardEntryController, WizardEntryView
+from LabExT.View.EditMeasurementWizard.WizardEntry.FinishedError import WizardFinishedError
+from LabExT.Experiments.ToDo import ToDo
+from LabExT.Wafer.Device import Device
+from LabExT.Measurements.MeasAPI.Measurement import Measurement
+
+#############
+# Controllers
+#############
+
+
+class SaveButtonsController(WizardEntryController):
+
+    def results(self):
+        dev: Device = self._main_controller.model.results[0]
+        meas: Measurement = self._main_controller.model.results[1]['measurement']
+
+        t = ToDo(device=dev, measurement=meas)
+        self._main_controller._experiment.to_do_list.append(t)
+        self._main_controller._experiment.update()
+        self._main_controller.view.scrollable_frame.unbound_mouse_wheel()
+        self._main_controller.escape_event(0)
+
+        raise WizardFinishedError()
+
+    def deserialize(self, settings: dict) -> None:
+        return None
+
+    def serialize(self, settings: dict) -> None:
+        return None
+
+    def _define_view(self, parent: Frame) -> WizardEntryView:
+        return WizardEntrySaveButtons(self._stage, parent, self._main_controller)
+
+
+####################
+# View
+####################
+
+
+class WizardEntrySaveButtons(WizardEntryView):
+
+    def _main_title(self) -> str:
+        return "Save"
+
+    def _content(self) -> Button:
+        close_button = Button(self._content_frame,
+                              text="Discard and close window.",
+                              command=lambda: self.controller.escape_event(0),
+                              width=30)
+        close_button.grid(row=0, column=0, padx=5, pady=5, sticky='w')
+
+        self.continue_button.config(text="Save Measurement to Queue!",
+                                    font=("bold",),
+                                    width=30)
+
+        return close_button
+
+    def results(self):
+        return None


### PR DESCRIPTION
# Summary

This pull request refactors the code for the edit measurement wizard. Instead of using hardcoded functions for each stage/entry in the wizard, we now have an abstract base class for the wizard entries which can be inherited. It provides most of the functionality. The subclasses only need to specify their content and what happens on serializing and deserializing.

Each of the 8 commits integrates one entry in the wizard, except for the first two, which create the new method interface and adapt the `EditMeasurementWizardController` to it.

The methods for the old way of creating gui entries are still in the code and (mostly) unchanged, however, they now log a deprecation warning. They will be removed in the next version of LabExT. Theoretically, no user plugins should ever interact with these methods, but you never know. That's why the methods aren't removed already.

# Advantages

This rework allows us to more easily add new entries to the wizard in the future. There is a small cross dependency between the `EditMeasurementWizardController` and the baseclasses, which could be resolved by using an event-based system. This would then allow the created abstract baseclasses to be used in any wizard. 
Another advantage is that the code is a lot more readable now :)

# Testing

Because the method interface changed I had to adapt one of the test cases to use the new variable names during testing. Afterwards all tests passed. 

## Future ToDo

- Create event-based system to make these classes independently useable
- Rework other wizards in the code to use this method interface