### PR TITLE
Fix bug causing LabExT to crash when trying to sort table

### DIFF
--- a/LabExT/View/AddonSettingsDialog.py
+++ b/LabExT/View/AddonSettingsDialog.py
@@ -110,7 +110,8 @@ class AddonSettingsDialog:
         CustomTable(parent=loaded_meas_frame,
                     columns=('Measurement class', 'imported from'),
                     rows=self._get_loaded_measurements_and_paths(),
-                    selectmode='none')  # custom table inserts itself into the parent frame
+                    selectmode='none',
+                    sortable=False)  # custom table inserts itself into the parent frame
 
         #
         # table with paths to all loaded instruments
@@ -124,7 +125,8 @@ class AddonSettingsDialog:
         CustomTable(parent=loaded_instr_frame,
                     columns=('Instrument class', 'imported from'),
                     rows=self._get_loaded_instruments_and_paths(),
-                    selectmode='none')  # custom table inserts itself into the parent frame
+                    selectmode='none',
+                    sortable=False)  # custom table inserts itself into the parent frame
 
         #
         # table with paths to all loaded live viewer cards
@@ -138,7 +140,8 @@ class AddonSettingsDialog:
         CustomTable(parent=loaded_lvcards_frame,
                     columns=('CardFrame class', 'instrument type', 'imported from'),
                     rows=self._get_loaded_lvcards_and_paths(),
-                    selectmode='none')  # custom table inserts itself into the parent frame
+                    selectmode='none',
+                    sortable=False)  # custom table inserts itself into the parent frame
 
         #
         # table with paths for all loaded stage classes
@@ -152,7 +155,8 @@ class AddonSettingsDialog:
         CustomTable(parent=loaded_stage_frame,
                 columns=('Stage class', 'imported from'),
                 rows=self._get_loaded_stages_and_paths(),
-                selectmode='none')  # custom table inserts itself into the parent frame
+                selectmode='none',
+                sortable=False)  # custom table inserts itself into the parent frame
         
         #
         # table with paths for all loaded stage classes
@@ -166,7 +170,8 @@ class AddonSettingsDialog:
         CustomTable(parent=loaded_chipsource_frame,
                 columns=('Chip Source class', 'imported from'),
                 rows=self._get_loaded_chip_sources_and_paths(),
-                selectmode='none')  # custom table inserts itself into the parent frame
+                selectmode='none',
+                sortable=False)  # custom table inserts itself into the parent frame
 
         #
         # bottom row buttons

--- a/LabExT/View/Controls/CustomTable.py
+++ b/LabExT/View/Controls/CustomTable.py
@@ -22,7 +22,8 @@ class CustomTable(object):
                  col_width=20,
                  add_checkboxes=False,
                  selectmode='extended',
-                 showmode='headings'):
+                 showmode='headings',
+                 sortable=True):
         """Constructor.
 
         Parameters
@@ -38,6 +39,8 @@ class CustomTable(object):
         selectmode : str, optional
             Whether the user can select items in the table
             'none' for no selection possible, 'browse' for single row selection, 'extended' for multiple rows selection
+        sortable : bool, optional
+            Sets ability to sort the table when clicking on the column headers
         """
         self._col_width = col_width
         self._root = parent
@@ -48,6 +51,7 @@ class CustomTable(object):
         self._select_mode = selectmode
         self._show_mode = showmode
         self._selection = dict()
+        self._sortable = sortable
 
         self.logger = logging.getLogger()
         self.logger.debug('Initialised CustomTable with parent: %s columns: %s' +
@@ -107,7 +111,7 @@ class CustomTable(object):
         """
         for col in self._columns:
             self._tree.heading(
-                col, text=col, command=lambda c=col: sortby(self._tree, c, 0))
+                col, text=col, command=lambda c=col: sortby(self._tree, c, 0) if self._sortable else None)
             # adjust the column's width
             self._tree.column(col, width=self._col_width)
 

--- a/LabExT/View/Controls/CustomTable.py
+++ b/LabExT/View/Controls/CustomTable.py
@@ -173,21 +173,19 @@ def sortby(tree, col, descending):
         Sort the tree in descending or ascending order.
     """
     # grab values to sort
-    raw_data = [(tree.set(child, col), child)
-                for child in tree.get_children('')]
+    raw_data = zip(*[(tree.set(child, col), child)
+                for child in tree.get_children('')])
 
-    data = []
-    # if the data to be sorted is numeric change to float
-    for i, item in enumerate(raw_data):
-        if item[0].isdigit():
-            tup = (int(item[0]), item[1])
-            data.append(tuple(tup))
-        elif item[0] == '':
-            tup = (float('+inf'), item[1])
-            data.append(tuple(tup))
-        else:
-            data.append(item)
+    # separate out the column data so we can verify it is all the same type
+    column_values = next(raw_data)
+    column_keys = next(raw_data)
 
+    # if the all the data to be sorted is numeric change to float
+    if all(map(is_float, column_values)):
+        column_values = map(lambda item: float('+inf') if item == '' else float(item), column_values)
+
+    data = zip(column_values, column_keys)
+    
     # sort the data in place
     data = sorted(data, key=lambda x: (x, itemgetter(0)), reverse=descending)
 
@@ -197,3 +195,20 @@ def sortby(tree, col, descending):
     # switch so tree will sort in opposite direction next time it is clicked
     tree.heading(
         col, command=lambda col=col: sortby(tree, col, int(not descending)))
+    
+def is_float(s):
+    """Helper function to check if a string is a float
+    Unfortunately this is the most foolproof method in python
+
+    Parameters
+    ----------
+    s : any
+    """
+    # We convert empty strings to +inf
+    if s == '': return True
+
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
In the Addon Settings menu, LabExT would crash if you clicked on the header of any of the tables.

For example,  if you were to click on the "Imported From"  header:

```
+--------------------+--------------------------------------------+
| Measurement Class  |               Imported From                |
+--------------------+--------------------------------------------+
| DummyMeas          |                                            | <- resolved to float("+inf")
| ->                 | /home/.../LabExT/.../DummyMeas.py          | <- resolved to string
| InsertionLossSweep |                                            |
| ->                 | /home/.../LabExT/.../InsertionLossSweep.py |
+--------------------+--------------------------------------------+

```
And python would try to compare a float and a string and LabExT would crash. Now, the sort function makes sure all the values it is sorting are of the same type.

This does leave a little weird behavior. The above table sorts to:
```

+--------------------+--------------------------------------------+
| Measurement Class  |               Imported From                |
+--------------------+--------------------------------------------+
| ->                 | /home/.../LabExT/.../DummyMeas.py          |
| ->                 | /home/.../LabExT/.../InsertionLossSweep.py |
| DummyMeas          |                                            |
| InsertionLossSweep |                                            |
+--------------------+--------------------------------------------+
```

I don't know if this is a problem. Another fix could be to utilize the underlying treeview and make the rows  actual children of their respective parent, but this changes the behavior of `CustomTable`.