### PR TITLE
Use blitting in live plot to improve performance

### DIFF
--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -97,6 +97,9 @@ class LiveViewerController:
         # averaging for bar plot
         self.model.averaging_bar_plot = max(1, int(abs(parameters["averaging in bar plot"].value)))
 
+        # show FPS counter
+        self.model.show_fps_counter = parameters["show FPS counter"].value
+
     def remove_card(self, card: CardFrame):
         """Removes a card from the liveviewer. This should be called when the user presses the 'x' symbol in the
         top right of a card.

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -91,11 +91,8 @@ class LiveViewerController:
         # the minimum y span
         self.model.min_y_span = abs(parameters["minimum y-axis span"].value)
 
-        # enable or disable the bar plots on the right
-        self.model.show_bar_plots = parameters["show bar plots"].value
-
         # averaging for bar plot
-        self.model.averaging_bar_plot = max(1, int(abs(parameters["averaging in bar plot"].value)))
+        self.model.averaging_arrow_height = max(1, int(abs(parameters["averaging arrow height"].value)))
 
         # show FPS counter
         self.model.show_fps_counter = parameters["show FPS counter"].value

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -145,7 +145,7 @@ class LiveViewerController:
     def reference_set(self):
         # this sets the references of the plot traces to the last measured value
         for plot_trace in self.model.traces_to_plot.values():
-            plot_trace.reference_set(n_avg=self.model.averaging_bar_plot)
+            plot_trace.reference_set(n_avg=self.model.averaging_arrow_height)
         # store reference data to file for later recall
         reference_data = {plot_trace.line_label: plot_trace.reference_value for plot_trace in self.model.traces_to_plot.values()}
         fname = get_configuration_file_path(self.model.references_file_name)

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -143,6 +143,10 @@ class LiveViewerController:
             self.model.plotting_active = True
 
     def create_snapshot(self):
+
+        if not self.model.traces_to_plot:
+            return
+
         param_output_path = str(self.experiment_manager.exp.save_parameters["Raw output path"].value)
         makedirs(param_output_path, exist_ok=True)
 

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -145,7 +145,7 @@ class LiveViewerController:
     def reference_set(self):
         # this sets the references of the plot traces to the last measured value
         for plot_trace in self.model.traces_to_plot.values():
-            plot_trace.reference_set()
+            plot_trace.reference_set(n_avg=self.model.averaging_bar_plot)
         # store reference data to file for later recall
         reference_data = {plot_trace.line_handle.get_label(): plot_trace.reference_value for plot_trace in self.model.traces_to_plot.values()}
         fname = get_configuration_file_path(self.model.references_file_name)

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -193,13 +193,17 @@ class LiveViewerController:
         param_output_path = str(self.experiment_manager.exp.save_parameters["Raw output path"].value)
         makedirs(param_output_path, exist_ok=True)
 
-        inst_data = {}
-
+        cards_props = {}
+        inst_props = {}
         for _, card in self.model.cards:
-            try:
-                inst_data[card.instance_title] = card.instrument.get_instrument_parameter()
-            except AttributeError as e:
-                pass
+            param_data = {}
+            card.ptable.serialize_to_dict(param_data)
+            cards_props[card.instance_title] = param_data['data']
+
+            instr_data = {}
+            for irolename, irole in card.available_instruments.items():
+                instr_data[irolename] = irole.choice
+            inst_props[card.instance_title] = instr_data
 
         now = datetime.datetime.now()
         ts = str("{date:%Y-%m-%d_%H%M%S}".format(date=now))
@@ -237,8 +241,8 @@ class LiveViewerController:
 
         data["measurement name"] = "Liveviewer Snapshot"
         data["measurement name and id"] = "Liveviewer Snapshot"
-        data["instruments"] = inst_data
-        data["measurement settings"] = {}
+        data["instruments"] = inst_props
+        data["measurement settings"] = cards_props
         data["values"] = OrderedDict()
         data["error"] = {}
 

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -257,6 +257,9 @@ class LiveViewerController:
 
         data.save()
 
+        self.experiment_manager.exp.load_measurement_dataset(meas_dict=data, file_path=save_file_path, force_gui_update=True)
+        self.experiment_manager.logger.info(f"Saved visible live viewer traces to file at {save_file_path:s}.")
+
     @staticmethod
     def load_all_cards(experiment_manager: ExperimentManager) -> Tuple[Dict[str, type], Dict[str, int]]:
         """

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -135,11 +135,11 @@ class LiveViewerController:
     def toggle_plotting_active(self):
         if self.model.plotting_active:
             self.view.main_window.main_frame.plot_wrapper.stop_animation()
-            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="▶️ Continue Plotting")
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Continue Plotting")
             self.model.plotting_active = False
         else:
             self.view.main_window.main_frame.plot_wrapper.start_animation()
-            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="⏸️ Pause Plotting")
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Pause Plotting")
             self.model.plotting_active = True
 
     def reference_set(self):

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -142,6 +142,14 @@ class LiveViewerController:
             self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Pause Plotting")
             self.model.plotting_active = True
 
+    def reference_set(self):
+        for plot_trace in self.model.traces_to_plot.values():
+            plot_trace.reference_set()
+    
+    def reference_clear(self):
+        for plot_trace in self.model.traces_to_plot.values():
+            plot_trace.reference_clear()
+
     def create_snapshot(self):
 
         if not self.model.traces_to_plot:

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -147,7 +147,7 @@ class LiveViewerController:
         for plot_trace in self.model.traces_to_plot.values():
             plot_trace.reference_set(n_avg=self.model.averaging_bar_plot)
         # store reference data to file for later recall
-        reference_data = {plot_trace.line_handle.get_label(): plot_trace.reference_value for plot_trace in self.model.traces_to_plot.values()}
+        reference_data = {plot_trace.line_label: plot_trace.reference_value for plot_trace in self.model.traces_to_plot.values()}
         fname = get_configuration_file_path(self.model.references_file_name)
         # make sure to keep existing data in the file
         try:
@@ -173,7 +173,7 @@ class LiveViewerController:
                 reference_data = json.loads(json_file.read())
             for trace_label, reference_value in reference_data.items():
                 for plot_trace in self.model.traces_to_plot.values():
-                    if trace_label == plot_trace.line_handle.get_label():
+                    if trace_label == plot_trace.line_label:
                         plot_trace.reference_set(reference_value)
                         break
         except FileNotFoundError:

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -135,11 +135,11 @@ class LiveViewerController:
     def toggle_plotting_active(self):
         if self.model.plotting_active:
             self.view.main_window.main_frame.plot_wrapper.stop_animation()
-            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Continue Plotting")
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="▶️ Continue Plotting")
             self.model.plotting_active = False
         else:
             self.view.main_window.main_frame.plot_wrapper.start_animation()
-            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="Pause Plotting")
+            self.view.main_window.main_frame.control_wrapper.pause_button.config(text="⏸️ Pause Plotting")
             self.model.plotting_active = True
 
     def reference_set(self):

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -134,6 +134,7 @@ class LiveViewerModel:
             "minimum y-axis span": MeasParamFloat(value=4.0),
             "show bar plots": MeasParamBool(value=True),
             "averaging in bar plot": MeasParamInt(value=20, unit="samples"),
+            "show FPS counter": MeasParamBool(value=False),
         }
 
         # the options when selecting a new card
@@ -162,6 +163,9 @@ class LiveViewerModel:
 
         # averaging for bar plot
         self.averaging_bar_plot: int = 20
+
+        # show FPS counter
+        self.show_fps_counter: bool = False
 
     def get_next_plot_color_index(self) -> int:
         """call this to get the next color for another trace to show"""

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -62,6 +62,7 @@ class PlotTrace:
     y_values: List[float] = field(default_factory=list)
     line_handle: Line2D = None
     annotation_handle: Annotation = None
+    legend_handle: Annotation = None
     line_label: str = None
     reference_value: float = None
     color_index: int = None
@@ -92,19 +93,17 @@ class PlotTrace:
             self.line_handle.set_data(x, y)
 
     def update_annotation(self, n_avg: Optional[int] = 1):
-        finite_vals = np.array(self.y_values)[np.isfinite(self.y_values)]
+        finite_vals = self.finite_y_values
         if len(finite_vals) > 0:
             self.annotation_handle.xy = (0, np.mean(finite_vals[-n_avg:]))
-        label = self.line_handle.get_label()
-        label += f'\n{self.y_values[-1]:.3f}'
-        self.annotation_handle.set_text(label)
+        self.annotation_handle.set_text(f'{finite_vals[-1]:.3f}')
 
     def update_line_label(self):
         if self.reference_value is not None:
-            new_label = self.line_label + f"\nref. to {self.reference_value:.3f}"
+            new_label = self.line_label + f" - ref. to {self.reference_value:.3f}"
         else:
             new_label = self.line_label
-        self.line_handle.set_label(new_label)
+        self.legend_handle.set_text(new_label)
 
     def reference_set(self, reference_value: Optional[float] = None, n_avg: Optional[int] = 1):
         if reference_value is not None:

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -95,17 +95,16 @@ class PlotTrace:
         finite_vals = np.array(self.y_values)[np.isfinite(self.y_values)]
         if len(finite_vals) > 0:
             self.annotation_handle.xy = (0, np.mean(finite_vals[-n_avg:]))
-            self.annotation_handle.set_text(f'{self.y_values[-1]:.3f}')
+        label = self.line_handle.get_label()
+        label += f'\n{self.y_values[-1]:.3f}'
+        self.annotation_handle.set_text(label)
 
     def update_line_label(self):
-        """ returns True if label changed and legend needs to be redrawn, otherwise false """
-        old_label = self.line_handle.get_label()
         if self.reference_value is not None:
-            new_label = self.line_label + f" - ref. to {self.reference_value:.3f}"
+            new_label = self.line_label + f"\nref. to {self.reference_value:.3f}"
         else:
             new_label = self.line_label
         self.line_handle.set_label(new_label)
-        return old_label != new_label
 
     def reference_set(self, reference_value: Optional[float] = None, n_avg: Optional[int] = 1):
         if reference_value is not None:

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -94,7 +94,7 @@ class PlotTrace:
             if len(finite_vals) > 0:
                 self.reference_value = finite_vals[-1]
             else:
-                raise ValueError("No valid data in trace to set reference from")
+                raise ValueError("No valid data in trace to set reference from.")
     
     def reference_clear(self):
         self.reference_value = None
@@ -146,7 +146,7 @@ class LiveViewerModel:
         # the minimum y span
         self.min_y_span: float = 4.0
 
-        # if bar pot should be shown
+        # if bar plot should be shown
         self.show_bar_plots: bool = True
 
         # averaging for bar plot

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -8,7 +8,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from collections import OrderedDict
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, TYPE_CHECKING
+from typing import Dict, List, Tuple, TYPE_CHECKING, Optional
 
 import matplotlib.lines
 import numpy as np
@@ -53,11 +53,12 @@ class PlotDataPoint:
 
 @dataclass
 class PlotTrace:
-    """stores data and ax/line references for a trace to plot"""
+    """stores data and ax/line pointers for a trace to plot"""
 
     timestamps: List[float] = field(default_factory=list)
     y_values: List[float] = field(default_factory=list)
     line_handle: matplotlib.lines.Line2D = None
+    reference_value: float = None
     color_index: int = None
     bar_index: int = None
 
@@ -67,7 +68,7 @@ class PlotTrace:
 
     @property
     def finite_y_values(self) -> np.ndarray:
-        return np.array(self.y_values)[np.isfinite(self.y_values)]
+        return np.array(self.y_values)[np.isfinite(self.y_values)] - (self.reference_value or 0.0)
 
     def delete_older_than(self, cutoff_s: float):
         deltas = self.delta_time_to_now
@@ -82,8 +83,21 @@ class PlotTrace:
 
     def update_line_data(self):
         x = np.hstack((self.delta_time_to_now, 1))
-        y = np.hstack((self.y_values, self.y_values[-1]))
+        y = np.hstack((self.y_values, self.y_values[-1])) - (self.reference_value or 0.0)
         self.line_handle.set_data(x, y)
+
+    def reference_set(self, reference_value: Optional[float] = None):
+        if reference_value is not None:
+            self.reference_value = reference_value
+        else:
+            finite_vals = np.array(self.y_values)[np.isfinite(self.y_values)]
+            if len(finite_vals) > 0:
+                self.reference_value = finite_vals[-1]
+            else:
+                raise ValueError("No valid data in trace to set reference from")
+    
+    def reference_clear(self):
+        self.reference_value = None
 
 
 class LiveViewerModel:

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -115,6 +115,7 @@ class LiveViewerModel:
         """
 
         self.settings_file_name: str = "LiveViewerConfig.json"
+        self.references_file_name: str = "LiveViewerReferences.json"
 
         # these are the general settings
         self.general_settings: MEAS_PARAMS_TYPE = {

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -97,13 +97,13 @@ class PlotTrace:
         self.line_handle.set_label(new_label)
         return old_label != new_label
 
-    def reference_set(self, reference_value: Optional[float] = None):
+    def reference_set(self, reference_value: Optional[float] = None, n_avg: Optional[int] = 1):
         if reference_value is not None:
             self.reference_value = reference_value
         else:
             finite_vals = np.array(self.y_values)[np.isfinite(self.y_values)]
             if len(finite_vals) > 0:
-                self.reference_value = finite_vals[-1]
+                self.reference_value = np.mean(finite_vals[-n_avg:])
             else:
                 raise ValueError("No valid data in trace to set reference from.")
     

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -58,6 +58,7 @@ class PlotTrace:
     timestamps: List[float] = field(default_factory=list)
     y_values: List[float] = field(default_factory=list)
     line_handle: matplotlib.lines.Line2D = None
+    line_label: str = None
     reference_value: float = None
     color_index: int = None
     bar_index: int = None
@@ -85,6 +86,16 @@ class PlotTrace:
         x = np.hstack((self.delta_time_to_now, 1))
         y = np.hstack((self.y_values, self.y_values[-1])) - (self.reference_value or 0.0)
         self.line_handle.set_data(x, y)
+
+    def update_line_label(self):
+        """ returns True if label changed and legend needs to be redrawn, otherwise false """
+        old_label = self.line_handle.get_label()
+        if self.reference_value is not None:
+            new_label = self.line_label + f" - ref. to {self.reference_value:.3f}"
+        else:
+            new_label = self.line_label
+        self.line_handle.set_label(new_label)
+        return old_label != new_label
 
     def reference_set(self, reference_value: Optional[float] = None):
         if reference_value is not None:

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -45,10 +45,8 @@ class LiveViewerPlot(Frame):
         self._figsize: Tuple[int, int] = (6, 4)
         self._title: str = "Live Plot"
         self._animate_interval_ms: int = 33
-        # self._full_redraw_every_N_ticks: int = 15
 
         # internal bookkeeping
-        # self._update_counter = 0
         self._saved_xlim = 0.0
         self._saved_ylim = (np.inf, -np.inf)
 

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -304,8 +304,9 @@ class LiveViewerPlot(Frame):
             # changed_artists.extend(self._ax_bar.get_xticklabels())
         
         # update FPS counter
-        self._fps_counter.set_text(f"FPS: {1/(time.time()-(self._last_draw_time or float('inf'))):.2f}Hz")
-        changed_artists.append(self._fps_counter)
+        if self.model.show_fps_counter:
+            self._fps_counter.set_text(f"FPS: {1/(time.time()-(self._last_draw_time or float('inf'))):.2f}Hz")
+            changed_artists.append(self._fps_counter)
         self._last_draw_time = time.time()
 
         return changed_artists

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -213,49 +213,50 @@ class LiveViewerPlot(Frame):
                     self._legend = None
 
         # update bar data
-        if redraw_bars and (self._ax_bar is not None):
-            for b in self._bar_collection:
-                b.remove()
-            for l in self._bar_collection_labels:
-                l.remove()
-            self._bar_collection_labels.clear()
+        if self._ax_bar is not None:
+            if redraw_bars:
+                for b in self._bar_collection:
+                    b.remove()
+                for l in self._bar_collection_labels:
+                    l.remove()
+                self._bar_collection_labels.clear()
 
-            x = []
-            height = []
-            colors = []
-            labels = []
-            for tidx, (_, plot_trace) in enumerate(self.model.traces_to_plot.items()):
-                plot_trace.bar_index = tidx
-                y_values = plot_trace.finite_y_values
-                if len(y_values) > 0:
-                    y_val = y_values[-1]
-                else:
-                    y_val = float("nan")
-                height.append(y_val - y_min)
-                x.append(tidx)
-                colors.append(plot_trace.line_handle.get_color())
-                labels.append(plot_trace.line_handle.get_label())
-                self._bar_collection_labels.append(
-                    self._ax_bar.text(x=tidx, y=y_min, s=f"{y_val:.3f}\n", va="bottom", ha="center")
-                )
-
-            self._bar_collection = self._ax_bar.bar(x, height, bottom=y_min, color=colors)
-
-            self._ax_bar.set_xlim([-0.6, len(x) - 0.4])
-            self._ax_bar.set_xticks([i for i in range(len(x))])
-            self._ax_bar.set_xticklabels(labels, rotation=90, va="bottom")
-            self._ax_bar.tick_params(axis="x", length=0.0, pad=-35.0, direction="in")
-
-        else:
-            for _, plot_trace in self.model.traces_to_plot.items():
-                y_values = plot_trace.finite_y_values
-                if len(y_values) > 0:
-                    self._bar_collection[plot_trace.bar_index].set_height(
-                        np.mean(y_values[-self.model.averaging_bar_plot :]) - y_min
+                x = []
+                height = []
+                colors = []
+                labels = []
+                for tidx, (_, plot_trace) in enumerate(self.model.traces_to_plot.items()):
+                    plot_trace.bar_index = tidx
+                    y_values = plot_trace.finite_y_values
+                    if len(y_values) > 0:
+                        y_val = y_values[-1]
+                    else:
+                        y_val = float("nan")
+                    height.append(y_val - y_min)
+                    x.append(tidx)
+                    colors.append(plot_trace.line_handle.get_color())
+                    labels.append(plot_trace.line_handle.get_label())
+                    self._bar_collection_labels.append(
+                        self._ax_bar.text(x=tidx, y=y_min, s=f"{y_val:.3f}\n", va="bottom", ha="center")
                     )
-                    self._bar_collection_labels[plot_trace.bar_index].set_text(f"{y_values[-1]:.3f}\n")
-                else:
-                    self._bar_collection[plot_trace.bar_index].set_height(0)
-                    self._bar_collection_labels[plot_trace.bar_index].set_text("N/A\n")
-                self._bar_collection[plot_trace.bar_index].set_y(y_min)
-                self._bar_collection_labels[plot_trace.bar_index].set_y(y_min)
+
+                self._bar_collection = self._ax_bar.bar(x, height, bottom=y_min, color=colors)
+
+                self._ax_bar.set_xlim([-0.6, len(x) - 0.4])
+                self._ax_bar.set_xticks([i for i in range(len(x))])
+                self._ax_bar.set_xticklabels(labels, rotation=90, va="bottom")
+                self._ax_bar.tick_params(axis="x", length=0.0, pad=-35.0, direction="in")
+
+            else:
+                for _, plot_trace in self.model.traces_to_plot.items():
+                    y_values = plot_trace.finite_y_values
+                    if len(y_values) > 0:
+                        self._bar_collection[plot_trace.bar_index].set_height(
+                            np.mean(y_values[-self.model.averaging_bar_plot :]) - y_min
+                        )
+                        self._bar_collection_labels[plot_trace.bar_index].set_text(f"{y_values[-1]:.3f}\n")
+                    else:
+                        self._bar_collection[plot_trace.bar_index].set_height(0)
+                        self._bar_collection_labels[plot_trace.bar_index].set_text("N/A\n")
+                    self._bar_collection[plot_trace.bar_index].set_y(y_min)
+                    self._bar_collection_labels[plot_trace.bar_index].set_y(y_min)

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -158,6 +158,7 @@ class LiveViewerPlot(Frame):
                             timestamps=[plot_data_point.timestamp],
                             y_values=[plot_data_point.y_value],
                             line_handle=line,
+                            line_label=line_label,
                             color_index=color_index,
                             bar_index=-1,
                         )
@@ -172,9 +173,11 @@ class LiveViewerPlot(Frame):
                 continue
 
         # update the line data for all traces
+        redraw_legend = False
         for plot_trace in self.model.traces_to_plot.values():
             plot_trace.delete_older_than(self.model.plot_cutoff_seconds)
             plot_trace.update_line_data()
+            redraw_legend = redraw_legend or plot_trace.update_line_label()
 
         # do y-axis re-scaling of plot
         # get current max/min of all traces
@@ -204,7 +207,7 @@ class LiveViewerPlot(Frame):
 
         # handle legend: show legend only if there are traces to plot
         # only do changes to the legend if there are any changes to the shown traces
-        if redraw_bars:
+        if redraw_bars or redraw_legend:
             if self.model.traces_to_plot:
                 self._legend = self._ax.legend(loc="upper left", frameon=False)
             else:

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -60,6 +60,7 @@ class LiveViewerPlot(Frame):
         self._canvas: FigureCanvasTkAgg = None
         self._fig: Figure = None
         self._ax: Axis = None
+        self._ax_bar: Axis = None
         self._legend: Legend = None
 
         self._fps_counter: Text = None
@@ -78,13 +79,29 @@ class LiveViewerPlot(Frame):
         if self._toolbar is not None:
             self._toolbar.pack_forget()
 
-        self._fig, self._ax = subplots(nrows=1, ncols=1, figsize=self._figsize)
+        self._fig, (self._ax, self._ax_bar) = subplots(
+                nrows=1,
+                ncols=2,
+                sharey="all",
+                gridspec_kw={
+                    "width_ratios": (6, 1),
+                    "left": 0.12,
+                    "bottom": 0.088,
+                    "right": 0.93,
+                    "top": 0.93,
+                    "wspace": 0.0,
+                    "hspace": 0.0,
+                },
+                figsize=self._figsize,
+            )
 
         self._fig.suptitle(self._title)
 
         self._ax.grid(color="gray", linestyle="-", linewidth=0.5)
         self._ax.set_xlabel("elapsed time [s]")
         self._ax.set_ylabel("Power [dBm]")
+
+        self._ax_bar.axis('off')
 
         self._canvas = FigureCanvasTkAgg(self._fig, self)
         self._toolbar = NavigationToolbar2Tk(self._canvas, self)
@@ -135,7 +152,9 @@ class LiveViewerPlot(Frame):
                         (line,) = self._ax.plot(
                             [], [], color=LIVE_VIEWER_PLOT_COLOR_CYCLE[color_index], label=line_label, animated=True
                         )
-                        annotation = self._ax.annotate(text="bla", xy=(0, 0), xytext=(-10,0), xycoords='data', textcoords='offset points', annotation_clip=False, ha="right", va="center", arrowprops=dict(arrowstyle="->", connectionstyle="arc3"), animated=True)
+                        annotation = self._ax_bar.annotate(
+                            text="n/a", xy=(0, 0), xytext=(10,0), xycoords='data', textcoords='offset points', annotation_clip=False, ha="left", va="center", arrowprops=dict(arrowstyle="->", connectionstyle="arc3", color=LIVE_VIEWER_PLOT_COLOR_CYCLE[color_index]), animated=True
+                        )
                         self.model.traces_to_plot[trace_key] = PlotTrace(
                             timestamps=[plot_data_point.timestamp],
                             y_values=[plot_data_point.y_value],

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -232,8 +232,6 @@ class LiveViewerPlot(Frame):
             y_min -= incr_by / 2
             y_max += incr_by / 2
         self._ax.set_ylim([y_min, y_max])
-        # self._ax.yaxis.set_animated(True)
-        # changed_artists.append(self._ax.yaxis)
 
         # do x-axis re-scaling of plot
         self._ax.set_xlim([-self.model.plot_cutoff_seconds, 0.0])

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -152,11 +152,15 @@ class LiveViewerPlot(Frame):
                         annotation = self._ax_bar.annotate(
                             text="n/a", xy=(0, 0), xytext=(10,0), xycoords='data', textcoords='offset points', annotation_clip=False, ha="left", va="center", arrowprops=dict(arrowstyle="->", connectionstyle="arc3", color=LIVE_VIEWER_PLOT_COLOR_CYCLE[color_index]), animated=True
                         )
+                        legend = self._ax.annotate(
+                            text="n/a", xy=(15, 15+15*color_index), xytext=(40,0), xycoords='axes points', textcoords='offset points', annotation_clip=False, ha="left", va="center", arrowprops=dict(arrowstyle="-", connectionstyle="arc3", color=LIVE_VIEWER_PLOT_COLOR_CYCLE[color_index]), animated=True
+                        )
                         self.model.traces_to_plot[trace_key] = PlotTrace(
                             timestamps=[plot_data_point.timestamp],
                             y_values=[plot_data_point.y_value],
                             line_handle=line,
                             annotation_handle=annotation,
+                            legend_handle=legend,
                             line_label=line_label,
                             color_index=color_index
                         )
@@ -175,6 +179,7 @@ class LiveViewerPlot(Frame):
         for plot_trace in self.model.traces_to_plot.values():
             plot_trace.delete_older_than(self.model.plot_cutoff_seconds)
             plot_trace.update_line_label()
+            changed_artists.append(plot_trace.legend_handle)
             plot_trace.update_line_data()
             changed_artists.append(plot_trace.line_handle)
             plot_trace.update_annotation(n_avg=self.model.averaging_arrow_height)

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from matplotlib.axis import Axis
     from matplotlib.text import Text
-    from matplotlib.legend import Legend
 else:
     Tk = None
     LiveViewerModel = None
@@ -33,7 +32,6 @@ else:
     Figure = None
     Axis = None
     Text = None
-    Legend = None
 
 
 class LiveViewerPlot(Frame):

--- a/LabExT/View/LiveViewer/LiveViewerPlot.py
+++ b/LabExT/View/LiveViewer/LiveViewerPlot.py
@@ -49,7 +49,7 @@ class LiveViewerPlot(Frame):
         self._figsize: Tuple[int, int] = (6, 4)
         self._title: str = "Live Plot"
         self._animate_interval_ms: int = 33
-        self._full_redraw_every_N_ticks: int = 10
+        self._full_redraw_every_N_ticks: int = 15
         self._update_counter = 0
 
         # plot object refs
@@ -210,9 +210,6 @@ class LiveViewerPlot(Frame):
                 plot_trace.delete_older_than(self.model.plot_cutoff_seconds)
                 redraw_legend = redraw_legend or plot_trace.update_line_label()
 
-        # update FPS counter
-        self._fps_counter.set_text(f"FPS: {1/(self._last_draw_time or float('nan')):.2f}Hz")
-
         # do y-axis re-scaling of plot
         # get current max/min of all traces
         y_min = []
@@ -307,7 +304,7 @@ class LiveViewerPlot(Frame):
             # changed_artists.extend(self._ax_bar.get_xticklabels())
         
         # update FPS counter
-        self._fps_counter.set_text(f"FPS: {1/(time.time()-(self._last_draw_time or float('nan'))):.2f}Hz")
+        self._fps_counter.set_text(f"FPS: {1/(time.time()-(self._last_draw_time or float('inf'))):.2f}Hz")
         changed_artists.append(self._fps_counter)
         self._last_draw_time = time.time()
 

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -165,7 +165,7 @@ class ControlFrame(Frame):
         self.ref_clear_button = Button(self, text="Clear Reference", command=self.controller.reference_clear)
         self.ref_clear_button.grid(row=3, column=1, sticky="NESW", pady=(12, 1))
 
-        self.ref_recall_button = Button(self, text="Recall Reference")
+        self.ref_recall_button = Button(self, text="Recall Reference", command=self.controller.reference_recall)
         self.ref_recall_button.grid(row=3, column=2, sticky="NESW", pady=(12, 1))
 
         self.pause_button = Button(self, text="Pause Plotting", command=self.controller.toggle_plotting_active)

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -7,6 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from typing import TYPE_CHECKING
 from tkinter import Frame, Toplevel, OptionMenu, Button, StringVar, Scrollbar, Canvas
+from tkinter.messagebox import askyesno
 
 from LabExT.View.LiveViewer.LiveViewerPlot import LiveViewerPlot
 from LabExT.View.Controls.ParameterTable import ParameterTable
@@ -159,7 +160,7 @@ class ControlFrame(Frame):
         self.cardM = CardManager(self, controller, model)
         self.cardM.grid(row=0, column=0, columnspan=3, sticky="NESW", pady=(12, 20))
 
-        self.ref_set_button = Button(self, text="Set Reference", command=self.controller.reference_set)
+        self.ref_set_button = Button(self, text="Set Reference", command=self.confirm_set_new_references)
         self.ref_set_button.grid(row=3, column=0, sticky="NESW", pady=(12, 1))
 
         self.ref_clear_button = Button(self, text="Clear Reference", command=self.controller.reference_clear)
@@ -200,6 +201,12 @@ class ControlFrame(Frame):
         self.canvas.create_window(0, 0, window=self.content_carrier, anchor="nw")
 
         self.set_cards()
+
+    def confirm_set_new_references(self):
+        if askyesno(title='Set References of all Live Viewer Traces',
+                    message='This references all plotted traces to the last measured value. ' + \
+                    'This overrides previously set references. Proceed?'):
+            self.controller.reference_set()
 
     def set_cards(self):
         """

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -170,10 +170,10 @@ class ControlFrame(Frame):
         self.ref_recall_button = Button(self, text="Recall Reference", command=self.controller.reference_recall)
         self.ref_recall_button.grid(row=3, column=2, sticky="NESW", pady=1)
 
-        self.pause_button = Button(self, text="⏸️ Pause Plotting", command=self.controller.toggle_plotting_active)
+        self.pause_button = Button(self, text="Pause Plotting", command=self.controller.toggle_plotting_active)
         self.pause_button.grid(row=4, column=0, columnspan=3, sticky="NESW", pady=1)
 
-        self.save_button = Button(self, text="💾 Save current Data", command=self.controller.create_snapshot)
+        self.save_button = Button(self, text="Save current Data", command=self.controller.create_snapshot)
         self.save_button.grid(row=5, column=0, columnspan=3, sticky="NESW", pady=1)
 
         self.card_full_container = Frame(self)

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -154,26 +154,27 @@ class ControlFrame(Frame):
         """
         self.model: LiveViewerModel = model
         self.controller: LiveViewerController = controller
+        self.parent: MainFrame = parent
         Frame.__init__(self, parent)
 
         # add the CardManager
         self.cardM = CardManager(self, controller, model)
-        self.cardM.grid(row=0, column=0, columnspan=3, sticky="NESW", pady=(12, 20))
+        self.cardM.grid(row=0, column=0, columnspan=3, sticky="NESW", pady=12)
 
         self.ref_set_button = Button(self, text="Set Reference", command=self.confirm_set_new_references)
-        self.ref_set_button.grid(row=3, column=0, sticky="NESW", pady=(12, 1))
+        self.ref_set_button.grid(row=3, column=0, sticky="NESW", pady=1)
 
         self.ref_clear_button = Button(self, text="Clear Reference", command=self.controller.reference_clear)
-        self.ref_clear_button.grid(row=3, column=1, sticky="NESW", pady=(12, 1))
+        self.ref_clear_button.grid(row=3, column=1, sticky="NESW", pady=1)
 
         self.ref_recall_button = Button(self, text="Recall Reference", command=self.controller.reference_recall)
-        self.ref_recall_button.grid(row=3, column=2, sticky="NESW", pady=(12, 1))
+        self.ref_recall_button.grid(row=3, column=2, sticky="NESW", pady=1)
 
-        self.pause_button = Button(self, text="Pause Plotting", command=self.controller.toggle_plotting_active)
-        self.pause_button.grid(row=4, column=0, columnspan=3, sticky="NESW", pady=(1, 1))
+        self.pause_button = Button(self, text="⏸️ Pause Plotting", command=self.controller.toggle_plotting_active)
+        self.pause_button.grid(row=4, column=0, columnspan=3, sticky="NESW", pady=1)
 
-        self.save_button = Button(self, text="Save current Data", command=self.controller.create_snapshot)
-        self.save_button.grid(row=5, column=0, columnspan=3, sticky="NESW", pady=(1, 20))
+        self.save_button = Button(self, text="💾 Save current Data", command=self.controller.create_snapshot)
+        self.save_button.grid(row=5, column=0, columnspan=3, sticky="NESW", pady=1)
 
         self.card_full_container = Frame(self)
         self.card_full_container.grid(row=1, column=0, columnspan=3, sticky="NESW")
@@ -205,7 +206,8 @@ class ControlFrame(Frame):
     def confirm_set_new_references(self):
         if askyesno(title='Set References of all Live Viewer Traces',
                     message='This references all plotted traces to the last measured value. ' + \
-                    'This overrides previously set references. Proceed?'):
+                    'This overrides previously set references. Proceed?',
+                    parent=self.parent):
             self.controller.reference_set()
 
     def set_cards(self):

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -157,17 +157,28 @@ class ControlFrame(Frame):
 
         # add the CardManager
         self.cardM = CardManager(self, controller, model)
-        self.cardM.grid(row=0, column=0, sticky="NEW", pady=(12, 20))
+        self.cardM.grid(row=0, column=0, columnspan=3, sticky="NESW", pady=(12, 20))
+
+        self.ref_set_button = Button(self, text="Set Reference", command=self.controller.reference_set)
+        self.ref_set_button.grid(row=3, column=0, sticky="NESW", pady=(12, 1))
+
+        self.ref_clear_button = Button(self, text="Clear Reference", command=self.controller.reference_clear)
+        self.ref_clear_button.grid(row=3, column=1, sticky="NESW", pady=(12, 1))
+
+        self.ref_recall_button = Button(self, text="Recall Reference")
+        self.ref_recall_button.grid(row=3, column=2, sticky="NESW", pady=(12, 1))
 
         self.pause_button = Button(self, text="Pause Plotting", command=self.controller.toggle_plotting_active)
-        self.pause_button.grid(row=2, column=0, sticky="SEW", pady=(12, 1))
+        self.pause_button.grid(row=4, column=0, columnspan=3, sticky="NESW", pady=(1, 1))
 
         self.save_button = Button(self, text="Save current Data", command=self.controller.create_snapshot)
-        self.save_button.grid(row=3, column=0, sticky="SEW", pady=(1, 20))
+        self.save_button.grid(row=5, column=0, columnspan=3, sticky="NESW", pady=(1, 20))
 
         self.card_full_container = Frame(self)
-        self.card_full_container.grid(row=1, column=0, sticky="NESW")
+        self.card_full_container.grid(row=1, column=0, columnspan=3, sticky="NESW")
         self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
         self.rowconfigure(1, weight=1)
 
         vscrollbar = Scrollbar(self.card_full_container, orient="vertical")

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -77,8 +77,8 @@ class LiveViewerMainWindow(Toplevel):
         self.controller: LiveViewerController = controller
         ws, hs = root.winfo_screenwidth(), root.winfo_screenheight()
         # limit window size - otherwise performance suffers heavily on large-screen systems
-        w = ws if ws < 2000 else 2000
-        h = hs if hs < 1200 else 1200
+        w = min(ws, 1600)
+        h = min(hs, 1000)
         self.geometry(f"{w:d}x{h:d}+{int((ws-w)/2)}+{int((hs-h)/2)}")
         self.lift()
         # self.attributes('-topmost', 'true')
@@ -275,7 +275,7 @@ class CardManager(Frame):
         self.ptable.grid(row=0, column=1, sticky="NESW", padx=(12, 0))
 
         _update_settings_button = Button(
-            self, text="Update Settings", command=lambda: self.controller.update_settings(self.ptable.to_meas_param())
+            self, text="Update General Parameters", command=lambda: self.controller.update_settings(self.ptable.to_meas_param())
         )
         _update_settings_button.grid(row=1, column=1, sticky="EW", padx=(12, 0))
 

--- a/LabExT/View/LiveViewer/LiveViewerView.py
+++ b/LabExT/View/LiveViewer/LiveViewerView.py
@@ -275,7 +275,7 @@ class CardManager(Frame):
         self.ptable.grid(row=0, column=1, sticky="NESW", padx=(12, 0))
 
         _update_settings_button = Button(
-            self, text="Update General Parameters", command=lambda: self.controller.update_settings(self.ptable.to_meas_param())
+            self, text="Apply General Parameters", command=lambda: self.controller.update_settings(self.ptable.to_meas_param())
         )
         _update_settings_button.grid(row=1, column=1, sticky="EW", padx=(12, 0))
 


### PR DESCRIPTION
## Goal
Improve performance of live viewer by using selective redrawing.

## Approach
Matplotlib's animation package offers the functionality of blitting - i.e. only redrawing the changed artists. We make use of this feature which requires tracking of the changed artists each animation tick.

I get between ~15FPS on my MacBook Pro for 2 enabled very noisy power meter signals.

## Implementation
* The default `axis.legend()` call is not compatible with blitted animations. So therefore I simply create my own small "legend" by using `axis.annotate()` calls.
* For debugging performance, I included an FPS counter in the live plot (disabled by default, can be enabled with global setting).
* setting x-axis and y-axis limits is very heavy on performance - so I check if its necessary (i.e. last limits within certain bounds of new limits) and only update then.

## Compatibility
No compatibility breaks.

## Live Viewer GUI
FPS counter and new legend is marked.
![image](https://github.com/LabExT/LabExT/assets/3842684/3e484ad1-88f9-47a7-8923-014073500e90)


