### PR TITLE
LVI [3/4]: Rewrite of LiveViewer - improve performance for more than one trace, improve GUI, improve LVCard API

### DIFF
--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -66,7 +66,6 @@ class StandardExperiment:
         self.param_chip_name = ""
 
         # plot collections, main window plot observe these lists
-        self.live_plot_collection = ObservableList()  # right plot, measurements can plot during run
         self.selec_plot_collection = ObservableList()  # left plot, plotting of finished measurement data
 
         # used in "new device sweep" wizard
@@ -224,9 +223,6 @@ class StandardExperiment:
                 save_file_ending = "_abort.json"
 
             finally:
-                # clear live plots after experiment finished
-                while len(self.live_plot_collection) > 0:
-                    self.live_plot_collection.remove(self.live_plot_collection[0])
 
                 # save instrument parameters again
                 data["instruments"] = measurement._get_data_from_all_instruments()

--- a/LabExT/Instruments/DummyInstrument.py
+++ b/LabExT/Instruments/DummyInstrument.py
@@ -35,7 +35,7 @@ class DummyInstrument(Instrument):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(visa_address="", channel=None)
+        super().__init__(visa_address=kwargs.get('visa_address', ''), channel=None)
         self._dummy_open = False
 
     def __getattr__(self, item):

--- a/LabExT/Measurements/DummyMeas.py
+++ b/LabExT/Measurements/DummyMeas.py
@@ -41,8 +41,6 @@ class DummyMeas(Measurement):
         self.name = 'DummyMeas'
         self.settings_path = 'DummyMeas_settings.json'
 
-        self.plot = None
-
         self.parameters = DummyMeas.get_default_parameter()
         self.wanted_instruments = DummyMeas.get_wanted_instrument()
 
@@ -65,7 +63,6 @@ class DummyMeas(Measurement):
         # get the parameters
         n_points = parameters.get('number of points').value
         tot_time = parameters.get('total measurement time').value
-        ptime = tot_time / n_points
         y_mean = parameters.get('mean').value
         y_stddev = parameters.get('std. deviation').value
         raise_error = parameters['simulate measurement error'].value
@@ -73,11 +70,6 @@ class DummyMeas(Measurement):
         # write the measurement parameters into the measurement settings
         for pname, pparam in parameters.items():
             data['measurement settings'][pname] = pparam.as_dict()
-
-        # start live plottings
-        if self._experiment is not None:
-            self.plot = PlotData(ObservableList(), ObservableList())
-            self._experiment.live_plot_collection.append(self.plot)
 
         # provoke error if set in parameters
         if raise_error:
@@ -87,14 +79,7 @@ class DummyMeas(Measurement):
         xvec = np.arange(0, n_points)
         yvec = y_stddev * np.random.randn(n_points) + y_mean
 
-        if self._experiment is not None:
-            # play to live plot
-            for x, y in zip(xvec, yvec):
-                self.plot.x.append(x)
-                self.plot.y.append(y)
-                sleep(ptime)
-        else:
-            sleep(tot_time)
+        sleep(tot_time)
 
         # convert numpy float32/float64 to python float
         data['values']['point indices'] = [x.item() for x in xvec]
@@ -102,9 +87,5 @@ class DummyMeas(Measurement):
 
         # sanity check if data contains all necessary keys
         self._check_data(data)
-
-        # remove live plot again from experiment
-        if self._experiment is not None:
-            self._experiment.live_plot_collection.remove(self.plot)
 
         return data

--- a/LabExT/Measurements/MeasAPI/Measurement.py
+++ b/LabExT/Measurements/MeasAPI/Measurement.py
@@ -6,8 +6,12 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import logging
+from typing import List, Dict
 
-from typing import List
+from LabExT.Measurements.MeasAPI.Measparam import MeasParam
+
+
+MEAS_PARAMS_TYPE = Dict[str, MeasParam]
 
 
 class Measurement:

--- a/LabExT/Tests/View/ExperimentWizard_test.py
+++ b/LabExT/Tests/View/ExperimentWizard_test.py
@@ -63,8 +63,6 @@ class ExperimentWizardTest(TKinterTestCase):
                 # this "patches" out some features of the classes due to patching not working across threads
                 self.mwc.allow_GUI_changes = False
                 self.mwm.allow_GUI_changes = False
-                # live plotting does not work as we don't run a mainloop in tk
-                self.expm.exp.live_plot_collection = []  # un-listenable list -> disables live plotting callbacks
 
     def test_experiment_wizard_repeated(self):
         self.test_experiment_wizard()

--- a/LabExT/View/Controls/InstrumentSelector.py
+++ b/LabExT/View/Controls/InstrumentSelector.py
@@ -211,16 +211,14 @@ class InstrumentSelector(CustomFrame):
 
     def serialize(self, file_name):
         """Serializes data in table to json."""
-        if self._instrument_source is None:
-            return
         settings_path = get_configuration_file_path(file_name)
         if os.path.isfile(settings_path):
             with open(settings_path, 'r') as json_file:
                 data = json.loads(json_file.read())
         else:
             data = {}
-        for role_name in self._instrument_source:
-            data[role_name] = self._instrument_source[role_name].choice
+        if not self.serialize_to_dict(data):
+            return False
         with open(settings_path, 'w') as json_file:
             json_file.write(json.dumps(data))
 
@@ -232,10 +230,7 @@ class InstrumentSelector(CustomFrame):
             return
         with open(settings_path, 'r') as json_file:
             data = json.loads(json_file.read())
-        for role_name in data:
-            if role_name in self._instrument_source:
-                self._instrument_source[role_name].create_and_set(data[role_name])
-        self.__setup__()
+        self.deserialize_from_dict(settings=data)
 
     def serialize_to_dict(self, settings: dict):
         """Serializes data in table to given dict."""

--- a/LabExT/View/LiveViewer/Cards/CardFrame.py
+++ b/LabExT/View/LiveViewer/Cards/CardFrame.py
@@ -6,22 +6,14 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import logging
+import queue
+import tkinter
 from functools import wraps
-from tkinter import Frame, Button, Label, colorchooser, messagebox
+from tkinter import Frame, Button, Label, messagebox, BooleanVar
 
 from LabExT.Utils import get_visa_address
+from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.Controls.InstrumentSelector import InstrumentRole, InstrumentSelector
-
-colors = {
-    0: 'red',
-    1: 'purple',
-    2: 'blue',
-    3: 'green',
-    4: 'skyblue',
-    5: 'black',
-    6: 'orange',
-    7: 'yellow'
-}
 
 
 def show_errors_as_popup(caught_err_classes=(Exception,)):
@@ -59,23 +51,32 @@ class CardFrame(Frame):
     """
 
     INSTRUMENT_TYPE = 'FILL ME'
-    PLOTTING_ENABLED = True
+    CARD_TITLE = 'FILL ME'
 
     default_parameters = {}
 
-    def __init__(self, parent, controller, model, index):
+    def __init__(self, parent, controller, model):
 
         # refs to LiveViewer objects
         self.model = model
         self.controller = controller
-        # my index
-        self.index = index
+
         # root window where I will be placed
         self._root = parent
         # logger, is always handy
         self.logger = logging.getLogger()
-        # plot color
-        self.color = colors.get(index, 'gray')
+
+        # card attributes
+        self.instance_title = f'{self.CARD_TITLE:s} {self.model.next_card_index:d}'
+        self.model.next_card_index += 1
+        self.instrument = None  # reference to instantiated instrument driver
+        self.active_thread = None  # reference to sub-thread (used for polling etc.)
+        self.data_to_plot_queue = queue.SimpleQueue()
+        self.card_active = BooleanVar(master=parent, value=False)  # indicator if card is active or not
+        self.card_active.trace('w', self._card_active_status_changed)
+
+        self.last_instrument_type = ""  # keep instrument info for saving out traces to file
+
         # keep my references which buttons to gray out when
         self.buttons_active_when_settings_enabled = []
         self.buttons_inactive_when_settings_enabled = []
@@ -92,16 +93,11 @@ class CardFrame(Frame):
         #
 
         # row 0: title
-        self.label = Label(self, text=self.INSTRUMENT_TYPE)
+        self.label = Label(self, text=self.instance_title)
         self.label.grid(row=0, column=0, padx=2, pady=2, sticky='NSW')
 
-        # row 0: color selection button
-        if self.PLOTTING_ENABLED:
-            self.color_button = Button(self, text="", command=self.choose_color, bg=self.color)
-            self.color_button.grid(row=0, column=1, sticky='NESW')
-
         # row 0: remove card button
-        self.remove_button = Button(self, text="X", command=lambda: controller.remove_card(self.index))
+        self.remove_button = Button(self, text="X", command=lambda: controller.remove_card(self))
         self.remove_button.grid(row=0, column=3, sticky='NE')
 
         # row 1: instrument selector
@@ -109,35 +105,20 @@ class CardFrame(Frame):
         io_set = get_visa_address(self.INSTRUMENT_TYPE)
         self.available_instruments.update({self.INSTRUMENT_TYPE: InstrumentRole(self._root, io_set)})
 
-        try:
-            for role_name in self.model.old_instr[index]:
-                if role_name in self.available_instruments:
-                    self.available_instruments[role_name].create_and_set(self.model.old_instr[index][role_name])
-        except IndexError:
-            pass
-
         self.instr_selec = InstrumentSelector(self)
         self.instr_selec.title = 'Instrument'
         self.instr_selec.instrument_source = self.available_instruments
         self.instr_selec.grid(row=1, column=0, columnspan=4, padx=2, pady=2, sticky='NESW')
 
-        # row 2: user's content frame, filled by subclasses
+        # row 2: parameter table for this card
+        self.ptable = ParameterTable(self)
+        self.ptable.title = 'Parameters'
+        self.ptable.parameter_source = self.default_parameters.copy()
+        self.ptable.grid(row=2, column=0, columnspan=4, padx=2, pady=2, sticky='NESW')
+
+        # row 3: user's content frame, filled by subclasses
         self.content_frame = Frame(self)
-        self.content_frame.grid(row=2, column=0, columnspan=4, padx=2, pady=2, sticky='NESW')
-
-        # define the card-related attributes
-        self.instrument = None
-        self.polling_function = None
-        self.active_thread = None
-        self.enabled = None
-        self.paused = False
-        self.thread_finished = True
-        self.plot_data = None
-
-        self.string_var = None
-        self.initialized = False
-
-        self.last_instrument_type = ""
+        self.content_frame.grid(row=3, column=0, columnspan=4, padx=2, pady=2, sticky='NESW')
 
     def load_instrument_instance(self):
         """
@@ -147,29 +128,25 @@ class CardFrame(Frame):
         for role_name, role_instrs in self.available_instruments.items():
             selected_instruments.update({role_name: role_instrs.choice})
 
-            # do not let card load an instrument if any other card already has the same instrument active
-            for i, (_, card) in enumerate(self.model.cards):
-                if card is self:
-                    continue
-                if card.INSTRUMENT_TYPE is not self.INSTRUMENT_TYPE:
-                    continue
-                if not card.enabled:
-                    continue
-                if card.instrument is None:
-                    continue
-                self_desc = role_instrs.choice
-                foreign_desc = card.instrument.instrument_config_descriptor
-                if self_desc['visa'] == foreign_desc['visa'] \
-                        and self_desc['class'] == foreign_desc['class'] \
-                        and self_desc['channel'] == foreign_desc['channel']:
-                    raise RuntimeError('This instrument is already active in another card.')
-
         loaded_instr = self.controller.experiment_manager.instrument_api.create_instrument_obj(self.INSTRUMENT_TYPE,
                                                                                                selected_instruments,
                                                                                                {})
 
         self.last_instrument_type = loaded_instr.instrument_parameters['class']
         return loaded_instr
+
+    def _card_active_status_changed(self, *args):
+        # callback on the card_active variable
+        # automatically set GUI elements depending on if card is active or not
+        try:
+            if self.card_active.get():
+                self.disable_settings_interaction()
+            else:
+                self.enable_settings_interaction()
+        except tkinter.TclError:
+            # sometimes the card is already destroyed
+            # so changes in GUI raise TclError but can safely be ignored
+            pass
 
     def enable_settings_interaction(self):
         # call this function when you want to enable GUI elements for changing settings
@@ -189,21 +166,5 @@ class CardFrame(Frame):
             b["state"] = "active"
         self.instr_selec.enabled = False
 
-    def choose_color(self):
-        """
-        Displays the color selection tool.
-        """
-        if not self.PLOTTING_ENABLED:
-            raise NotImplementedError('Plotting is not implemented for this card. Cannot choose color.')
-        # variable to store hexadecimal code of color
-        color_code = colorchooser.askcolor(title="Choose color")
-        self.color = color_code[1]
-        self.controller.show_main_window()
-        self.color_button.configure(bg=color_code[1])
-        self.controller.update_color(self.index, self.color)
-
     def stop_instr(self):
-        raise NotImplementedError
-
-    def tear_down(self):
         raise NotImplementedError

--- a/LabExT/View/LiveViewer/Cards/LaserCard.py
+++ b/LabExT/View/LiveViewer/Cards/LaserCard.py
@@ -6,11 +6,16 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from tkinter import Label, Button, StringVar
+from typing import TYPE_CHECKING
 
 from LabExT.Instruments.InstrumentAPI import InstrumentException
 from LabExT.Measurements.MeasAPI import MeasParamFloat
-from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.LiveViewer.Cards.CardFrame import CardFrame, show_errors_as_popup
+
+if TYPE_CHECKING:
+    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
+else:
+    MEAS_PARAMS_TYPE = None
 
 
 class LaserCard(CardFrame):
@@ -52,19 +57,13 @@ class LaserCard(CardFrame):
 
         # row 0: control buttons
         self.enable_button = Button(content_frame, text="Start Laser",
-                                    command=lambda: self.start_laser(self.available_instruments,
-                                                                     self.ptable.to_meas_param(),
-                                                                     self.laser_enabled_warning_text))
+                                    command=lambda: self.start_laser(self.ptable.to_meas_param()))
         self.enable_button.grid(row=0, column=0, padx=2, pady=2, sticky='NESW')
         self.disable_button = Button(content_frame, text="Stop Laser",
-                                     command=lambda: self.stop_laser(self.available_instruments,
-                                                                     self.ptable.to_meas_param(),
-                                                                     self.laser_enabled_warning_text))
+                                     command=lambda: self.stop_laser())
         self.disable_button.grid(row=0, column=1, padx=2, pady=2, sticky='NESW')
         self.update_button = Button(content_frame, text="Update Settings",
-                                    command=lambda: self.update_laser(self.available_instruments,
-                                                                      self.ptable.to_meas_param(),
-                                                                      self.laser_enabled_warning_text))
+                                    command=lambda: self.update_laser(self.ptable.to_meas_param()))
         self.update_button.grid(row=0, column=2, padx=2, pady=2, sticky='NESW')
 
         # row 0: laser enabled warning text
@@ -81,7 +80,7 @@ class LaserCard(CardFrame):
         self.buttons_inactive_when_settings_enabled.append(self.update_button)
 
     @show_errors_as_popup()
-    def start_laser(self, instr, parameters, warning_variable):
+    def start_laser(self, parameters: MEAS_PARAMS_TYPE):
         """
         Sets up the laser and starts it.
         """
@@ -97,13 +96,13 @@ class LaserCard(CardFrame):
             loaded_instr.power = laser_pwr
             loaded_instr.enable = True
 
-        warning_variable.set("LASER ENABLED")
+        self.laser_enabled_warning_text.set("LASER ENABLED")
 
         self.instrument = loaded_instr
         self.card_active.set(True)
 
     @show_errors_as_popup()
-    def stop_laser(self, instr, parameters, warning_variable):
+    def stop_laser(self):
         """
         Stops the laser.
         """
@@ -112,14 +111,14 @@ class LaserCard(CardFrame):
             return
         with loaded_instr.thread_lock:
             loaded_instr.enable = False
-        warning_variable.set("")
+        self.laser_enabled_warning_text.set("")
         self.card_active.set(False)
 
         self.instrument.close()
         self.instrument = None
 
     @show_errors_as_popup()
-    def update_laser(self, instr, parameters, warning_variable):
+    def update_laser(self, parameters: MEAS_PARAMS_TYPE):
         """
         Updates the lasers parameters.
         """
@@ -138,4 +137,4 @@ class LaserCard(CardFrame):
         """
         This function is needed as a generic stopping function.
         """
-        self.stop_laser(None, None, self.laser_enabled_warning_text)
+        self.stop_laser()

--- a/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
+++ b/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
@@ -11,7 +11,6 @@ from time import sleep
 from tkinter import Button
 
 from LabExT.Measurements.MeasAPI import MeasParamInt, MeasParamFloat, MeasParamString
-from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.LiveViewer.Cards.CardFrame import CardFrame, show_errors_as_popup
 from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint
 

--- a/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
+++ b/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
@@ -6,15 +6,14 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import threading
+import time
 from time import sleep
 from tkinter import Button
 
-from LabExT.Instruments.InstrumentAPI import InstrumentException
-from LabExT.Measurements.MeasAPI import MeasParamInt
-from LabExT.View.Controls.ParameterTable import ParameterTable, MeasParamFloat
-from LabExT.View.Controls.PlotControl import PlotData
+from LabExT.Measurements.MeasAPI import MeasParamInt, MeasParamFloat, MeasParamString
+from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.LiveViewer.Cards.CardFrame import CardFrame, show_errors_as_popup
-from LabExT.ViewModel.Utilities.ObservableList import ObservableList
+from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint
 
 
 class PowerMeterCard(CardFrame):
@@ -28,14 +27,16 @@ class PowerMeterCard(CardFrame):
         'powermeter range': MeasParamInt(value=0, unit='dBm'),
         # integration time of power meter
         'powermeter averagetime': MeasParamFloat(value=0.1, unit='s'),
-        # integration time of power meter
+        # center wavelength of observed signal
         'powermeter wavelength': MeasParamFloat(value=1550.0, unit='nm'),
+        # which channels to interrogate
+        'channels to plot (comma separated)': MeasParamString(value='1')
     }
 
-    # static variable that defines the cards type
-    instrument_type = "Power Meter"
+    INSTRUMENT_TYPE = 'Power Meter'
+    CARD_TITLE = 'Poll OPM'
 
-    def __init__(self, parent, controller, model, index):
+    def __init__(self, parent, controller, model):
         """Constructor.
 
         Parameters
@@ -46,178 +47,180 @@ class PowerMeterCard(CardFrame):
             The Live viewer controller
         model :
             The Live viewer model
-        index :
-            This cards index
         """
-        self.INSTRUMENT_TYPE = 'Power Meter'
-        self.PLOTTING_ENABLED = True
 
         # create basics GUI elements from super class
-        super().__init__(parent, controller, model, index)
+        super().__init__(parent, controller, model)
         content_frame = self.content_frame  # created in constructor of super class
         content_frame.columnconfigure(0, minsize=120)
         content_frame.columnconfigure(1, minsize=120)
         content_frame.columnconfigure(2, minsize=120)
         content_frame.columnconfigure(3, weight=4)
 
-        # row 0: parameter table
-        self.ptable = ParameterTable(content_frame)
-        self.ptable.title = 'Parameters'
-        try:
-            self.ptable.parameter_source = self.model.old_params[index]
-        except IndexError:
-            self.ptable.parameter_source = self.default_parameters.copy()
-        self.ptable.grid(row=0, column=0, columnspan=4, padx=2, pady=2, sticky='NESW')
+        # thread-control related
+        self.stop_thread = False
+        self.thread_finished = True
 
-        # row 1: control buttons
+        # row 0: control buttons
         self.enable_button = Button(content_frame,
                                     text="Start PM",
-                                    command=lambda: self.start_pm(self.available_instruments,
-                                                                  self.ptable.to_meas_param(),
-                                                                  self.color))
-        self.enable_button.grid(row=1, column=0, padx=2, pady=2, sticky='NESW')
+                                    command=lambda: self.start_pm())
+        self.enable_button.grid(row=0, column=0, padx=2, pady=2, sticky='NESW')
         self.disable_button = Button(content_frame,
                                      text="Stop PM",
-                                     command=lambda: self.stop_pm(self.available_instruments,
-                                                                  self.ptable.to_meas_param()))
-        self.disable_button.grid(row=1, column=1, padx=2, pady=2, sticky='NESW')
+                                     command=lambda: self.stop_pm())
+        self.disable_button.grid(row=0, column=1, padx=2, pady=2, sticky='NESW')
         self.update_button = Button(content_frame,
                                     text="Update Settings",
-                                    command=lambda: self.update_pm(self.available_instruments,
-                                                                   self.ptable.to_meas_param()))
-        self.update_button.grid(row=1, column=2, padx=2, pady=2, sticky='NESW')
+                                    command=lambda: self.update_pm())
+        self.update_button.grid(row=0, column=2, padx=2, pady=2, sticky='NESW')
 
         # register which buttons to enable / disable on state change
         self.buttons_active_when_settings_enabled.append(self.enable_button)
         self.buttons_inactive_when_settings_enabled.append(self.disable_button)
         self.buttons_inactive_when_settings_enabled.append(self.update_button)
 
-    def tear_down(self):
-        """
-        Called on card destruction.
-        """
-        self.stop_pm(None, None)
+        # internal state keeping: which channels are enabled?
+        self.enabled_channels = {}
 
     @show_errors_as_popup()
-    def start_pm(self, instr, parameters, color):
+    def start_pm(self):
         """
         Sets up the pm and starts it.
         """
-        if self.initialized:
-            self.model.plot_collection.remove(self.plot_data)
-            self.initialized = False
+        if self.card_active.get():
+            raise RuntimeError('Cannot start pm when already started.')
+
+        for _, trace in self.enabled_channels.items():
+            self.data_to_plot_queue.put(PlotDataPoint(trace_name=trace, delete_trace=True))
 
         loaded_instr = self.load_instrument_instance()
-
         loaded_instr.open()
-
-        plot = PlotData(ObservableList(), ObservableList(), color=color)
-        self.model.plot_collection.append(plot)
-
-        nopk = self.model.plot_size
-
-        plot.x.extend([x for x in range(nopk)])
-        plot.y.extend([float('nan') for _ in range(nopk)])
-
-        pm_range = parameters['powermeter range'].value
-        pm_atime = parameters['powermeter averagetime'].value
-        pm_wavelength = parameters['powermeter wavelength'].value
-
-        with loaded_instr.thread_lock:
-            loaded_instr.wavelength = pm_wavelength
-            loaded_instr.averagetime = pm_atime
-            loaded_instr.unit = 'dBm'
-            loaded_instr.range = pm_range
-            loaded_instr.trigger(continuous=False)
-
-        func = lambda: self.poll_pm()
-
-        th = threading.Thread(target=func, name="live viewer measurement")
-
         self.instrument = loaded_instr
-        self.polling_function = func
-        self.active_thread = th
-        self.enabled = True
-        self.plot_data = plot
-        self.initialized = True
 
+        # ToDo - nice to have would be saving existing instrument parameters and restoring them afterwards
+
+        # do the first setting of params
+        self.update_pm_raise_errors()
+
+        # Startet die Motoren!
+        self._start_polling()
+
+        self.card_active.set(True)
+
+    def _start_polling(self):
+        """ start polling thread """
+        if self.active_thread is not None:
+            return  # do not start thread twice 
+        th = threading.Thread(target=lambda: self.poll_pm(), name="live viewer measurement")
+        self.active_thread = th
+        self.stop_thread = False
         self.thread_finished = False
         th.start()
-        self.disable_settings_interaction()
+
+    def _stop_polling(self):
+        """ stop polling thread (busy wait until thread terminated) """
+        self.stop_thread = True
+        if self.active_thread is not None:
+            self.active_thread.join()
+        self.active_thread = None
 
     @show_errors_as_popup()
-    def stop_pm(self, instr, parameters):
+    def stop_pm(self):
         """
         Stops the pm.
         """
-        self.enabled = False
-        loaded_instr = self.instrument
+        self._stop_polling()
 
-        # the following block is needed for a few reasons. We want for the polling thread to be finished, to make sure
-        # there are no requests or communications to the instruments left pending. If we however do not call the
-        # update_idletasks() function, the plot window cannot update (as we, the main thread are waiting in a spinlock,
-        # and in tk only the main thread is allowed to alter GUI elements), and therefore the thread will never exit,
-        # leading to a deadlock. Hence we manually update the TK GUI, and allow the thread to finish.
-        while not self.thread_finished:
-            self.update_idletasks()
-            self.update()
-        if loaded_instr is None:
-            return
+        if self.instrument is not None:
+            # ToDo: would be nice to restore saved parameters here
+            self.instrument.close()
+            self.instrument = None
 
-        self.enable_settings_interaction()
-        # since we know that the thread finished, we can now join the thread without risking a deadlock
-        self.active_thread.join()
-
-        self.instrument.close()
-        self.instrument = None
+        self.card_active.set(False)
 
     @show_errors_as_popup()
-    def update_pm(self, instr, parameters):
+    def update_pm(self, *args, **kwargs):
+        self.update_pm_raise_errors(*args, **kwargs)
+
+    def update_pm_raise_errors(self):
         """
         Updates the power meters parameters.
         """
-        self.paused = True
-        sleep(0.2)
-
         loaded_instr = self.instrument
         if loaded_instr is None:
-            self.paused = False
-            return
+            raise RuntimeError('Instrument pointer is None, instrument is not loaded so cannot update.')
+
+        parameters = self.ptable.to_meas_param()
 
         pm_range = parameters['powermeter range'].value
         pm_atime = parameters['powermeter averagetime'].value
         pm_wavelength = parameters['powermeter wavelength'].value
 
-        if loaded_instr is not None:
+        # validate chosen channels before changing anything
+        channel_designators = [str(c).strip() for c in
+                               str(parameters['channels to plot (comma separated)'].value).split(',')]
+        valid_channels = [str(v) for v in loaded_instr.instrument_config_descriptor['channels']]
+        for ac in channel_designators:
+            if str(ac) not in valid_channels:
+                raise ValueError(f'Channel {ac:s} is not a valid channel designator. Valid channels: {valid_channels}')
+
+        self._stop_polling()
+
+        # remove plots for previously enabled, now disabled channels
+        to_remove = []
+        for ac, trace in self.enabled_channels.items():
+            if ac not in channel_designators:
+                self.data_to_plot_queue.put(PlotDataPoint(trace_name=trace, delete_trace=True))
+                to_remove.append(ac)
+        for ac in to_remove:
+            self.enabled_channels.pop(ac)
+
+        # add trace name for each newly enabled channel
+        for ac in channel_designators:
+            if ac in self.enabled_channels:
+                continue
+            self.enabled_channels[ac] = f'Ch{ac:s}'
+
+        # configure the instrument for each activated channel
+        for ac in self.enabled_channels.keys():
             with loaded_instr.thread_lock:
+                loaded_instr.channel = ac
                 loaded_instr.wavelength = pm_wavelength
                 loaded_instr.averagetime = pm_atime
                 loaded_instr.unit = 'dBm'
                 loaded_instr.range = pm_range
                 loaded_instr.trigger(continuous=False)
-        else:
-            raise (InstrumentException("The Power Meter is currently not enabled"))
 
-        self.paused = False
+        self._start_polling()
 
     @show_errors_as_popup()
     def poll_pm(self):
         """
-        Function to be run in a thread, continuously polls the pm
+        Function to be run in a thread, continuously polls the pm.
         """
-        loaded_instr = self.instrument
-        plot = self.plot_data
+        first = True
+        while not self.stop_thread:
+            with self.instrument.thread_lock:
+                for ac, trace in self.enabled_channels.items():
 
-        while self.enabled:
-            if self.paused:
-                sleep(0.2)
-            else:
-                with loaded_instr.thread_lock:
-                    loaded_instr.trigger()
-                    power_current = loaded_instr.fetch_power()
-                # add the values to the plot
-                del plot.y[0]
-                plot.y.append(power_current)
+                    # check break conditions
+                    if self.stop_thread or (self.instrument is None):
+                        break
+
+                    # get up-to-date power value
+                    self.instrument.channel = ac
+                    if not first:
+                        power_data = self.instrument.fetch_power()
+                        time_stamp = time.time()
+                        self.data_to_plot_queue.put(PlotDataPoint(trace_name=trace,
+                                                                  timestamp=time_stamp,
+                                                                  y_value=power_data))
+
+                    # trigger channel anew
+                    self.instrument.trigger()
+            first = False
+            sleep(1e-3)
 
         self.thread_finished = True
 
@@ -225,4 +228,4 @@ class PowerMeterCard(CardFrame):
         """
         This function is needed as a generic stopping function.
         """
-        self.stop_pm(None, None)
+        self.stop_pm()

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -11,6 +11,7 @@ import json
 from json import JSONDecodeError
 from os import makedirs
 from os.path import dirname, join
+from typing import TYPE_CHECKING, Dict, Tuple
 
 from LabExT.Experiments.AutosaveDict import AutosaveDict
 from LabExT.PluginLoader import PluginLoader
@@ -19,13 +20,23 @@ from LabExT.View.LiveViewer.Cards import CardFrame
 from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel, PlotDataPoint
 from LabExT.View.LiveViewer.LiveViewerView import LiveViewerView
 
+if TYPE_CHECKING:
+    from tkinter import Tk, Toplevel
+    from LabExT.ExperimentManager import ExperimentManager
+    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
+else:
+    Tk = None
+    Toplevel = None
+    ExperimentManager = None
+    MEAS_PARAMS_TYPE = None
+
 
 class LiveViewerController:
     """
     Controller class for the live viewer. Contains all functions interacting the view and model classes.
     """
 
-    def __init__(self, root, experiment_manager):
+    def __init__(self, root: Tk, experiment_manager: ExperimentManager):
         """Constructor.
 
         Parameters
@@ -35,19 +46,19 @@ class LiveViewerController:
         experiment_manager : ExperimentManager
             Current instance of ExperimentManager
         """
-        self.root = root
-        self.experiment_manager = experiment_manager
+        self.root: Tk = root
+        self.experiment_manager: ExperimentManager = experiment_manager
 
         # set up the liveviewer model
-        self.model = LiveViewerModel(root)
+        self.model: LiveViewerModel = LiveViewerModel(root)
         self.model.lvcards_classes.update(self.experiment_manager.live_viewer_cards)
         self.experiment_manager.live_viewer_model = self.model
 
         # set up the liveviewer view
-        self.view = LiveViewerView(self.root, self, self.model, experiment_manager)
+        self.view: LiveViewerView = LiveViewerView(self.root, self, self.model, experiment_manager)
 
         # sets the member variable current_window, needed by the LabExT backend
-        self.current_window = self.view.main_window
+        self.current_window: Toplevel = self.view.main_window
 
         # restore previously saved state
         self.restore_lv_from_saved_parameters()
@@ -61,7 +72,7 @@ class LiveViewerController:
         for _, card in self.model.cards:
             card.stop_instr()
 
-    def update_settings(self, parameters):
+    def update_settings(self, parameters: MEAS_PARAMS_TYPE):
         """Updates the main parameters of the plot. These are the ones represented without a card, present
         on any liveviewer.
 
@@ -83,7 +94,7 @@ class LiveViewerController:
         # averaging for bar plot
         self.model.averaging_bar_plot = max(1, int(abs(parameters["averaging in bar plot"].value)))
 
-    def remove_card(self, card):
+    def remove_card(self, card: CardFrame):
         """Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the
         top right of a card.
         """
@@ -105,7 +116,7 @@ class LiveViewerController:
             lambda: self._destroy_card(card),
         )
 
-    def _destroy_card(self, card):
+    def _destroy_card(self, card: CardFrame):
         """deferred call to destroy card frame after corresponding traces were removed"""
         self.model.cards.remove((card.CARD_TITLE, card))
         card.destroy()
@@ -193,7 +204,7 @@ class LiveViewerController:
         data.save()
 
     @staticmethod
-    def load_all_cards(experiment_manager):
+    def load_all_cards(experiment_manager: ExperimentManager) -> Tuple[Dict[str, type], Dict[str, int]]:
         """
         This function dynamically loads all card objects, from the static cards directory
         """

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -6,18 +6,17 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 import datetime
-import json
 from collections import OrderedDict
+import json
+from json import JSONDecodeError
 from os import makedirs
 from os.path import dirname, join
 
 from LabExT.Experiments.AutosaveDict import AutosaveDict
-from LabExT.Measurements.MeasAPI import MeasParamAuto
 from LabExT.PluginLoader import PluginLoader
-from LabExT.Utils import get_configuration_file_path
-from LabExT.Utils import make_filename_compliant, get_labext_version
+from LabExT.Utils import get_configuration_file_path, make_filename_compliant, get_labext_version
 from LabExT.View.LiveViewer.Cards import CardFrame
-from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
+from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel, PlotDataPoint
 from LabExT.View.LiveViewer.LiveViewerView import LiveViewerView
 
 
@@ -41,10 +40,8 @@ class LiveViewerController:
 
         # set up the liveviewer model
         self.model = LiveViewerModel(root)
-
-        self.model.options = self.experiment_manager.live_viewer_cards
-        # loads old, saved parameters
-        self.load_parameters()
+        self.model.lvcards_classes.update(self.experiment_manager.live_viewer_cards)
+        self.experiment_manager.live_viewer_model = self.model
 
         # set up the liveviewer view
         self.view = LiveViewerView(self.root, self, self.model, experiment_manager)
@@ -52,67 +49,8 @@ class LiveViewerController:
         # sets the member variable current_window, needed by the LabExT backend
         self.current_window = self.view.main_window
 
-        self.model.old_params = []
-
-    def save_parameters(self):
-        """Saves all parameters to a config file, so that when the next instance of the liveviewer is loaded,
-        all the parameters remain the same.
-
-        Parameters
-        ----------
-        """
-        # initialize json element
-        to_save = []
-        # loop over all cards
-        for (type, card) in self.model.cards:
-            # for each card, make a json out of the parameter tables
-            params = card.ptable.make_json_able()
-
-            instr_data = {}
-            for role_name in card.available_instruments:
-                instr_data[role_name] = card.available_instruments[role_name].choice
-            # build the config object
-            config = [type, params, instr_data]
-            # add the config to the list
-            to_save.append(config)
-
-        # write all elements to the json file
-        fname = get_configuration_file_path('LiveViewerConfig.json')
-        with open(fname, 'w') as json_file:
-            json_file.write(json.dumps(to_save))
-
-    def load_parameters(self):
-        """Loads all parameters from a config file, so that when the next instance of the liveviewer is loaded,
-        all the parameters remain the same.
-
-        Parameters
-        ----------
-        """
-        # try to open the json.
-        try:
-            fname = get_configuration_file_path('LiveViewerConfig.json')
-            with open(fname, 'r') as json_file:
-                data = json.loads(json_file.read())
-
-            # read all configs from the json
-            for old_card in data:
-                # save the config to the model, by appending cards directly to the model
-                self.model.cards.append((old_card[0], None))
-                # load the config
-                old_param = {}
-                for op in old_card[1]:
-                    old_param[op] = MeasParamAuto(old_card[1][op])
-
-                # add the parameters to the old_params list
-                self.model.old_params.append(old_param)
-                self.model.old_instr.append(old_card[2])
-
-        # if we do not succeed, the json does not exist and we do nothing
-        except json.JSONDecodeError as e:
-            pass
-
-        except FileNotFoundError as e:
-            pass
+        # restore previously saved state
+        self.restore_lv_from_saved_parameters()
 
     def close_all_instruments(self):
         """Wrapper function that closes all instruments.
@@ -120,33 +58,11 @@ class LiveViewerController:
         Parameters
         ----------
         """
-        for (card_type, card) in self.model.cards:
+        for _, card in self.model.cards:
             card.stop_instr()
 
-    def toggle_card_mode_enable(self, index):
-        """ Switches one card at index to enable mode. This is, such that buttons can be greyed out while
-        an instrument is active.
-
-        Parameters
-        ----------
-        index :
-            index of the card that needs to be toggled
-        """
-        self.model.cards[index][1].enable_settings_interaction()
-
-    def toggle_card_mode_disable(self, index):
-        """ Switches one card at index to disable mode. This is, such that buttons can be greyed out while
-        an instrument is disabled.
-
-        Parameters
-        ----------
-        index :
-            index of the card that needs to be toggled
-        """
-        self.model.cards[index][1].disable_settings_interaction()
-
     def update_settings(self, parameters):
-        """ Updates the main parameters of the plot. These are the ones represented without a card, present
+        """Updates the main parameters of the plot. These are the ones represented without a card, present
         on any liveviewer.
 
         Parameters
@@ -155,113 +71,77 @@ class LiveViewerController:
             List of new parameters
         """
 
-        #
-        # update x axis length
-        #
+        # only keep this many seconds in the live plot
+        self.model.plot_cutoff_seconds = abs(parameters["time range to display"].value)
 
-        # load the number of points kept
-        nopk = parameters['number of points kept'].value
-        # find the difference in plot size
-        diff = self.model.plot_size - nopk
+        # the minimum y span
+        self.model.min_y_span = abs(parameters["minimum y-axis span"].value)
 
-        # set the axes to the new plot size
-        self.model.live_plot.ax.set_xlim([0, nopk - 1])
-        # manually update the canvas
-        self.model.live_plot.__update_canvas__()
+        # enable or disable the bar plots on the right
+        self.model.show_bar_plots = parameters["show bar plots"].value
 
-        # clean the plots, loop over all cards
-        for c in self.model.cards:
-            # find out whether the card has a plot attached
-            if c[1].plot_data is not None:
-                # clean
-                if diff > 0:
-                    # we need to remove points. The amount was calculated beforehand
-                    pd = c[1].plot_data
-                    for i in range(diff):
-                        del(pd.y[0])
-                        del(pd.x[nopk])
-                elif diff < 0:
-                    # we need to add points. The amount was calculated beforehand
-                    c[1].plot_data.x.extend([x for x in range(self.model.plot_size, nopk)])
-                    c[1].plot_data.y[0:0] = [float('nan') for _ in range(nopk - self.model.plot_size)]
+        # averaging for bar plot
+        self.model.averaging_bar_plot = max(1, int(abs(parameters["averaging in bar plot"].value)))
 
-        # set the number of point kepts in the model structure
-        self.model.plot_size = nopk
-
-        #
-        # update min y span
-        #
-
-        min_y = parameters['minimum y-axis span'].value
-        self.model.live_plot.min_y_axis_span = min_y
-        self.model.min_y_span = min_y
-
-    def remove_card(self, index):
-        """ Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the
+    def remove_card(self, card):
+        """Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the
         top right of a card.
-
-        Parameters
-        ----------
-        index :
-            Index of card that will be removed
         """
-        # find the card that we need to remove
-        (c_type, card) = self.model.cards[index]
-        # call the cards tear down function
-        card.tear_down()
 
-        # issue the tk command to destroy the card
+        # stop any interaction w/ instrument
+        card.stop_instr()
+
+        # tell plot to delete the corresponding traces
+        for trace_key in self.model.traces_to_plot.keys():
+            if trace_key[0] is card:
+                card.data_to_plot_queue.put(PlotDataPoint(trace_name=trace_key[1], delete_trace=True))
+
+        # hide card by removing from geometry manager, the card will be only destroyed later
+        card.pack_forget()
+
+        # schedule card frame for deletion after plot update tick
+        self.root.after(
+            int(2.0 * self.view.main_window.main_frame.plot_wrapper._animate_interval_ms),
+            lambda: self._destroy_card(card),
+        )
+
+    def _destroy_card(self, card):
+        """deferred call to destroy card frame after corresponding traces were removed"""
+        self.model.cards.remove((card.CARD_TITLE, card))
         card.destroy()
 
-        # clean up the data
-        # remove the plot collection
-        if card.initialized:
-            self.model.plot_collection.remove(card.plot_data)
-
-        # delete the cards record from the list of all cards
-        del(self.model.cards[index])
-
-        # update the indices of all cards.
-        # this is a slight work-around, but all cards need to know their index, to simplify and speedup various commands
-        for i, (card_type, card) in enumerate(self.model.cards):
-            card.index = i
-
-    def update_color(self, index, color):
-        """ Updates the color of a plot with a new one.
-
-        Parameters
-        ----------
-        index :
-            Index of card that will change color
-        color :
-            The new color for the plot
-        """
-        # update the plot_data element
-        if self.model.cards[index][1].plot_data is not None:
-            self.model.cards[index][1].plot_data.color = color
-
     def show_main_window(self):
-        """ Lifts the LiveViewer main window to the front.
+        """Lifts the LiveViewer main window to the front.
 
         Parameters
         ----------
         """
         self.view.main_window.lift()
 
+    def toggle_plotting_active(self):
+        if self.model.plotting_active:
+            self.view.main_window.main_frame.plot_wrapper.stop_animation()
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Continue Plotting")
+            self.model.plotting_active = False
+        else:
+            self.view.main_window.main_frame.plot_wrapper.start_animation()
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Pause Plotting")
+            self.model.plotting_active = True
+
     def create_snapshot(self):
-        param_output_path = str(self.experiment_manager.exp.save_parameters['Raw output path'].value)
+        param_output_path = str(self.experiment_manager.exp.save_parameters["Raw output path"].value)
         makedirs(param_output_path, exist_ok=True)
 
         inst_data = {}
 
-        for i, (card_type, card) in enumerate(self.model.cards):
+        for _, card in self.model.cards:
             try:
-                inst_data[card_type + str(i)] = card.instrument.get_instrument_parameter()
+                inst_data[card.instance_title] = card.instrument.get_instrument_parameter()
             except AttributeError as e:
                 pass
 
         now = datetime.datetime.now()
-        ts = str('{date:%Y-%m-%d_%H%M%S}'.format(date=now))
+        ts = str("{date:%Y-%m-%d_%H%M%S}".format(date=now))
         ts_iso = str(datetime.datetime.isoformat(now))
 
         save_file_name = make_filename_compliant("LiveViewerSnapshot_" + ts_iso)
@@ -270,43 +150,45 @@ class LiveViewerController:
 
         data = AutosaveDict(freq=50, file_path=save_file_path + ".json")
 
-        data['software'] = OrderedDict()
-        data['software']["name"] = "LabExT"
+        data["software"] = OrderedDict()
+        data["software"]["name"] = "LabExT"
         version_string, gitref_string = get_labext_version()
-        data['software']["version"] = version_string
-        data['software']["git rev"] = gitref_string
+        data["software"]["version"] = version_string
+        data["software"]["git rev"] = gitref_string
 
-        data['chip'] = OrderedDict()
+        data["chip"] = OrderedDict()
         if self.experiment_manager.chip is None:
-            data['chip']['name'] = "Chip Not Available"
-            data['chip']['description file path'] = "N/A"
+            data["chip"]["name"] = "Chip Not Available"
+            data["chip"]["description file path"] = "N/A"
         else:
-            data['chip']['name'] = self.experiment_manager.chip._name
-            data['chip']['description file path'] = self.experiment_manager.chip._path
+            data["chip"]["name"] = self.experiment_manager.chip._name
+            data["chip"]["description file path"] = self.experiment_manager.chip._path
 
-        data['timestamp start'] = ts
-        data['timestamp iso start'] = ts_iso
-        data['timestamp'] = ts
+        data["timestamp start"] = ts
+        data["timestamp iso start"] = ts_iso
+        data["timestamp"] = ts
 
-        data['device'] = OrderedDict()
-        data['device']['id'] = 0
-        data['device']['in_position'] = "Not Available"
-        data['device']['out_position'] = "Not Available"
-        data['device']['type'] = "Live Viewed Chip"
+        data["device"] = OrderedDict()
+        data["device"]["id"] = 0
+        data["device"]["in_position"] = "Not Available"
+        data["device"]["out_position"] = "Not Available"
+        data["device"]["type"] = "Live Viewed Chip"
 
-        data['measurement name'] = "Liveviewer Snapshot"
-        data['measurement name and id'] = "Liveviewer Snapshot"
-        data['instruments'] = inst_data
-        data['measurement settings'] = {}
-        data['values'] = OrderedDict()
-        data['error'] = {}
+        data["measurement name"] = "Liveviewer Snapshot"
+        data["measurement name and id"] = "Liveviewer Snapshot"
+        data["instruments"] = inst_data
+        data["measurement settings"] = {}
+        data["values"] = OrderedDict()
+        data["error"] = {}
 
-        for i, (card_type, card) in enumerate(self.model.cards):
-            if card.plot_data is not None:
-                data['values'][str(card_type) + " " + str(i) + ": " + card.last_instrument_type] = card.plot_data.y
-                data['values']["x"] = card.plot_data.x
+        for trace_key, plot_trace in self.model.traces_to_plot.items():
+            this_card = trace_key[0]
+            trace_name = trace_key[1]
+            fqtn = f"{this_card.instance_title:s}: {trace_name:s}"
+            data["values"][f"{fqtn:s}: y-values"] = plot_trace.y_values
+            data["values"][f"{fqtn:s}: timestamps"] = plot_trace.timestamps
 
-        data['finished'] = True
+        data["finished"] = True
 
         data.save()
 
@@ -320,13 +202,68 @@ class LiveViewerController:
         plugin_loader = PluginLoader()
         plugin_loader_stats = {}
 
-        cards_search_path = [join(dirname(__file__), 'Cards')]  # include cards from LabExT core first
-        cards_search_path += experiment_manager.addon_settings['addon_search_directories']
+        cards_search_path = [join(dirname(__file__), "Cards")]  # include cards from LabExT core first
+        cards_search_path += experiment_manager.addon_settings["addon_search_directories"]
 
         for csp in cards_search_path:
             plugins = plugin_loader.load_plugins(csp, plugin_base_class=CardFrame, recursive=True)
-            unique_plugins = {v.instrument_type: v for v in plugins.values() if v.instrument_type not in return_dict}
+            unique_plugins = {v.CARD_TITLE: v for v in plugins.values() if v.CARD_TITLE not in return_dict}
             plugin_loader_stats[csp] = len(unique_plugins)
             return_dict.update(unique_plugins)
 
         return return_dict, plugin_loader_stats
+
+    def save_parameters(self):
+        """saves current parameters of live viewer to file, this includes global parameters and configured cards"""
+
+        lv_state_to_save = []
+
+        global_settings = {}
+        self.view.main_window.main_frame.control_wrapper.cardM.ptable.serialize_to_dict(global_settings)
+        lv_state_to_save.append(global_settings)
+
+        for ctype, card in self.model.cards:
+            instr_data = {}
+            for irolename, irole in card.available_instruments.items():
+                instr_data[irolename] = irole.choice
+
+            param_data = {}
+            card.ptable.serialize_to_dict(param_data)
+
+            lv_state_to_save.append((ctype, instr_data, param_data))
+
+        # write all elements to the json file
+        fname = get_configuration_file_path(self.model.settings_file_name)
+        with open(fname, "w") as json_file:
+            json_file.write(json.dumps(lv_state_to_save))
+
+    def restore_lv_from_saved_parameters(self):
+        """restores a liveviewer state given previously saved parameters"""
+        try:
+            # load state from file
+            fname = get_configuration_file_path(self.model.settings_file_name)
+            with open(fname, "r") as json_file:
+                loaded_lv_state = json.loads(json_file.read())
+
+            # apply global settings
+            self.view.main_window.main_frame.control_wrapper.cardM.ptable.deserialize_from_dict(loaded_lv_state[0])
+            self.update_settings(self.view.main_window.main_frame.control_wrapper.cardM.ptable.to_meas_param())
+
+            # create cards
+            for ctype, _, _ in loaded_lv_state[1:]:
+                self.model.cards.append((ctype, None))
+            self.view.main_window.main_frame.control_wrapper.set_cards()
+
+            # restore card settings
+            for cidx, (_, instr_data, param_data) in enumerate(loaded_lv_state[1:]):
+                _, card = self.model.cards[cidx]
+                card.instr_selec.deserialize_from_dict(instr_data)
+                card.ptable.deserialize_from_dict(param_data)
+        except FileNotFoundError:
+            # save file does not exist, don't care
+            return
+        except (KeyError, IndexError, ValueError, TypeError, JSONDecodeError) as _:
+            # loading errors can be safely ignored as the state will be written anew upon liveviewer termination
+            self.experiment_manager.logger.warning(
+                "Could not load live viewer state from saved file. Live viewer reset to default settings."
+            )

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -17,8 +17,12 @@ from LabExT.Measurements.MeasAPI import MeasParamFloat, MeasParamBool, MeasParam
 
 if TYPE_CHECKING:
     from LabExT.View.LiveViewer.Cards import CardFrame
+    from tkinter import Tk
+    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
 else:
     CardFrame = None
+    Tk = None
+    MEAS_PARAMS_TYPE = None
 
 
 LIVE_VIEWER_PLOT_COLOR_CYCLE = OrderedDict(
@@ -62,10 +66,10 @@ class PlotTrace:
         return np.array(self.timestamps) - time.time()
 
     @property
-    def finite_y_values(self):
+    def finite_y_values(self) -> np.ndarray:
         return np.array(self.y_values)[np.isfinite(self.y_values)]
 
-    def delete_older_than(self, cutoff_s):
+    def delete_older_than(self, cutoff_s: float):
         deltas = self.delta_time_to_now
         n_elems_older_than_cutoff = np.count_nonzero(np.abs(deltas) > np.abs(cutoff_s)) - 1
         if n_elems_older_than_cutoff > 0:
@@ -87,7 +91,7 @@ class LiveViewerModel:
     Model class for the live viewer. Contains all data needed for the operation of the liveviewer.
     """
 
-    def __init__(self, root):
+    def __init__(self, root: Tk):
         """Constructor.
 
         Parameters
@@ -96,10 +100,10 @@ class LiveViewerModel:
             Tkinter root window.
         """
 
-        self.settings_file_name = "LiveViewerConfig.json"
+        self.settings_file_name: str = "LiveViewerConfig.json"
 
         # these are the general settings
-        self.general_settings = {
+        self.general_settings: MEAS_PARAMS_TYPE = {
             "time range to display": MeasParamFloat(value=20.0, unit="s"),
             "minimum y-axis span": MeasParamFloat(value=4.0),
             "show bar plots": MeasParamBool(value=True),
@@ -108,7 +112,7 @@ class LiveViewerModel:
 
         # the options when selecting a new card
         # this is dynamically filled in during start of the live viewer
-        self.lvcards_classes = {}
+        self.lvcards_classes: Dict[str, type] = {}
 
         # the cards list
         self.cards: List[Tuple[str, CardFrame]] = []
@@ -133,7 +137,7 @@ class LiveViewerModel:
         # averaging for bar plot
         self.averaging_bar_plot: int = 20
 
-    def get_next_plot_color_index(self) -> str:
+    def get_next_plot_color_index(self) -> int:
         """call this to get the next color for another trace to show"""
         occupied_color_indices = [t.color_index for t in self.traces_to_plot.values()]
         indices_in_ccycle = [k for k in LIVE_VIEWER_PLOT_COLOR_CYCLE.keys() if k not in occupied_color_indices]

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -5,15 +5,88 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from LabExT.Measurements.MeasAPI import MeasParamInt, MeasParamFloat
+from collections import OrderedDict
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, TYPE_CHECKING
 
-from LabExT.ViewModel.Utilities.ObservableList import ObservableList
+import matplotlib.lines
+import numpy as np
+
+from LabExT.Measurements.MeasAPI import MeasParamFloat, MeasParamBool, MeasParamInt
+
+if TYPE_CHECKING:
+    from LabExT.View.LiveViewer.Cards import CardFrame
+else:
+    CardFrame = None
+
+
+LIVE_VIEWER_PLOT_COLOR_CYCLE = OrderedDict(
+    [
+        (0, "#1f77b4"),
+        (1, "#ff7f0e"),
+        (2, "#2ca02c"),
+        (3, "#d62728"),
+        (4, "#9467bd"),
+        (5, "#8c564b"),
+        (6, "#e377c2"),
+        (7, "#7f7f7f"),
+        (8, "#bcbd22"),
+        (9, "#17becf"),
+    ]
+)
+
+
+@dataclass
+class PlotDataPoint:
+    """use this object to transfer data to the live plotter"""
+
+    trace_name: str
+    timestamp: float = float("nan")
+    y_value: float = float("nan")
+    delete_trace: bool = False
+
+
+@dataclass
+class PlotTrace:
+    """stores data and ax/line references for a trace to plot"""
+
+    timestamps: List[float] = field(default_factory=list)
+    y_values: List[float] = field(default_factory=list)
+    line_handle: matplotlib.lines.Line2D = None
+    color_index: int = None
+    bar_index: int = None
+
+    @property
+    def delta_time_to_now(self):
+        return np.array(self.timestamps) - time.time()
+
+    @property
+    def finite_y_values(self):
+        return np.array(self.y_values)[np.isfinite(self.y_values)]
+
+    def delete_older_than(self, cutoff_s):
+        deltas = self.delta_time_to_now
+        n_elems_older_than_cutoff = np.count_nonzero(np.abs(deltas) > np.abs(cutoff_s)) - 1
+        if n_elems_older_than_cutoff > 0:
+            self.timestamps[:n_elems_older_than_cutoff] = []
+            self.y_values[:n_elems_older_than_cutoff] = []
+
+    def add_plot_data_point(self, pdp: PlotDataPoint):
+        self.timestamps.append(pdp.timestamp)
+        self.y_values.append(pdp.y_value)
+
+    def update_line_data(self):
+        x = np.hstack((self.delta_time_to_now, 1))
+        y = np.hstack((self.y_values, self.y_values[-1]))
+        self.line_handle.set_data(x, y)
 
 
 class LiveViewerModel:
     """
     Model class for the live viewer. Contains all data needed for the operation of the liveviewer.
     """
+
     def __init__(self, root):
         """Constructor.
 
@@ -23,31 +96,50 @@ class LiveViewerModel:
             Tkinter root window.
         """
 
+        self.settings_file_name = "LiveViewerConfig.json"
+
         # these are the general settings
         self.general_settings = {
-            # number of points kept
-            'number of points kept': MeasParamInt(value=100),
-            'minimum y-axis span': MeasParamFloat(value=4.0),
+            "time range to display": MeasParamFloat(value=20.0, unit="s"),
+            "minimum y-axis span": MeasParamFloat(value=4.0),
+            "show bar plots": MeasParamBool(value=True),
+            "averaging in bar plot": MeasParamInt(value=20, unit="samples"),
         }
-
-        # the plot collection, which is used for the plotting frame
-        self.plot_collection = ObservableList()
 
         # the options when selecting a new card
         # this is dynamically filled in during start of the live viewer
-        self.options = {}
+        self.lvcards_classes = {}
 
         # the cards list
-        self.cards = []
-        # the old parameters, used when loading from an existing instance of the liveviewer
-        self.old_params = []
-        self.old_instr = []
+        self.cards: List[Tuple[str, CardFrame]] = []
+        self.next_card_index: int = 1
 
-        # the current live plot
-        self.live_plot = None
+        # the currently plotted traces in the live viewer plot
+        self.traces_to_plot: Dict[Tuple[CardFrame, str], PlotTrace] = {}
+        self.plotting_active: bool = True
 
-        # the number of points kept
-        self.plot_size = 100
+        # the color index to be used for the next trace
+        self.new_color_idx: int = 0
+
+        # only keep this many seconds in the live plot
+        self.plot_cutoff_seconds: float = 20.0
 
         # the minimum y span
-        self.min_y_span = 4.0
+        self.min_y_span: float = 4.0
+
+        # if bar pot should be shown
+        self.show_bar_plots: bool = True
+
+        # averaging for bar plot
+        self.averaging_bar_plot: int = 20
+
+    def get_next_plot_color_index(self) -> str:
+        """call this to get the next color for another trace to show"""
+        occupied_color_indices = [t.color_index for t in self.traces_to_plot.values()]
+        indices_in_ccycle = [k for k in LIVE_VIEWER_PLOT_COLOR_CYCLE.keys() if k not in occupied_color_indices]
+        if indices_in_ccycle:
+            return indices_in_ccycle[0]
+        else:
+            ret_idx = self.new_color_idx
+            self.new_color_idx = (self.new_color_idx + 1) % len(LIVE_VIEWER_PLOT_COLOR_CYCLE)
+            return ret_idx

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -7,8 +7,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 
 from queue import Empty
-from tkinter import Tk, Frame, TOP, BOTH
-from typing import TYPE_CHECKING
+from tkinter import Frame, TOP, BOTH
+from typing import TYPE_CHECKING, Optional, Tuple, List
 
 import matplotlib.animation as animation
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
@@ -18,33 +18,47 @@ import numpy as np
 from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint, PlotTrace, LIVE_VIEWER_PLOT_COLOR_CYCLE
 
 if TYPE_CHECKING:
+    from tkinter import Tk
     from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
+    from matplotlib.animation import Animation
+    from matplotlib.figure import Figure
+    from matplotlib.axis import Axis
+    from matplotlib.container import BarContainer
+    from matplotlib.text import Text
+    from matplotlib.legend import Legend
 else:
+    Tk = None
     LiveViewerModel = None
+    Animation = None
+    Figure = None
+    Axis = None
+    BarContainer = None
+    Text = None
+    Legend = None
 
 
 class LiveViewerPlot(Frame):
     def __init__(self, parent: Tk, model: LiveViewerModel):
         super().__init__(parent, highlightbackground="grey", highlightthickness=1)
-        self._root = parent
+        self._root: Tk = parent
 
-        self.model = model
+        self.model: LiveViewerModel = model
 
         # some constants
-        self._figsize = (6, 4)
-        self._title = "Live Plot"
-        self._animate_interval_ms = 100
+        self._figsize: Tuple[int, int] = (6, 4)
+        self._title: str = "Live Plot"
+        self._animate_interval_ms: int = 100
 
         # plot object refs
-        self._ani = None
-        self._toolbar = None
-        self._canvas = None
-        self._fig = None
-        self._ax = None
-        self._ax_bar = None
-        self._bar_collection = []
-        self._bar_collection_labels = []
-        self._legend = None
+        self._ani: Optional[Animation] = None
+        self._toolbar: Optional[NavigationToolbar2Tk] = None
+        self._canvas: Optional[FigureCanvasTkAgg] = None
+        self._fig: Optional[Figure] = None
+        self._ax: Optional[Axis] = None
+        self._ax_bar: Optional[Axis] = None
+        self._bar_collection: BarContainer = []
+        self._bar_collection_labels: List[Text] = []
+        self._legend: Legend = None
 
         self.__setup__()
 

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2023  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+
+from queue import Empty
+from tkinter import Tk, Frame, TOP, BOTH
+from typing import TYPE_CHECKING
+
+import matplotlib.animation as animation
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+from matplotlib.pyplot import subplots
+import numpy as np
+
+from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint, PlotTrace, LIVE_VIEWER_PLOT_COLOR_CYCLE
+
+if TYPE_CHECKING:
+    from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
+else:
+    LiveViewerModel = None
+
+
+class LiveViewerPlot(Frame):
+    def __init__(self, parent: Tk, model: LiveViewerModel):
+        super().__init__(parent, highlightbackground="grey", highlightthickness=1)
+        self._root = parent
+
+        self.model = model
+
+        # some constants
+        self._figsize = (6, 4)
+        self._title = "Live Plot"
+        self._animate_interval_ms = 100
+
+        # plot object refs
+        self._ani = None
+        self._toolbar = None
+        self._canvas = None
+        self._fig = None
+        self._ax = None
+        self._ax_bar = None
+        self._bar_collection = []
+        self._bar_collection_labels = []
+        self._legend = None
+
+        self.__setup__()
+
+    def __setup__(self):
+        if self._ani is not None:
+            self.stop_animation()
+        if self._canvas is not None:
+            self._canvas.get_tk_widget().pack_forget()
+        if self._toolbar is not None:
+            self._toolbar.pack_forget()
+
+        if self.model.show_bar_plots:
+            self._fig, (self._ax, self._ax_bar) = subplots(
+                nrows=1,
+                ncols=2,
+                sharey="all",
+                gridspec_kw={
+                    "width_ratios": (4, 1),
+                    "left": 0.12,
+                    "bottom": 0.088,
+                    "right": 0.93,
+                    "top": 0.93,
+                    "wspace": 0.0,
+                    "hspace": 0.0,
+                },
+                figsize=self._figsize,
+            )
+        else:
+            self._fig, self._ax = subplots(
+                nrows=1,
+                ncols=1,
+                sharey="all",
+                gridspec_kw={"left": 0.12, "bottom": 0.088, "right": 0.93, "top": 0.93, "wspace": 0.0, "hspace": 0.0},
+                figsize=self._figsize,
+            )
+            self._ax_bar = None
+
+        self._fig.suptitle(self._title)
+
+        # self.ax = self.fig.add_subplot(1, 2, 1)
+        self._ax.grid(color="gray", linestyle="-", linewidth=0.5)
+        self._ax.set_xlabel("elapsed time [s]")
+        self._ax.set_ylabel("Power [dBm]")
+
+        self._canvas = FigureCanvasTkAgg(self._fig, self)
+        self._toolbar = NavigationToolbar2Tk(self._canvas, self)
+        self._toolbar.update()
+        self._canvas.get_tk_widget().pack(side=TOP, fill=BOTH, expand=True)
+
+        self._canvas.draw()
+
+        # configure timed updating, starts automatically
+        self._ani = animation.FuncAnimation(
+            self._fig, self.animation_tick, interval=self._animate_interval_ms, cache_frame_data=False
+        )
+
+    def start_animation(self):
+        self._ani.resume()
+
+    def stop_animation(self):
+        self._ani.pause()
+
+    def animation_tick(self, _):
+        if (self._ax_bar is not None) != self.model.show_bar_plots:
+            # show/hiding bar plot changed, we need to start anew with the plot setup
+            for trace in self.model.traces_to_plot.values():
+                trace.line_handle.remove()
+            self.model.traces_to_plot.clear()
+            self.__setup__()
+            # setup started a new animation loop, return here
+            return
+
+        redraw_bars = False
+
+        for _, card in self.model.cards:
+            try:
+                while True:
+                    plot_data_point: PlotDataPoint = card.data_to_plot_queue.get_nowait()
+
+                    trace_key = (card, plot_data_point.trace_name)
+
+                    # line delete flag is set, remove line from axis and delete internal data structure
+                    if plot_data_point.delete_trace and (trace_key in self.model.traces_to_plot):
+                        self.model.traces_to_plot[trace_key].line_handle.remove()  # removes this line from axis
+                        self.model.traces_to_plot.pop(trace_key, None)
+                        redraw_bars = True
+                        continue
+
+                    # we got a new trace name, setup internal data structure and put line onto axis
+                    if trace_key not in self.model.traces_to_plot:
+                        color_index = self.model.get_next_plot_color_index()
+                        line_label = f"{card.instance_title:s}: {plot_data_point.trace_name:s}"
+                        (line,) = self._ax.plot(
+                            [], [], color=LIVE_VIEWER_PLOT_COLOR_CYCLE[color_index], label=line_label
+                        )
+                        self.model.traces_to_plot[trace_key] = PlotTrace(
+                            timestamps=[plot_data_point.timestamp],
+                            y_values=[plot_data_point.y_value],
+                            line_handle=line,
+                            color_index=color_index,
+                            bar_index=-1,
+                        )
+                        redraw_bars = True
+                        continue
+
+                    # append new data point to internal datastructure
+                    self.model.traces_to_plot[trace_key].add_plot_data_point(plot_data_point)
+
+            except Empty:
+                # jumps to next card if no more plot values left to process
+                continue
+
+        # update the line data for all traces
+        for plot_trace in self.model.traces_to_plot.values():
+            plot_trace.delete_older_than(self.model.plot_cutoff_seconds)
+            plot_trace.update_line_data()
+
+        # do y-axis re-scaling of plot
+        # get current max/min of all traces
+        y_min = []
+        y_max = []
+        for plot_trace in self.model.traces_to_plot.values():
+            y_values = plot_trace.finite_y_values
+            if len(y_values) > 0:
+                y_min.append(min(y_values))
+                y_max.append(max(y_values))
+        y_min = min(y_min) if y_min else 0.0
+        y_max = max(y_max) if y_max else 0.0
+        # make sure that we have a small margin
+        dy = y_max - y_min
+        y_min -= dy * 0.1
+        y_max += dy * 0.1
+        # make sure to adhere to the user-defined minimum y-range
+        dy_scaled = y_max - y_min
+        if dy_scaled < self.model.min_y_span:
+            incr_by = self.model.min_y_span - dy_scaled
+            y_min -= incr_by / 2
+            y_max += incr_by / 2
+        self._ax.set_ylim([y_min, y_max])
+
+        # do x-axis re-scaling of plot
+        self._ax.set_xlim([-self.model.plot_cutoff_seconds, 0.0])
+
+        # handle legend: show legend only if there are traces to plot
+        # only do changes to the legend if there are any changes to the shown traces
+        if redraw_bars:
+            if self.model.traces_to_plot:
+                self._legend = self._ax.legend(loc="upper left", frameon=False)
+            else:
+                if self._legend is not None:
+                    self._legend.remove()
+                    self._legend = None
+
+        # update bar data
+        if redraw_bars and (self._ax_bar is not None):
+            for b in self._bar_collection:
+                b.remove()
+            for l in self._bar_collection_labels:
+                l.remove()
+            self._bar_collection_labels.clear()
+
+            x = []
+            height = []
+            colors = []
+            labels = []
+            for tidx, (_, plot_trace) in enumerate(self.model.traces_to_plot.items()):
+                plot_trace.bar_index = tidx
+                y_values = plot_trace.finite_y_values
+                if len(y_values) > 0:
+                    y_val = y_values[-1]
+                else:
+                    y_val = float("nan")
+                height.append(y_val - y_min)
+                x.append(tidx)
+                colors.append(plot_trace.line_handle.get_color())
+                labels.append(plot_trace.line_handle.get_label())
+                self._bar_collection_labels.append(
+                    self._ax_bar.text(x=tidx, y=y_min, s=f"{y_val:.3f}\n", va="bottom", ha="center")
+                )
+
+            self._bar_collection = self._ax_bar.bar(x, height, bottom=y_min, color=colors)
+
+            self._ax_bar.set_xlim([-0.6, len(x) - 0.4])
+            self._ax_bar.set_xticks([i for i in range(len(x))])
+            self._ax_bar.set_xticklabels(labels, rotation=90, va="bottom")
+            self._ax_bar.tick_params(axis="x", length=0.0, pad=-35.0, direction="in")
+
+        else:
+            for _, plot_trace in self.model.traces_to_plot.items():
+                y_values = plot_trace.finite_y_values
+                if len(y_values) > 0:
+                    self._bar_collection[plot_trace.bar_index].set_height(
+                        np.mean(y_values[-self.model.averaging_bar_plot :]) - y_min
+                    )
+                    self._bar_collection_labels[plot_trace.bar_index].set_text(f"{y_values[-1]:.3f}\n")
+                else:
+                    self._bar_collection[plot_trace.bar_index].set_height(0)
+                    self._bar_collection_labels[plot_trace.bar_index].set_text("N/A\n")
+                self._bar_collection[plot_trace.bar_index].set_y(y_min)
+                self._bar_collection_labels[plot_trace.bar_index].set_y(y_min)

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -7,14 +7,15 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from tkinter import Frame, Toplevel, OptionMenu, Button, StringVar, Scrollbar, Canvas
 
+from LabExT.View.LiveViewer.LiveViewerPlot import LiveViewerPlot
 from LabExT.View.Controls.ParameterTable import ParameterTable
-from LabExT.View.Controls.PlotControl import PlotControl
 
 
 class LiveViewerView:
     """
     Viewer class for the live viewer. Contains all functionality related to widgets.
     """
+
     def __init__(self, root, controller, model, experiment_manager):
         """Constructor.
 
@@ -41,6 +42,7 @@ class LiveViewerMainWindow(Toplevel):
     """
     The main window itself. Inherits from TopLevel and acts as a standalone window.
     """
+
     def __init__(self, root, controller, model):
         """Constructor.
 
@@ -55,15 +57,18 @@ class LiveViewerMainWindow(Toplevel):
         """
         Toplevel.__init__(self, root)
         self.controller = controller
-        w, h = root.winfo_screenwidth() - 20, root.winfo_screenheight() - 100
-        self.geometry("%dx%d+0+0" % (w, h))
+        ws, hs = root.winfo_screenwidth(), root.winfo_screenheight()
+        # limit window size - otherwise performance suffers heavily on large-screen systems
+        w = ws if ws < 2000 else 2000
+        h = hs if hs < 1200 else 1200
+        self.geometry(f"{w:d}x{h:d}+{int((ws-w)/2)}+{int((hs-h)/2)}")
         self.lift()
         # self.attributes('-topmost', 'true')
         # self.protocol('WM_DELETE_WINDOW', self.controller.close_wizard)
-        self.bind('<F1>', self.controller.experiment_manager.show_documentation)
+        self.bind("<F1>", self.controller.experiment_manager.show_documentation)
 
         self.main_frame = MainFrame(self, controller, model)
-        self.main_frame.grid(row=0, column=0, padx=2, pady=2, sticky='NESW')
+        self.main_frame.grid(row=0, column=0, padx=2, pady=2, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)  # this needed to be added
         self.grid_columnconfigure(0, weight=1)
 
@@ -73,8 +78,9 @@ class LiveViewerMainWindow(Toplevel):
         """
         Overloading of the destroy operator. Makes sure, that all parameters are saved and the instruments closed.
         """
-        self.controller.save_parameters()
+        self.main_frame.plot_wrapper.stop_animation()
         self.controller.close_all_instruments()
+        self.controller.save_parameters()
         Toplevel.destroy(self)
 
 
@@ -82,6 +88,7 @@ class MainFrame(Frame):
     """
     The main Frame. Contains all other smaller frames.
     """
+
     def __init__(self, parent, controller, model):
         """Constructor.
 
@@ -98,19 +105,23 @@ class MainFrame(Frame):
 
         # add the selector bar
         self.control_wrapper = ControlFrame(self, controller, model)
-        self.control_wrapper.grid(row=0, column=1, padx=2, pady=2, sticky='NESW')
+        self.control_wrapper.grid(row=0, column=1, padx=2, pady=2, sticky="NESW")
 
         # add the plot window
-        self.plot_wrapper = PlotFrame(self, controller, model)
-        self.plot_wrapper.grid(row=0, column=0, padx=2, pady=2, sticky='NESW')
-        self.grid_rowconfigure(0, weight=1)  # this needed to be added
+        self.plot_wrapper = LiveViewerPlot(self, model=model)
+        self.plot_wrapper.grid(row=0, column=0, padx=2, pady=2, sticky="NESW")
+        self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
 
 class ControlFrame(Frame):
     """
     The control Frame. Contains all cards.
+
+    ToDo: this control frame currently bugs when turning MouseWheel, we might need to disable
+    see https://gist.github.com/JackTheEngineer/81df334f3dcff09fd19e4169dd560c59
     """
+
     def __init__(self, parent, controller, model):
         """Constructor.
 
@@ -129,21 +140,24 @@ class ControlFrame(Frame):
 
         # add the CardManager
         self.cardM = CardManager(self, controller, model)
-        self.cardM.grid(row=0, column=0, sticky='NEW', pady=(12, 20))
+        self.cardM.grid(row=0, column=0, sticky="NEW", pady=(12, 20))
+
+        self.pause_button = Button(self, text="Pause Plotting", command=self.controller.toggle_plotting_active)
+        self.pause_button.grid(row=2, column=0, sticky="SEW", pady=(12, 1))
 
         self.save_button = Button(self, text="Save current Data", command=self.controller.create_snapshot)
-        self.save_button.grid(row=2, column=0, sticky='SEW', pady=(12, 20))
+        self.save_button.grid(row=3, column=0, sticky="SEW", pady=(1, 20))
 
         self.card_full_container = Frame(self)
-        self.card_full_container.grid(row=1, column=0, sticky='NESW')
+        self.card_full_container.grid(row=1, column=0, sticky="NESW")
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
 
-        vscrollbar = Scrollbar(self.card_full_container, orient='vertical')
-        vscrollbar.pack(side='right', fill='y')
+        vscrollbar = Scrollbar(self.card_full_container, orient="vertical")
+        vscrollbar.pack(side="right", fill="y")
 
         self.canvas = Canvas(self.card_full_container, yscrollcommand=vscrollbar.set)
-        self.canvas.pack(side='left', fill='y')
+        self.canvas.pack(side="left", fill="y")
 
         vscrollbar.config(command=self.canvas.yview)
 
@@ -155,21 +169,21 @@ class ControlFrame(Frame):
         self.content_carrier = Frame(self.canvas)
 
         # add the content frame to the canvas
-        self.canvas_frame = self.canvas.create_window(0, 0, window=self.content_carrier, anchor='nw')
+        self.canvas.create_window(0, 0, window=self.content_carrier, anchor="nw")
 
         self.set_cards()
 
     def set_cards(self):
         """
-        Function to render all cards from the corellating model
+        Function to render all cards from the correlating model
         """
-        for i, (card_type, card) in enumerate(self.model.cards):
+        for i, (card_title, card) in enumerate(self.model.cards):
             if card is not None:
                 continue
             # set up new card
-            new_card = self.model.options[card_type](self.content_carrier, self.controller, self.model, i)
-            self.model.cards[i] = (card_type, new_card)
-            new_card.pack(side='top', anchor='nw', fill='x', pady=(0, 20))
+            new_card = self.model.lvcards_classes[card_title](self.content_carrier, self.controller, self.model)
+            self.model.cards[i] = (card_title, new_card)
+            new_card.pack(side="top", anchor="nw", fill="x", pady=(0, 20))
 
             # when a card is newly created, we enable the GUI elements s.t. the user can set the parameters
             # this can only happen after the card has been rendered in the "pack" call above
@@ -180,83 +194,11 @@ class ControlFrame(Frame):
         self.canvas.configure(width=self.canvas.bbox("all")[2])
 
 
-class PlotFrame(Frame):
-    """
-    Plot Frame, containing the live plot.
-    """
-    def __init__(self, parent, controller, model):
-        """Constructor.
-
-        Parameters
-        ----------
-        parent : Tk
-            Tkinter parent frame
-        controller :
-            The Live viewer controller
-        model :
-            The Live viewer model
-        """
-        self.model = model
-        self.controller = controller
-        Frame.__init__(self, parent)
-        self.plot_widget = PlotWidget(self, self.model)
-
-        self.plot_widget.grid(row=0, column=0, rowspan=2, padx=10, pady=10, sticky='nswe')
-        self.rowconfigure(0, weight=1)
-        self.columnconfigure(0, weight=1)
-
-
-class PlotWidget (PlotControl):
-    """
-    Plot Widget class. Resides inside the Plotwindow.
-    """
-    def __init__(self, parent, model):
-        """Constructor.
-
-        Parameters
-        ----------
-        parent : Tk
-            Tkinter parent frame
-        model :
-            The Live viewer model
-        """
-        PlotControl.__init__(self,
-                             parent,
-                             add_toolbar=True,
-                             figsize=(12, 6),
-                             autoscale_axis=True,
-                             no_x_autoscale=True,
-                             min_y_axis_span=None
-                             )
-
-        self.parent = parent
-        self.model = model
-
-        self.model.live_plot = self
-
-        self.title = 'Live Plot'
-        self.show_grid = True
-        self.data_source = self.model.plot_collection
-
-        current_nopk = self.model.general_settings['number of points kept'].value
-        current_y_min = self.model.general_settings['minimum y-axis span'].value
-
-        self.ax.set_xlim([0, current_nopk])
-        self.min_y_axis_span = current_y_min
-
-    def destroy(self):
-        # this is a workaround for the LiveViewer thread
-        # This thread is usually waiting on a function return
-        # Once we close this frame however, the call would be blocking forever
-        # Hence we close it
-        self.return_queue.put(None)
-        PlotControl.destroy(self)
-
-
 class CardManager(Frame):
     """
     Card manager frame, containing buttons and menus to add more cards.
     """
+
     def __init__(self, parent, controller, model):
         """Constructor.
 
@@ -277,28 +219,28 @@ class CardManager(Frame):
 
         self.add_card_button = Button(self, text="Add Instrument", command=self.add_card)
 
-        self.add_card_button.grid(row=0, column=0, sticky='EW')
+        self.add_card_button.grid(row=0, column=0, sticky="EW")
 
-        options = model.options
+        options = model.lvcards_classes
 
         self.selected_value = StringVar()
         self.selected_value.set([*options][0])
 
         self.card_selector = OptionMenu(self, self.selected_value, *[*options])
 
-        self.card_selector.grid(row=1, column=0, sticky='EW')
+        self.card_selector.grid(row=1, column=0, sticky="EW")
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
 
         self.ptable = ParameterTable(self)
-        self.ptable.title = 'General Parameters'
+        self.ptable.title = "General Parameters"
         self.ptable.parameter_source = self.model.general_settings
-        self.ptable.grid(row=0, column=1, sticky='NESW', padx=(12, 0))
+        self.ptable.grid(row=0, column=1, sticky="NESW", padx=(12, 0))
 
-        self.add_card_button = Button(self,
-                                      text="Update Settings",
-                                      command=lambda: self.controller.update_settings(self.ptable.to_meas_param()))
-        self.add_card_button.grid(row=1, column=1, sticky='EW', padx=(12, 0))
+        _update_settings_button = Button(
+            self, text="Update Settings", command=lambda: self.controller.update_settings(self.ptable.to_meas_param())
+        )
+        _update_settings_button.grid(row=1, column=1, sticky="EW", padx=(12, 0))
 
     def add_card(self):
         """

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -5,10 +5,22 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+from typing import TYPE_CHECKING
 from tkinter import Frame, Toplevel, OptionMenu, Button, StringVar, Scrollbar, Canvas
 
 from LabExT.View.LiveViewer.LiveViewerPlot import LiveViewerPlot
 from LabExT.View.Controls.ParameterTable import ParameterTable
+
+if TYPE_CHECKING:
+    from tkinter import Tk
+    from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
+    from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
+    from LabExT.ExperimentManager import ExperimentManager
+else:
+    Tk = None
+    LiveViewerController = None
+    LiveViewerModel = None
+    ExperimentManager = None
 
 
 class LiveViewerView:
@@ -16,7 +28,7 @@ class LiveViewerView:
     Viewer class for the live viewer. Contains all functionality related to widgets.
     """
 
-    def __init__(self, root, controller, model, experiment_manager):
+    def __init__(self, root: Tk, controller: LiveViewerController, model: LiveViewerModel, experiment_manager: ExperimentManager):
         """Constructor.
 
         Parameters
@@ -30,10 +42,10 @@ class LiveViewerView:
         experiment_manager : ExperimentManager
             Current instance of ExperimentManager
         """
-        self.root = root
-        self.controller = controller
-        self.model = model
-        self.experiment_manager = experiment_manager
+        self.root: Tk = root
+        self.controller: LiveViewerController = controller
+        self.model: LiveViewerModel = model
+        self.experiment_manager: ExperimentManager = experiment_manager
 
         self.main_window = LiveViewerMainWindow(self.root, controller, model)
 
@@ -43,7 +55,7 @@ class LiveViewerMainWindow(Toplevel):
     The main window itself. Inherits from TopLevel and acts as a standalone window.
     """
 
-    def __init__(self, root, controller, model):
+    def __init__(self, root: Tk, controller: LiveViewerController, model: LiveViewerModel):
         """Constructor.
 
         Parameters
@@ -56,7 +68,7 @@ class LiveViewerMainWindow(Toplevel):
             The Live viewer model
         """
         Toplevel.__init__(self, root)
-        self.controller = controller
+        self.controller: LiveViewerController = controller
         ws, hs = root.winfo_screenwidth(), root.winfo_screenheight()
         # limit window size - otherwise performance suffers heavily on large-screen systems
         w = ws if ws < 2000 else 2000
@@ -89,7 +101,7 @@ class MainFrame(Frame):
     The main Frame. Contains all other smaller frames.
     """
 
-    def __init__(self, parent, controller, model):
+    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
         """Constructor.
 
         Parameters
@@ -122,7 +134,7 @@ class ControlFrame(Frame):
     see https://gist.github.com/JackTheEngineer/81df334f3dcff09fd19e4169dd560c59
     """
 
-    def __init__(self, parent, controller, model):
+    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
         """Constructor.
 
         Parameters
@@ -134,8 +146,8 @@ class ControlFrame(Frame):
         model :
             The Live viewer model
         """
-        self.model = model
-        self.controller = controller
+        self.model: LiveViewerModel = model
+        self.controller: LiveViewerController = controller
         Frame.__init__(self, parent)
 
         # add the CardManager
@@ -199,7 +211,7 @@ class CardManager(Frame):
     Card manager frame, containing buttons and menus to add more cards.
     """
 
-    def __init__(self, parent, controller, model):
+    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
         """Constructor.
 
         Parameters
@@ -211,10 +223,10 @@ class CardManager(Frame):
         model :
             The Live viewer model
         """
-        self._root = parent
-        self.model = model
-        self.parent = parent
-        self.controller = controller
+        self._root: Tk = parent
+        self.model: LiveViewerModel = model
+        self.parent: Tk = parent
+        self.controller: LiveViewerController = controller
         Frame.__init__(self, parent, relief="groove", borderwidth=2)
 
         self.add_card_button = Button(self, text="Add Instrument", command=self.add_card)

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -8,6 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import json
 import logging
 import os
+import sys
 from tkinter import Tk, Toplevel, messagebox
 from tkinter.simpledialog import askinteger
 
@@ -585,12 +586,15 @@ class MainWindowController:
         """Gets called once the application is trying to close.
         Terminates the currently running experiment.
         """
-        self.logger.debug("ViewModel trying to close")
+        # stop experiment
         self.model.experiment_handler.stop_experiment()
+
         # call the cleanup function of the documentation engine
         self.experiment_manager.docu.cleanup()
 
+        # close mainwindow and quit Python interpreter
         self.root.destroy()
+        sys.exit(0)
 
     def _register_keyboard_shortcuts(self):
         self.root.bind("<F1>", self.experiment_manager.show_documentation)

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -69,8 +69,6 @@ class MainWindowController:
         """Called when user closes the application. Save experiment
         settings in .json and call context-callback.
         """
-        self.view.frame.live_plot.stop_polling()
-
         # remove any chip path from parameters if chip is not loaded -> prevent offering reloading-of not loaded chip
         # on next startup
         if self.experiment_manager.chip is None:

--- a/LabExT/View/MainWindow/MainWindowModel.py
+++ b/LabExT/View/MainWindow/MainWindowModel.py
@@ -57,7 +57,6 @@ class MainWindowModel:
         self.experiment = None
         self.chip_parameters = None
         self.save_parameters = None
-        self.live_plot_data = None
         self.selec_plot_data = None
         self.last_opened_new_meas_wizard_controller = None
 
@@ -101,7 +100,6 @@ class MainWindowModel:
             self.experiment = self.experiment_manager.exp
             self.chip_parameters = self.experiment_manager.exp.chip_parameters
             self.save_parameters = self.experiment_manager.exp.save_parameters
-            self.live_plot_data = self.experiment.live_plot_collection
             self.selec_plot_data = self.experiment.selec_plot_collection
 
     def experiment_changed(self, ex):

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -555,7 +555,6 @@ class MainWindowFrame(Frame):
         self.control_panel = None
 
         self.selec_plot = None
-        self.live_plot = None
         self.axes_frame = None
 
         self.logging_frame = None
@@ -593,17 +592,9 @@ class MainWindowFrame(Frame):
         self.selec_plot.title = "Measurement Selection Plot"
         self.selec_plot.show_grid = True
         self.selec_plot.data_source = self.model.selec_plot_data
-        self.selec_plot.grid(row=0, column=1, rowspan=2, padx=10, pady=10, sticky="nswe")
+        self.selec_plot.grid(row=0, column=1, rowspan=2, columnspan=2, padx=10, pady=10, sticky='nswe')
         self.selec_plot.rowconfigure(0, weight=1)
         self.selec_plot.columnconfigure(0, weight=1)
-
-        self.live_plot = PlotControl(self, add_toolbar=True, figsize=(5, 5), polling_time_s=0.5)
-        self.live_plot.title = "Live Plot"
-        self.live_plot.show_grid = True
-        self.live_plot.data_source = self.model.live_plot_data
-        self.live_plot.grid(row=0, column=2, rowspan=2, padx=10, pady=10, sticky="nswe")
-        self.live_plot.rowconfigure(0, weight=1)
-        self.live_plot.columnconfigure(0, weight=1)
 
     def set_up_logging_frame(self):
         """
@@ -672,10 +663,10 @@ class MainWindowView:
         self.frame.set_up_control_frame()
 
         self.frame.set_up_logging_frame()
+
         #
         # active and finished measurement tables
         #
-
         self.frame.set_up_auxiliary_tables()
 
     def set_up_context_menu(self):

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -566,8 +566,9 @@ class StageAssignmentStep(Step):
             return
 
         if stage in self._stage_polygon_parameter_tables:
-            polygon_cls_cfg = self._stage_polygon_parameter_tables[stage].make_json_able(
-            )
+            settings = {}
+            self._stage_polygon_parameter_tables[stage].serialize_to_dict(settings)
+            polygon_cls_cfg = settings['data']
         else:
             polygon_cls_cfg = polygon_cls.get_default_parameters()
 
@@ -586,8 +587,9 @@ class StageAssignmentStep(Step):
             polygon_cls_name = self.polygon_vars[stage].get()
             polygon_cls = self.POLYGON_OPTIONS[polygon_cls_name]
 
-            self.polygon_cfg[stage] = (
-                polygon_cls, polygon_cfg_table.make_json_able())
+            settings = {}
+            polygon_cfg_table.serialize_to_dict(settings)
+            self.polygon_cfg[stage] = (polygon_cls, settings['data'])
 
     def _build_assignment_variables(self) -> tuple:
         """


### PR DESCRIPTION
# Goal
Improve the Live Viewer: performance wise, some GUI elements and simplified API for cards

# Approach
* **Performance** Instead of having a call-back based plot (i.e. updates graph as soon as new value was coming in), a polled plotting method is used (via `matplotlib.animation`). This de-couples instrument polling into a separate thread and connects it via a queue to the tk mainloop thread for plotting. To enable better code readability, the required live-plotting functionality was refactored out from `PlotControl` to a highly specific class (`LiveViewerPlot`) which is now used for the LiveViewer plot.
* **GUI/UX**: A bar-plot was added to the right-hand side of the live-viewer plot. It is helpful during coupling to get an immediate impression of the coupling value. The bar plot can be disabled. By default, a small low-pass filter is applied to the bar's height to reduce noise and guide the eye.
* **Card API**: the card API was simplified - no more indices or colors need to be tracked in the cards themselves, no more plot data needs to be organized. A card really just needs to take care of GUI objects, their control methods and should make use of the new queue to submit a new value sample for plotting. A card can now draw multiple traces on the plot. Also, more than one card class can be written for an instrument type.

# Implementation
Specific improvements were also done for the `PowerMeterCard` class: The new class can poll and plot multiple channels at once.

# Compatibility
Yes - any custom written live viewer cards need to be re-written to adhere to the new API.