### PR TITLE
LVI [2/4]: Depreciating "json_able" functions in Widgets

### DIFF
--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -66,7 +66,6 @@ class StandardExperiment:
         self.param_chip_name = ""
 
         # plot collections, main window plot observe these lists
-        self.live_plot_collection = ObservableList()  # right plot, measurements can plot during run
         self.selec_plot_collection = ObservableList()  # left plot, plotting of finished measurement data
 
         # used in "new device sweep" wizard
@@ -224,9 +223,6 @@ class StandardExperiment:
                 save_file_ending = "_abort.json"
 
             finally:
-                # clear live plots after experiment finished
-                while len(self.live_plot_collection) > 0:
-                    self.live_plot_collection.remove(self.live_plot_collection[0])
 
                 # save instrument parameters again
                 data["instruments"] = measurement._get_data_from_all_instruments()

--- a/LabExT/Instruments/DummyInstrument.py
+++ b/LabExT/Instruments/DummyInstrument.py
@@ -35,7 +35,7 @@ class DummyInstrument(Instrument):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(visa_address="", channel=None)
+        super().__init__(visa_address=kwargs.get('visa_address', ''), channel=None)
         self._dummy_open = False
 
     def __getattr__(self, item):

--- a/LabExT/Measurements/DummyMeas.py
+++ b/LabExT/Measurements/DummyMeas.py
@@ -41,8 +41,6 @@ class DummyMeas(Measurement):
         self.name = 'DummyMeas'
         self.settings_path = 'DummyMeas_settings.json'
 
-        self.plot = None
-
         self.parameters = DummyMeas.get_default_parameter()
         self.wanted_instruments = DummyMeas.get_wanted_instrument()
 
@@ -65,7 +63,6 @@ class DummyMeas(Measurement):
         # get the parameters
         n_points = parameters.get('number of points').value
         tot_time = parameters.get('total measurement time').value
-        ptime = tot_time / n_points
         y_mean = parameters.get('mean').value
         y_stddev = parameters.get('std. deviation').value
         raise_error = parameters['simulate measurement error'].value
@@ -73,11 +70,6 @@ class DummyMeas(Measurement):
         # write the measurement parameters into the measurement settings
         for pname, pparam in parameters.items():
             data['measurement settings'][pname] = pparam.as_dict()
-
-        # start live plottings
-        if self._experiment is not None:
-            self.plot = PlotData(ObservableList(), ObservableList())
-            self._experiment.live_plot_collection.append(self.plot)
 
         # provoke error if set in parameters
         if raise_error:
@@ -87,14 +79,7 @@ class DummyMeas(Measurement):
         xvec = np.arange(0, n_points)
         yvec = y_stddev * np.random.randn(n_points) + y_mean
 
-        if self._experiment is not None:
-            # play to live plot
-            for x, y in zip(xvec, yvec):
-                self.plot.x.append(x)
-                self.plot.y.append(y)
-                sleep(ptime)
-        else:
-            sleep(tot_time)
+        sleep(tot_time)
 
         # convert numpy float32/float64 to python float
         data['values']['point indices'] = [x.item() for x in xvec]
@@ -102,9 +87,5 @@ class DummyMeas(Measurement):
 
         # sanity check if data contains all necessary keys
         self._check_data(data)
-
-        # remove live plot again from experiment
-        if self._experiment is not None:
-            self._experiment.live_plot_collection.remove(self.plot)
 
         return data

--- a/LabExT/Tests/View/ExperimentWizard_test.py
+++ b/LabExT/Tests/View/ExperimentWizard_test.py
@@ -63,8 +63,6 @@ class ExperimentWizardTest(TKinterTestCase):
                 # this "patches" out some features of the classes due to patching not working across threads
                 self.mwc.allow_GUI_changes = False
                 self.mwm.allow_GUI_changes = False
-                # live plotting does not work as we don't run a mainloop in tk
-                self.expm.exp.live_plot_collection = []  # un-listenable list -> disables live plotting callbacks
 
     def test_experiment_wizard_repeated(self):
         self.test_experiment_wizard()

--- a/LabExT/View/Controls/InstrumentSelector.py
+++ b/LabExT/View/Controls/InstrumentSelector.py
@@ -211,16 +211,14 @@ class InstrumentSelector(CustomFrame):
 
     def serialize(self, file_name):
         """Serializes data in table to json."""
-        if self._instrument_source is None:
-            return
         settings_path = get_configuration_file_path(file_name)
         if os.path.isfile(settings_path):
             with open(settings_path, 'r') as json_file:
                 data = json.loads(json_file.read())
         else:
             data = {}
-        for role_name in self._instrument_source:
-            data[role_name] = self._instrument_source[role_name].choice
+        if not self.serialize_to_dict(data):
+            return False
         with open(settings_path, 'w') as json_file:
             json_file.write(json.dumps(data))
 
@@ -232,10 +230,7 @@ class InstrumentSelector(CustomFrame):
             return
         with open(settings_path, 'r') as json_file:
             data = json.loads(json_file.read())
-        for role_name in data:
-            if role_name in self._instrument_source:
-                self._instrument_source[role_name].create_and_set(data[role_name])
-        self.__setup__()
+        self.deserialize_from_dict(settings=data)
 
     def serialize_to_dict(self, settings: dict):
         """Serializes data in table to given dict."""

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -69,8 +69,6 @@ class MainWindowController:
         """Called when user closes the application. Save experiment
         settings in .json and call context-callback.
         """
-        self.view.frame.live_plot.stop_polling()
-
         # remove any chip path from parameters if chip is not loaded -> prevent offering reloading-of not loaded chip
         # on next startup
         if self.experiment_manager.chip is None:

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -57,7 +57,6 @@ class MainWindowModel:
         self.experiment = None
         self.chip_parameters = None
         self.save_parameters = None
-        self.live_plot_data = None
         self.selec_plot_data = None
         self.last_opened_new_meas_wizard_controller = None
 
@@ -101,7 +100,6 @@ class MainWindowModel:
             self.experiment = self.experiment_manager.exp
             self.chip_parameters = self.experiment_manager.exp.chip_parameters
             self.save_parameters = self.experiment_manager.exp.save_parameters
-            self.live_plot_data = self.experiment.live_plot_collection
             self.selec_plot_data = self.experiment.selec_plot_collection
 
     def experiment_changed(self, ex):

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -555,7 +555,6 @@ class MainWindowFrame(Frame):
         self.control_panel = None
 
         self.selec_plot = None
-        self.live_plot = None
         self.axes_frame = None
 
         self.logging_frame = None
@@ -593,17 +592,9 @@ class MainWindowFrame(Frame):
         self.selec_plot.title = "Measurement Selection Plot"
         self.selec_plot.show_grid = True
         self.selec_plot.data_source = self.model.selec_plot_data
-        self.selec_plot.grid(row=0, column=1, rowspan=2, padx=10, pady=10, sticky="nswe")
+        self.selec_plot.grid(row=0, column=1, rowspan=2, columnspan=2, padx=10, pady=10, sticky='nswe')
         self.selec_plot.rowconfigure(0, weight=1)
         self.selec_plot.columnconfigure(0, weight=1)
-
-        self.live_plot = PlotControl(self, add_toolbar=True, figsize=(5, 5), polling_time_s=0.5)
-        self.live_plot.title = "Live Plot"
-        self.live_plot.show_grid = True
-        self.live_plot.data_source = self.model.live_plot_data
-        self.live_plot.grid(row=0, column=2, rowspan=2, padx=10, pady=10, sticky="nswe")
-        self.live_plot.rowconfigure(0, weight=1)
-        self.live_plot.columnconfigure(0, weight=1)
 
     def set_up_logging_frame(self):
         """
@@ -672,10 +663,10 @@ class MainWindowView:
         self.frame.set_up_control_frame()
 
         self.frame.set_up_logging_frame()
+
         #
         # active and finished measurement tables
         #
-
         self.frame.set_up_auxiliary_tables()
 
     def set_up_context_menu(self):

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -566,8 +566,9 @@ class StageAssignmentStep(Step):
             return
 
         if stage in self._stage_polygon_parameter_tables:
-            polygon_cls_cfg = self._stage_polygon_parameter_tables[stage].make_json_able(
-            )
+            settings = {}
+            self._stage_polygon_parameter_tables[stage].serialize_to_dict(settings)
+            polygon_cls_cfg = settings['data']
         else:
             polygon_cls_cfg = polygon_cls.get_default_parameters()
 
@@ -586,8 +587,9 @@ class StageAssignmentStep(Step):
             polygon_cls_name = self.polygon_vars[stage].get()
             polygon_cls = self.POLYGON_OPTIONS[polygon_cls_name]
 
-            self.polygon_cfg[stage] = (
-                polygon_cls, polygon_cfg_table.make_json_able())
+            settings = {}
+            polygon_cfg_table.serialize_to_dict(settings)
+            self.polygon_cfg[stage] = (polygon_cls, settings['data'])
 
     def _build_assignment_variables(self) -> tuple:
         """


### PR DESCRIPTION
# Goal
Finalize the transition to the new (de-) serialization of parameter and instrument widgets.

# Reasoning
The change on how widgets store their state in JSON in files was started in #172. This PR deletes the former function `make_json_able` and switches over to usage of the new functions.

# Implementation
Some old code in `MovementWizard` needed to be updated. The polygon parameter tables used the old function.

# Compatibility
No compatibility break expected.