### PR TITLE
LVI [4/4]: Small Improvements after new LV rewrite: PlotControl performance, Extra-confirmation for run, black config

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -69,6 +69,7 @@ class ExperimentManager:
         self.mover = MoverNew(experiment_manager=self, chip=chip)
         self.peak_searcher = PeakSearcher(
             None, self, mover=self.mover, parent=self.root)
+        self.live_viewer_model = None
         self.instrument_api = InstrumentAPI(self)
         self.docu = None
         self.already_shown_docu_path = False

--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -114,6 +114,29 @@ class StandardExperiment:
         self.param_output_path = str(self.save_parameters["Raw output path"].value)
         makedirs(self.param_output_path, exist_ok=True)
 
+    def ask_user_to_continue_even_if_live_viewer_active(self):
+        """ check if any of the instrument addresses in the ToDo queue are currently active in live viewer """
+        instr_addrs_in_todo_queue = set()
+        for todo in self.to_do_list:
+            for v in todo.measurement.selected_instruments.values():
+                instr_addrs_in_todo_queue.add(v['visa'])
+        instr_active_in_lv = set()
+        if self._experiment_manager.live_viewer_model is not None:
+            for _, card in self._experiment_manager.live_viewer_model.cards:
+                if card.instrument is not None and card.card_active.get():
+                    visa = card.instrument.instrument_parameters['visa']
+                    if visa in instr_addrs_in_todo_queue:
+                        instr_active_in_lv.add(visa)
+        if instr_active_in_lv:
+            if 'no' == messagebox.askquestion('Active LiveViewer Instruments Found!', 'Some ToDos will interact ' +  
+                                          'with instruments that are currently active in the live viewer. Concurrent instrument ' + 
+                                          'access might not be supported for these instrument classes. It is recommended to ' +
+                                          'stop all live-viewer cards before proceeding. Are you sure you want to proceed?',
+                                          default='no',
+                                          icon='warning'):
+                return False
+        return True
+
     def show_meas_finished_infobox(self):
         messagebox.showinfo("Measurements finished!", "Measurements finished!")
 
@@ -124,6 +147,10 @@ class StandardExperiment:
         self._experiment_manager.main_window.model.exctrl_vars_changed()
 
         self.read_parameters_to_variables()
+
+        if not self.ask_user_to_continue_even_if_live_viewer_active():
+            self.logger.info('The LiveViewer currently occupies some instruments needed for executing measurements. Please stop live viewer cards before running measurements.')
+            return
 
         # we iterate over every measurement of every device in the To Do Queue
         while 0 < len(self.to_do_list):

--- a/LabExT/View/LiveViewer/Cards/CardFrame.py
+++ b/LabExT/View/LiveViewer/Cards/CardFrame.py
@@ -9,29 +9,11 @@ import logging
 import queue
 import tkinter
 from functools import wraps
-from typing import TYPE_CHECKING, Dict, Optional, List
 from tkinter import Frame, Button, Label, messagebox, BooleanVar
 
 from LabExT.Utils import get_visa_address
 from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.Controls.InstrumentSelector import InstrumentRole, InstrumentSelector
-
-if TYPE_CHECKING:
-    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
-    from tkinter import Tk
-    from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
-    from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
-    from logging import Logger
-    from LabExT.Instruments.InstrumentAPI import Instrument
-    from threading import Thread
-else:
-    MEAS_PARAMS_TYPE = None
-    Tk = None
-    LiveViewerController = None
-    LiveViewerModel = None
-    Logger = None
-    Instrument = None
-    Thread = None
 
 
 def show_errors_as_popup(caught_err_classes=(Exception,)):
@@ -68,36 +50,36 @@ class CardFrame(Frame):
     Parent class for all cards. Contains functions that inherited card types must follow.
     """
 
-    INSTRUMENT_TYPE: str = 'FILL ME'
-    CARD_TITLE: str = 'FILL ME'
+    INSTRUMENT_TYPE = 'FILL ME'
+    CARD_TITLE = 'FILL ME'
 
-    default_parameters: MEAS_PARAMS_TYPE = {}
+    default_parameters = {}
 
-    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
+    def __init__(self, parent, controller, model):
 
         # refs to LiveViewer objects
-        self.model: LiveViewerModel = model
-        self.controller: LiveViewerController = controller
+        self.model = model
+        self.controller = controller
 
         # root window where I will be placed
-        self._root: Tk = parent
+        self._root = parent
         # logger, is always handy
-        self.logger: Logger = logging.getLogger()
+        self.logger = logging.getLogger()
 
         # card attributes
-        self.instance_title: str = f'{self.CARD_TITLE:s} {self.model.next_card_index:d}'
+        self.instance_title = f'{self.CARD_TITLE:s} {self.model.next_card_index:d}'
         self.model.next_card_index += 1
-        self.instrument: Optional[Instrument] = None  # reference to instantiated instrument driver
-        self.active_thread: Optional[Thread] = None  # reference to sub-thread (used for polling etc.)
+        self.instrument = None  # reference to instantiated instrument driver
+        self.active_thread = None  # reference to sub-thread (used for polling etc.)
         self.data_to_plot_queue = queue.SimpleQueue()
         self.card_active = BooleanVar(master=parent, value=False)  # indicator if card is active or not
         self.card_active.trace('w', self._card_active_status_changed)
 
-        self.last_instrument_type: str = ""  # keep instrument info for saving out traces to file
+        self.last_instrument_type = ""  # keep instrument info for saving out traces to file
 
         # keep my references which buttons to gray out when
-        self.buttons_active_when_settings_enabled: List[Button] = []
-        self.buttons_inactive_when_settings_enabled: List[Button] = []
+        self.buttons_active_when_settings_enabled = []
+        self.buttons_inactive_when_settings_enabled = []
 
         # setup my main frame, its 3 rows by 3 columns
         Frame.__init__(self, parent, relief="groove", borderwidth=2)
@@ -119,7 +101,7 @@ class CardFrame(Frame):
         self.remove_button.grid(row=0, column=3, sticky='NE')
 
         # row 1: instrument selector
-        self.available_instruments: Dict[str, InstrumentRole] = dict()
+        self.available_instruments = dict()
         io_set = get_visa_address(self.INSTRUMENT_TYPE)
         self.available_instruments.update({self.INSTRUMENT_TYPE: InstrumentRole(self._root, io_set)})
 

--- a/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
+++ b/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
@@ -11,6 +11,7 @@ from time import sleep
 from tkinter import Button
 
 from LabExT.Measurements.MeasAPI import MeasParamInt, MeasParamFloat, MeasParamString
+from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.LiveViewer.Cards.CardFrame import CardFrame, show_errors_as_popup
 from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint
 

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -11,7 +11,6 @@ import json
 from json import JSONDecodeError
 from os import makedirs
 from os.path import dirname, join
-from typing import TYPE_CHECKING, Dict, Tuple
 
 from LabExT.Experiments.AutosaveDict import AutosaveDict
 from LabExT.PluginLoader import PluginLoader
@@ -20,23 +19,13 @@ from LabExT.View.LiveViewer.Cards import CardFrame
 from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel, PlotDataPoint
 from LabExT.View.LiveViewer.LiveViewerView import LiveViewerView
 
-if TYPE_CHECKING:
-    from tkinter import Tk, Toplevel
-    from LabExT.ExperimentManager import ExperimentManager
-    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
-else:
-    Tk = None
-    Toplevel = None
-    ExperimentManager = None
-    MEAS_PARAMS_TYPE = None
-
 
 class LiveViewerController:
     """
     Controller class for the live viewer. Contains all functions interacting the view and model classes.
     """
 
-    def __init__(self, root: Tk, experiment_manager: ExperimentManager):
+    def __init__(self, root, experiment_manager):
         """Constructor.
 
         Parameters
@@ -46,19 +35,19 @@ class LiveViewerController:
         experiment_manager : ExperimentManager
             Current instance of ExperimentManager
         """
-        self.root: Tk = root
-        self.experiment_manager: ExperimentManager = experiment_manager
+        self.root = root
+        self.experiment_manager = experiment_manager
 
         # set up the liveviewer model
-        self.model: LiveViewerModel = LiveViewerModel(root)
+        self.model = LiveViewerModel(root)
         self.model.lvcards_classes.update(self.experiment_manager.live_viewer_cards)
         self.experiment_manager.live_viewer_model = self.model
 
         # set up the liveviewer view
-        self.view: LiveViewerView = LiveViewerView(self.root, self, self.model, experiment_manager)
+        self.view = LiveViewerView(self.root, self, self.model, experiment_manager)
 
         # sets the member variable current_window, needed by the LabExT backend
-        self.current_window: Toplevel = self.view.main_window
+        self.current_window = self.view.main_window
 
         # restore previously saved state
         self.restore_lv_from_saved_parameters()
@@ -72,7 +61,7 @@ class LiveViewerController:
         for _, card in self.model.cards:
             card.stop_instr()
 
-    def update_settings(self, parameters: MEAS_PARAMS_TYPE):
+    def update_settings(self, parameters):
         """Updates the main parameters of the plot. These are the ones represented without a card, present
         on any liveviewer.
 
@@ -94,7 +83,7 @@ class LiveViewerController:
         # averaging for bar plot
         self.model.averaging_bar_plot = max(1, int(abs(parameters["averaging in bar plot"].value)))
 
-    def remove_card(self, card: CardFrame):
+    def remove_card(self, card):
         """Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the
         top right of a card.
         """
@@ -116,7 +105,7 @@ class LiveViewerController:
             lambda: self._destroy_card(card),
         )
 
-    def _destroy_card(self, card: CardFrame):
+    def _destroy_card(self, card):
         """deferred call to destroy card frame after corresponding traces were removed"""
         self.model.cards.remove((card.CARD_TITLE, card))
         card.destroy()
@@ -204,7 +193,7 @@ class LiveViewerController:
         data.save()
 
     @staticmethod
-    def load_all_cards(experiment_manager: ExperimentManager) -> Tuple[Dict[str, type], Dict[str, int]]:
+    def load_all_cards(experiment_manager):
         """
         This function dynamically loads all card objects, from the static cards directory
         """

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -17,12 +17,8 @@ from LabExT.Measurements.MeasAPI import MeasParamFloat, MeasParamBool, MeasParam
 
 if TYPE_CHECKING:
     from LabExT.View.LiveViewer.Cards import CardFrame
-    from tkinter import Tk
-    from LabExT.Measurements.MeasAPI.Measurement import MEAS_PARAMS_TYPE
 else:
     CardFrame = None
-    Tk = None
-    MEAS_PARAMS_TYPE = None
 
 
 LIVE_VIEWER_PLOT_COLOR_CYCLE = OrderedDict(
@@ -66,10 +62,10 @@ class PlotTrace:
         return np.array(self.timestamps) - time.time()
 
     @property
-    def finite_y_values(self) -> np.ndarray:
+    def finite_y_values(self):
         return np.array(self.y_values)[np.isfinite(self.y_values)]
 
-    def delete_older_than(self, cutoff_s: float):
+    def delete_older_than(self, cutoff_s):
         deltas = self.delta_time_to_now
         n_elems_older_than_cutoff = np.count_nonzero(np.abs(deltas) > np.abs(cutoff_s)) - 1
         if n_elems_older_than_cutoff > 0:
@@ -91,7 +87,7 @@ class LiveViewerModel:
     Model class for the live viewer. Contains all data needed for the operation of the liveviewer.
     """
 
-    def __init__(self, root: Tk):
+    def __init__(self, root):
         """Constructor.
 
         Parameters
@@ -100,10 +96,10 @@ class LiveViewerModel:
             Tkinter root window.
         """
 
-        self.settings_file_name: str = "LiveViewerConfig.json"
+        self.settings_file_name = "LiveViewerConfig.json"
 
         # these are the general settings
-        self.general_settings: MEAS_PARAMS_TYPE = {
+        self.general_settings = {
             "time range to display": MeasParamFloat(value=20.0, unit="s"),
             "minimum y-axis span": MeasParamFloat(value=4.0),
             "show bar plots": MeasParamBool(value=True),
@@ -112,7 +108,7 @@ class LiveViewerModel:
 
         # the options when selecting a new card
         # this is dynamically filled in during start of the live viewer
-        self.lvcards_classes: Dict[str, type] = {}
+        self.lvcards_classes = {}
 
         # the cards list
         self.cards: List[Tuple[str, CardFrame]] = []
@@ -137,7 +133,7 @@ class LiveViewerModel:
         # averaging for bar plot
         self.averaging_bar_plot: int = 20
 
-    def get_next_plot_color_index(self) -> int:
+    def get_next_plot_color_index(self) -> str:
         """call this to get the next color for another trace to show"""
         occupied_color_indices = [t.color_index for t in self.traces_to_plot.values()]
         indices_in_ccycle = [k for k in LIVE_VIEWER_PLOT_COLOR_CYCLE.keys() if k not in occupied_color_indices]

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -7,8 +7,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 
 from queue import Empty
-from tkinter import Frame, TOP, BOTH
-from typing import TYPE_CHECKING, Optional, Tuple, List
+from tkinter import Tk, Frame, TOP, BOTH
+from typing import TYPE_CHECKING
 
 import matplotlib.animation as animation
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
@@ -18,47 +18,33 @@ import numpy as np
 from LabExT.View.LiveViewer.LiveViewerModel import PlotDataPoint, PlotTrace, LIVE_VIEWER_PLOT_COLOR_CYCLE
 
 if TYPE_CHECKING:
-    from tkinter import Tk
     from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
-    from matplotlib.animation import Animation
-    from matplotlib.figure import Figure
-    from matplotlib.axis import Axis
-    from matplotlib.container import BarContainer
-    from matplotlib.text import Text
-    from matplotlib.legend import Legend
 else:
-    Tk = None
     LiveViewerModel = None
-    Animation = None
-    Figure = None
-    Axis = None
-    BarContainer = None
-    Text = None
-    Legend = None
 
 
 class LiveViewerPlot(Frame):
     def __init__(self, parent: Tk, model: LiveViewerModel):
         super().__init__(parent, highlightbackground="grey", highlightthickness=1)
-        self._root: Tk = parent
+        self._root = parent
 
-        self.model: LiveViewerModel = model
+        self.model = model
 
         # some constants
-        self._figsize: Tuple[int, int] = (6, 4)
-        self._title: str = "Live Plot"
-        self._animate_interval_ms: int = 100
+        self._figsize = (6, 4)
+        self._title = "Live Plot"
+        self._animate_interval_ms = 100
 
         # plot object refs
-        self._ani: Optional[Animation] = None
-        self._toolbar: Optional[NavigationToolbar2Tk] = None
-        self._canvas: Optional[FigureCanvasTkAgg] = None
-        self._fig: Optional[Figure] = None
-        self._ax: Optional[Axis] = None
-        self._ax_bar: Optional[Axis] = None
-        self._bar_collection: BarContainer = []
-        self._bar_collection_labels: List[Text] = []
-        self._legend: Legend = None
+        self._ani = None
+        self._toolbar = None
+        self._canvas = None
+        self._fig = None
+        self._ax = None
+        self._ax_bar = None
+        self._bar_collection = []
+        self._bar_collection_labels = []
+        self._legend = None
 
         self.__setup__()
 

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -5,22 +5,10 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from typing import TYPE_CHECKING
 from tkinter import Frame, Toplevel, OptionMenu, Button, StringVar, Scrollbar, Canvas
 
 from LabExT.View.LiveViewer.LiveViewerPlot import LiveViewerPlot
 from LabExT.View.Controls.ParameterTable import ParameterTable
-
-if TYPE_CHECKING:
-    from tkinter import Tk
-    from LabExT.View.LiveViewer.LiveViewerController import LiveViewerController
-    from LabExT.View.LiveViewer.LiveViewerModel import LiveViewerModel
-    from LabExT.ExperimentManager import ExperimentManager
-else:
-    Tk = None
-    LiveViewerController = None
-    LiveViewerModel = None
-    ExperimentManager = None
 
 
 class LiveViewerView:
@@ -28,7 +16,7 @@ class LiveViewerView:
     Viewer class for the live viewer. Contains all functionality related to widgets.
     """
 
-    def __init__(self, root: Tk, controller: LiveViewerController, model: LiveViewerModel, experiment_manager: ExperimentManager):
+    def __init__(self, root, controller, model, experiment_manager):
         """Constructor.
 
         Parameters
@@ -42,10 +30,10 @@ class LiveViewerView:
         experiment_manager : ExperimentManager
             Current instance of ExperimentManager
         """
-        self.root: Tk = root
-        self.controller: LiveViewerController = controller
-        self.model: LiveViewerModel = model
-        self.experiment_manager: ExperimentManager = experiment_manager
+        self.root = root
+        self.controller = controller
+        self.model = model
+        self.experiment_manager = experiment_manager
 
         self.main_window = LiveViewerMainWindow(self.root, controller, model)
 
@@ -55,7 +43,7 @@ class LiveViewerMainWindow(Toplevel):
     The main window itself. Inherits from TopLevel and acts as a standalone window.
     """
 
-    def __init__(self, root: Tk, controller: LiveViewerController, model: LiveViewerModel):
+    def __init__(self, root, controller, model):
         """Constructor.
 
         Parameters
@@ -68,7 +56,7 @@ class LiveViewerMainWindow(Toplevel):
             The Live viewer model
         """
         Toplevel.__init__(self, root)
-        self.controller: LiveViewerController = controller
+        self.controller = controller
         ws, hs = root.winfo_screenwidth(), root.winfo_screenheight()
         # limit window size - otherwise performance suffers heavily on large-screen systems
         w = ws if ws < 2000 else 2000
@@ -101,7 +89,7 @@ class MainFrame(Frame):
     The main Frame. Contains all other smaller frames.
     """
 
-    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
+    def __init__(self, parent, controller, model):
         """Constructor.
 
         Parameters
@@ -134,7 +122,7 @@ class ControlFrame(Frame):
     see https://gist.github.com/JackTheEngineer/81df334f3dcff09fd19e4169dd560c59
     """
 
-    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
+    def __init__(self, parent, controller, model):
         """Constructor.
 
         Parameters
@@ -146,8 +134,8 @@ class ControlFrame(Frame):
         model :
             The Live viewer model
         """
-        self.model: LiveViewerModel = model
-        self.controller: LiveViewerController = controller
+        self.model = model
+        self.controller = controller
         Frame.__init__(self, parent)
 
         # add the CardManager
@@ -211,7 +199,7 @@ class CardManager(Frame):
     Card manager frame, containing buttons and menus to add more cards.
     """
 
-    def __init__(self, parent: Tk, controller: LiveViewerController, model: LiveViewerModel):
+    def __init__(self, parent, controller, model):
         """Constructor.
 
         Parameters
@@ -223,10 +211,10 @@ class CardManager(Frame):
         model :
             The Live viewer model
         """
-        self._root: Tk = parent
-        self.model: LiveViewerModel = model
-        self.parent: Tk = parent
-        self.controller: LiveViewerController = controller
+        self._root = parent
+        self.model = model
+        self.parent = parent
+        self.controller = controller
         Frame.__init__(self, parent, relief="groove", borderwidth=2)
 
         self.add_card_button = Button(self, text="Add Instrument", command=self.add_card)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 119


### PR DESCRIPTION
# Goal
Some clean-up work after the big live-viewer rewrite is in order

# Approach
* **PlotControl performance**: small improvements to the `PlotControl` class should enhance performance: 1st the canvas is only redrawn at the end of `plotdata_changed`, not for every plotted line. 2nd extra code takes care of shutting down the polled execution of foreign functions properly when the plot is destroyed. 3rd polling time for executing foreign functions is increased to 50ms, could possibly be increased to 100ms without perceivable difference.
* **Live-viewer not stopped warning**: A messagebox is now shown to the user in case a measurement run is started but the live-viewer is not stopped. This should avert quite some crashes when using the software.
* **Black formatter** The line-length configuration option for the black code formatter was set to 119 characters.

# Compatibility
No compatibility issues expected.