### PR TITLE
Save chip info in MainWindow more often than just on exit

### DIFF
--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -73,9 +73,9 @@ class MainWindowController:
         if self.experiment_manager.chip is None:
             self.model.chip_parameters["Chip path"].value = ""
         if self.view.frame.parameter_frame.chip_parameter_table.serialize(self.model.chiptable_settings_path):
-            self.logger.info("Saved chip settings to file.")
+            self.logger.debug("Saved chip settings to file.")
         if self.view.frame.parameter_frame.save_parameter_table.serialize(self.model.savetable_settings_path):
-            self.logger.info("Saved json save path settings to file.")
+            self.logger.debug("Saved json save path settings to file.")
 
     def on_window_close(self):
         """Called when user closes the application. Save experiment
@@ -261,8 +261,8 @@ class MainWindowController:
         """
         Called on user click on "Repeat last executed Measurement"
         """
+        self.serialize_parameter_frame()
         self.logger.debug("Requested repeating of last executed measurement.")
-
         last_executed_todos = self.experiment_manager.exp.last_executed_todos
 
         if not last_executed_todos:
@@ -550,22 +550,27 @@ class MainWindowController:
 
     def open_import_chip(self):
         """opens window to import new chip"""
+        self.serialize_parameter_frame()
         self.view.frame.menu_listener.client_import_chip()
 
     def open_live_viewer(self):
         """opens live-viewer window by calling appropriate menu listener function"""
+        self.serialize_parameter_frame()
         self.view.frame.menu_listener.client_live_view()
 
     def open_peak_searcher(self):
         """opens search for peak window by calling appropriate menu listener function"""
+        self.serialize_parameter_frame()
         self.view.frame.menu_listener.client_search_for_peak()
 
     def open_stage_calibration(self):
         """opens window to calibrate stages"""
+        self.serialize_parameter_frame()
         self.view.frame.menu_listener.client_calibrate_stage()
 
     def start(self):
         """Calls the experiment handler to start the experiment."""
+        self.serialize_parameter_frame()
         self.logger.debug("Start experiment")
 
         # internal callback
@@ -589,6 +594,7 @@ class MainWindowController:
         Called when the user presses "new single measurement" button.
         Opens the new measurement window.
         """
+        self.serialize_parameter_frame()
         self.experiment_manager.main_window.open_edit_measurement_wizard()
 
     def on_shutdown(self):

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -597,6 +597,13 @@ class MainWindowController:
         self.serialize_parameter_frame()
         self.experiment_manager.main_window.open_edit_measurement_wizard()
 
+    def new_swept_devices_experiment(self):
+        """
+        Called when the user presses "New device sweep experiment" button.
+        """
+        self.serialize_parameter_frame()
+        self.view.frame.menu_listener.client_new_experiment()
+
     def on_shutdown(self):
         """Gets called once the application is trying to close.
         Terminates the currently running experiment.

--- a/LabExT/View/MainWindow/MainWindowController.py
+++ b/LabExT/View/MainWindow/MainWindowController.py
@@ -67,10 +67,7 @@ class MainWindowController:
 
         self.allow_GUI_changes = True
 
-    def on_window_close(self):
-        """Called when user closes the application. Save experiment
-        settings in .json and call context-callback.
-        """
+    def serialize_parameter_frame(self):
         # remove any chip path from parameters if chip is not loaded -> prevent offering reloading-of not loaded chip
         # on next startup
         if self.experiment_manager.chip is None:
@@ -80,6 +77,11 @@ class MainWindowController:
         if self.view.frame.parameter_frame.save_parameter_table.serialize(self.model.savetable_settings_path):
             self.logger.info("Saved json save path settings to file.")
 
+    def on_window_close(self):
+        """Called when user closes the application. Save experiment
+        settings in .json and call context-callback.
+        """
+        self.serialize_parameter_frame()
         self.on_shutdown()
 
     def experiment_changed(self, ex):

--- a/LabExT/View/MainWindow/MainWindowView.py
+++ b/LabExT/View/MainWindow/MainWindowView.py
@@ -282,7 +282,7 @@ class MainWindowButtonsFrame(LabelFrame):
         self.new_exp_button = Button(
             self,
             text="New device sweep experiment",
-            command=self.main_frame.menu_listener.client_new_experiment,
+            command=self.controller.new_swept_devices_experiment,
         )
         self.new_exp_button.grid(row=1, column=0, sticky="we", padx=5)
         self.repeat_meas_button = Button(

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -78,6 +78,8 @@ class MListener:
         """Called when user wants to start new Experiment. Calls the
         ExperimentWizard.
         """
+        self._experiment_manager.main_window.serialize_parameter_frame()
+
         if try_to_lift_window(self.swept_exp_wizard_toplevel):
             return
 

--- a/LabExT/View/MenuListener.py
+++ b/LabExT/View/MenuListener.py
@@ -78,8 +78,6 @@ class MListener:
         """Called when user wants to start new Experiment. Calls the
         ExperimentWizard.
         """
-        self._experiment_manager.main_window.serialize_parameter_frame()
-
         if try_to_lift_window(self.swept_exp_wizard_toplevel):
             return
 


### PR DESCRIPTION
# Goal
Make LabExT more user friendly by saving entered chip params more often than just on graceful exit. Sometimes, LabExT crashes (gasp!), and then the chip parameters need to be re-entered, because they weren't saved because there was no graceful exit!

# Approach
Any button that is in the main window now also calls saving of the chip parameters to disk. As the chance of pressing any of the buttons is very high once the chip settings were adapted, this serves as a good proxy to "save immediately". This also works when using the keyboard shortcuts!

# Compatibility
No compatibility issues expected.