### PR TITLE
Replacing flaky with pytes-rerunfailures

### DIFF
--- a/LabExT/Tests/View/Controls/DriverPathDialog_test.py
+++ b/LabExT/Tests/View/Controls/DriverPathDialog_test.py
@@ -8,15 +8,15 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import json
 from unittest.mock import patch, mock_open
 from pathlib import Path
-from flaky import flaky
+import pytest
 
 from LabExT.Tests.Utils import TKinterTestCase
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
 
 
-@flaky(max_runs=3)
 class DriverPathDialogTest(TKinterTestCase):
 
+    @pytest.mark.flaky(reruns=3)
     def test_dialog_initial_state(self):
         settings_file_path = 'my_path_file.txt'
         current_driver_path = str(Path('/path/to/control/module.py'))
@@ -33,6 +33,7 @@ class DriverPathDialogTest(TKinterTestCase):
                     current_driver_path
                 )
 
+    @pytest.mark.flaky(reruns=3)
     def test_save_without_change(self):
         settings_file_path = 'my_path_file.txt'
         current_driver_path = str(Path('/path/to/control/module.py'))
@@ -45,6 +46,7 @@ class DriverPathDialogTest(TKinterTestCase):
                 self.assertEqual(Path(dialog.driver_path), Path(current_driver_path))
                 self.assertFalse(dialog.path_has_changed)
 
+    @pytest.mark.flaky(reruns=3)
     def test_save_with_change(self):
         settings_file_path = 'my_path_file.txt'
         current_driver_path = str(Path('/path/to/control/module.py'))

--- a/LabExT/Tests/View/Controls/Wizard_test.py
+++ b/LabExT/Tests/View/Controls/Wizard_test.py
@@ -6,14 +6,13 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from unittest.mock import Mock
+import pytest
 from LabExT.Tests.Utils import TKinterTestCase
-from flaky import flaky
 
 import tkinter
 from LabExT.View.Controls.Wizard import Step, Wizard
 
 
-@flaky(max_runs=3)
 class WizardUnitTest(TKinterTestCase):
     """
     Unittests for Wizard Widget.
@@ -32,6 +31,7 @@ class WizardUnitTest(TKinterTestCase):
         )
         self.builder = Mock()
 
+    @pytest.mark.flaky(reruns=3)
     def test_wizard_build(self):
         self.assertEqual(self.wizard._next_button['text'], "Custom Next Label")
         self.assertEqual(
@@ -44,6 +44,7 @@ class WizardUnitTest(TKinterTestCase):
             self.wizard._finish_button['text'],
             "Custom Finish Label")
 
+    @pytest.mark.flaky(reruns=3)
     def test_add_step_handle_callbacks(self):
         on_reload = Mock()
         on_next = Mock()
@@ -64,6 +65,7 @@ class WizardUnitTest(TKinterTestCase):
         step.on_reload_callback()
         on_reload.assert_called_once()
 
+    @pytest.mark.flaky(reruns=3)
     def test_add_step_handle_step_linking(self):
         step = self.wizard.add_step(builder=lambda: None)
         previous_step = self.wizard.add_step(builder=lambda: None)
@@ -93,6 +95,7 @@ class WizardUnitTest(TKinterTestCase):
         self.assertFalse(next_step.next_step_available)
         self.assertIsNone(next_step.next_step)
 
+    @pytest.mark.flaky(reruns=3)
     def test_add_step_creates_new_sidebar_label(self):
         step = self.wizard.add_step(
             builder=lambda: None,
@@ -115,7 +118,7 @@ class WizardUnitTest(TKinterTestCase):
             Step.INACTIVE_LABEL_COLOR)
 
     # Testing current step
-
+    @pytest.mark.flaky(reruns=3)
     def test_next_step_if_next_step_is_present(self):
         on_next = Mock(return_value=False)
         current_step = self.wizard.add_step(
@@ -129,6 +132,7 @@ class WizardUnitTest(TKinterTestCase):
         on_next.assert_not_called()
         self.assertEqual(self.wizard.current_step, current_step)
 
+    @pytest.mark.flaky(reruns=3)
     def test_next_step_if_next_step_callback_fails(self):
         on_next = Mock(return_value=False)
         next_builder = Mock()
@@ -146,6 +150,7 @@ class WizardUnitTest(TKinterTestCase):
         self.assertEqual(self.wizard.current_step, current_step)
         next_builder.assert_not_called()
 
+    @pytest.mark.flaky(reruns=3)
     def test_next_step_if_next_step_callback_succeeds(self):
         on_next = Mock(return_value=True)
         next_builder = Mock()
@@ -163,6 +168,7 @@ class WizardUnitTest(TKinterTestCase):
         self.assertEqual(self.wizard.current_step, next_step)
         next_builder.assert_called_once()
 
+    @pytest.mark.flaky(reruns=3)
     def test_previous_step_if_previous_step_is_present(self):
         on_previous = Mock(return_value=False)
         current_step = self.wizard.add_step(
@@ -176,6 +182,7 @@ class WizardUnitTest(TKinterTestCase):
         on_previous.assert_not_called()
         self.assertEqual(self.wizard.current_step, current_step)
 
+    @pytest.mark.flaky(reruns=3)
     def test_previous_step_if_previous_step_callback_fails(self):
         on_previous = Mock(return_value=False)
         previous_builder = Mock()
@@ -193,6 +200,7 @@ class WizardUnitTest(TKinterTestCase):
         self.assertEqual(self.wizard.current_step, current_step)
         previous_builder.assert_not_called()
 
+    @pytest.mark.flaky(reruns=3)
     def test_previous_step_if_previous_step_callback_succeeds(self):
         on_previous = Mock(return_value=True)
         previous_builder = Mock()
@@ -210,6 +218,7 @@ class WizardUnitTest(TKinterTestCase):
         self.assertEqual(self.wizard.current_step, previous_step)
         previous_builder.assert_called_once()
 
+    @pytest.mark.flaky(reruns=3)
     def test_current_step_changes_sidebar_config(self):
         current_step = self.wizard.add_step(
             builder=self.builder, title="Current Step")
@@ -228,6 +237,7 @@ class WizardUnitTest(TKinterTestCase):
             Step.ACTIVE_LABEL_COLOR)
         self.assertEqual(self.wizard.current_step, step)
 
+    @pytest.mark.flaky(reruns=3)
     def test_current_step_renders_new_frame(self):
         current_step = self.wizard.add_step(
             builder=self.builder, title="Current Step")
@@ -235,6 +245,7 @@ class WizardUnitTest(TKinterTestCase):
 
         self.builder.assert_called_once()
 
+    @pytest.mark.flaky(reruns=3)
     def test_current_step_calls_reload_callback(self):
         on_reload = Mock()
 
@@ -245,7 +256,6 @@ class WizardUnitTest(TKinterTestCase):
         on_reload.assert_called_once()
 
 
-@flaky(max_runs=3)
 class WizardIntegrationTest(TKinterTestCase):
     """
     Integration test for a Wizard with 2 steps.
@@ -307,6 +317,7 @@ class WizardIntegrationTest(TKinterTestCase):
         self.assertEqual(self.wizard._cancel_button['state'], cancel)
         self.assertEqual(self.wizard._finish_button['state'], finish)
 
+    @pytest.mark.flaky(reruns=3)
     def test_next_from_first_step(self):
         self.wizard.current_step = self.first_step
 
@@ -340,6 +351,7 @@ class WizardIntegrationTest(TKinterTestCase):
             finish=tkinter.DISABLED
         )
 
+    @pytest.mark.flaky(reruns=3)
     def test_previous_from_first_step(self):
         self.wizard.current_step = self.first_step
 
@@ -359,6 +371,7 @@ class WizardIntegrationTest(TKinterTestCase):
             finish=tkinter.DISABLED
         )
 
+    @pytest.mark.flaky(reruns=3)
     def test_next_from_second_step(self):
         self.wizard.current_step = self.second_step
 
@@ -378,6 +391,7 @@ class WizardIntegrationTest(TKinterTestCase):
             finish=tkinter.DISABLED
         )
 
+    @pytest.mark.flaky(reruns=3)
     def test_previous_from_second_step(self):
         self.wizard.current_step = self.second_step
 
@@ -411,6 +425,7 @@ class WizardIntegrationTest(TKinterTestCase):
             finish=tkinter.DISABLED
         )
 
+    @pytest.mark.flaky(reruns=3)
     def test_finish(self):
         self.wizard.current_step = self.first_step
         self.first_step.finish_step_enabled = False
@@ -432,6 +447,7 @@ class WizardIntegrationTest(TKinterTestCase):
 
         self.on_finish.assert_called_once()
 
+    @pytest.mark.flaky(reruns=3)
     def test_cancel(self):
         self.wizard.current_step = self.first_step
 

--- a/LabExT/Tests/View/CoordinatePairingsWindow_test.py
+++ b/LabExT/Tests/View/CoordinatePairingsWindow_test.py
@@ -6,7 +6,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 
 from unittest.mock import Mock
-from flaky import flaky
+import pytest
 
 from LabExT.Movement.config import DevicePort, Orientation
 
@@ -19,7 +19,6 @@ from LabExT.Wafer.Device import Device
 from LabExT.Wafer.Chip import Chip
 
 
-@flaky(max_runs=3)
 class CoordinatePairingsWindowTest(TKinterTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -55,11 +54,13 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             with_input_stage=with_input_stage,
             with_output_stage=with_output_stage)
 
+    @pytest.mark.flaky(reruns=3)
     def test_raises_error_if_no_chip_is_imported(self):
         with self.assertRaises(ValueError):
             CoordinatePairingsWindow(
                 self.root, self.mover, None, self.on_finish)
 
+    @pytest.mark.flaky(reruns=3)
     def test_raises_error_if_input_is_requested_but_not_defined(self):
         with self.assertRaises(ValueError):
             CoordinatePairingsWindow(
@@ -69,6 +70,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
                 self.on_finish,
                 with_input_stage=True)
 
+    @pytest.mark.flaky(reruns=3)
     def test_raises_error_if_output_is_requested_but_not_defined(self):
         with self.assertRaises(ValueError):
             CoordinatePairingsWindow(
@@ -78,6 +80,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
                 self.on_finish,
                 with_output_stage=True)
 
+    @pytest.mark.flaky(reruns=3)
     def test_no_callback_for_no_device_selection(self):
         self.setup_calibrations()
         window = self.setup_window()
@@ -86,6 +89,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
 
         self.on_finish.assert_not_called()
 
+    @pytest.mark.flaky(reruns=3)
     def test_device_selection(self):
         self.setup_calibrations()
         window = self.setup_window()
@@ -95,6 +99,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
 
         self.assertEqual(window._device, self.device)
 
+    @pytest.mark.flaky(reruns=3)
     def test_device_reset(self):
         self.setup_calibrations()
         window = self.setup_window()
@@ -106,6 +111,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
         window._clear_device_button.invoke()
         self.assertIsNone(window._device)
 
+    @pytest.mark.flaky(reruns=3)
     def test_pairings_for_input_stage(self):
         self.setup_calibrations()
         window = self.setup_window(
@@ -129,6 +135,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             pairings[0].stage_coordinate.to_list())
         self.assertEqual([0, 0, 0], pairings[0].chip_coordinate.to_list())
 
+    @pytest.mark.flaky(reruns=3)
     def test_pairings_for_output_stage(self):
         self.setup_calibrations()
         window = self.setup_window(
@@ -152,6 +159,7 @@ class CoordinatePairingsWindowTest(TKinterTestCase):
             pairings[0].stage_coordinate.to_list())
         self.assertEqual([1, 1, 0], pairings[0].chip_coordinate.to_list())
 
+    @pytest.mark.flaky(reruns=3)
     def test_pairings_for_input_and_output_stage(self):
         self.setup_calibrations()
         window = self.setup_window(

--- a/LabExT/Tests/View/ExperimentWizard_test.py
+++ b/LabExT/Tests/View/ExperimentWizard_test.py
@@ -9,7 +9,7 @@ import random
 from itertools import product
 from os import remove
 from os.path import join, dirname
-from flaky import flaky
+import pytest
 from unittest.mock import patch, mock_open
 
 import LabExT.Wafer.Device
@@ -46,7 +46,6 @@ def check_DummyMeas_meas_dict_meta_data(testinst, meas_record, dev_props=None, m
 
 
 @mark_as_gui_integration_test
-@flaky(max_runs=3)
 class ExperimentWizardTest(TKinterTestCase):
 
     def main_window_setup(self):
@@ -64,11 +63,13 @@ class ExperimentWizardTest(TKinterTestCase):
                 self.mwc.allow_GUI_changes = False
                 self.mwm.allow_GUI_changes = False
 
+    @pytest.mark.flaky(reruns=3)
     def test_experiment_wizard_repeated(self):
         self.test_experiment_wizard()
         self.test_experiment_wizard()
         self.test_experiment_wizard()
 
+    @pytest.mark.flaky(reruns=3)
     def test_experiment_wizard(self):
         self.main_window_setup()
 

--- a/LabExT/Tests/View/MainWindow_test.py
+++ b/LabExT/Tests/View/MainWindow_test.py
@@ -7,7 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 import json
 import random
 from os import remove
-from flaky import flaky
+import pytest
 from unittest.mock import patch
 
 from typing import TYPE_CHECKING
@@ -66,7 +66,6 @@ def check_InsertionLossSweep_meas_dict_meta_data(testinst, meas_record, dev_prop
 
 
 @mark_as_gui_integration_test
-@flaky(max_runs=3)
 class MainWindowTest(TKinterTestCase):
 
     def main_window_setup(self):
@@ -83,11 +82,13 @@ class MainWindowTest(TKinterTestCase):
                 self.mwc.allow_GUI_changes = False
                 self.mwm.allow_GUI_changes = False
 
+    @pytest.mark.flaky(reruns=3)
     def test_mainwindow_repeated_IL_sweep(self):
         self.test_mainwindow_single_IL_sweep()
         self.test_mainwindow_single_IL_sweep()
         self.test_mainwindow_single_IL_sweep()
 
+    @pytest.mark.flaky(reruns=3)
     def test_mainwindow_single_IL_sweep(self):
         with patch('LabExT.View.EditMeasurementWizard.WizardEntry.MeasurementSelect.get_visa_address',
                    simulator_only_instruments_descriptions):

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,7 +3,7 @@
 #
 pytest
 pytest-xvfb
-flaky
+pytest-rerunfailures
 parameterized
 tox
 tox-gh-actions

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ python =
 deps =
     pytest
     pytest-xvfb
-    flaky
+    pytest-rerunfailures
     parameterized
 commands = python -m LabExT.Tests.runtests  --skip_gui_integration_tests
 


### PR DESCRIPTION
Flaky is a test plugin that we used to re-run a failed test up to three times. This was necessary as our GUI integration tests sometimes did not have Tk not properly initiated.

However, [Flaky seems to be an abandoned project](https://github.com/box/flaky/issues/192).  Furthermore, all Python 3.10 tests started to fail on 4th March 2024 due to an import error within the Flaky module.

This PR replaces flaky with the pytest internal [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures). This should keep us future-proof in our testing.