### PR TITLE
hotfix: logging within live viewer crashes GUI

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@ instrument drivers, reported bugs, helped answer newbie questions, and generally
 * Andreas Messner
 * Boris Vukovic <vukovicb@ethz.ch>
 * David Moor
+* Dillon Elste
 * Dominik Werner
 * Etienne Corminboeuf
 * Guy Lüthi

--- a/LabExT/Instruments/PowerMeterSimulator.py
+++ b/LabExT/Instruments/PowerMeterSimulator.py
@@ -137,6 +137,9 @@ class PowerMeterSimulator(DummyInstrument):
     def fetch_power(self):
         if self._trigger == 'on':
             self._last_val = self._simulate_opt_power_value()
+            if self.range < -30:
+                # just for GUI test purposes here
+                self.logger.warning('OPM: Sensitivity is too low.')
             return self._last_val
         elif self._trigger == 'off':
             return self._last_val

--- a/LabExT/Logs/LoggingWidgetHandler.py
+++ b/LabExT/Logs/LoggingWidgetHandler.py
@@ -39,6 +39,10 @@ class LoggingWidgetHandler(logging.Handler):
         self.counter = 0
 
     def emit(self, record):
+        if "nogui" in record.name.lower():
+            # do not emit this record onto the GUI window if the nogui logger was used
+            return
+
         msg = self.format(record)
         msg = msg.replace("\n", "\n  ")
 

--- a/LabExT/Logs/LoggingWidgetHandler.py
+++ b/LabExT/Logs/LoggingWidgetHandler.py
@@ -56,7 +56,6 @@ class LoggingWidgetHandler(logging.Handler):
             self.text_frame.configure(state="disabled")
             # Autoscroll to the bottom
             self.text_frame.yview(tk.END)
-            self.text_frame.update()
         except tk.TclError:
             # the text_frame does not exist anymore, do not emit log
             pass

--- a/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
+++ b/LabExT/View/LiveViewer/Cards/PowerMeterCard.py
@@ -5,6 +5,7 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+import logging
 import threading
 import time
 from time import sleep
@@ -94,6 +95,7 @@ class PowerMeterCard(CardFrame):
             self.data_to_plot_queue.put(PlotDataPoint(trace_name=trace, delete_trace=True))
 
         loaded_instr = self.load_instrument_instance()
+        loaded_instr.logger = logging.getLogger('nogui')
         loaded_instr.open()
         self.instrument = loaded_instr
 

--- a/LabExT/View/LiveViewer/LiveViewerModel.py
+++ b/LabExT/View/LiveViewer/LiveViewerModel.py
@@ -96,7 +96,7 @@ class PlotTrace:
         finite_vals = self.finite_y_values
         if len(finite_vals) > 0:
             self.annotation_handle.xy = (0, np.mean(finite_vals[-n_avg:]))
-        self.annotation_handle.set_text(f'{finite_vals[-1]:.3f}')
+            self.annotation_handle.set_text(f'{finite_vals[-1]:.3f}')
 
     def update_line_label(self):
         if self.reference_value is not None:


### PR DESCRIPTION
Due to our fancy log widget in the MainWindow of LabExT, every logging action actually triggered a redraw of the Tk windows. This is not a thread safe action and caused crashes when the live-viewer thread was emitting log messages.

This PR implements a hotfix such that the optical power meter does not crash the live viewer anymore on a wrong range setting and is not intended as a long-term solution.

As a long-term fix, I'd suggest not using any logging in the instrument drivers, but simply throw errors and let code higher up in the hierarchy handle the issues. - Let's discuss soon.

(also, adding Dillon to authors list)