### PR TITLE
json tab indentation

### DIFF
--- a/LabExT/Experiments/AutosaveDict.py
+++ b/LabExT/Experiments/AutosaveDict.py
@@ -55,4 +55,4 @@ class AutosaveDict(OrderedDict):
         Saves itself to a file.
         """
         with open(self.file_path, "w+") as f:
-            json.dump(self, f, indent=4)
+            json.dump(self, f, indent="\t")


### PR DESCRIPTION
This replaces the 4-spaces indentation in the stored json files with a "tab" saving roughly 30% of the original file size without compromising readability.