### PR TITLE
Sweeps now also handles lists -> unconditionally cycle through all list entries.

### DIFF
--- a/LabExT/Measurements/MeasAPI/Measparam.py
+++ b/LabExT/Measurements/MeasAPI/Measparam.py
@@ -46,7 +46,7 @@ class MeasParam:
         return d
 
     @property
-    def sweep_type(self) -> Union[None, Literal["binary", "range"]]:
+    def sweep_type(self) -> Union[None, Literal["binary", "range", "list"]]:
         """Returns the type of sweep this parameter supports.
         """
         return None
@@ -70,7 +70,7 @@ class MeasParamInt(MeasParam):
         return self._value
 
     @property
-    def sweep_type(self) -> Union[Literal['binary', 'range'], None]:
+    def sweep_type(self) -> Union[Literal['binary', 'range', 'list'], None]:
         return "range"
 
     @value.setter
@@ -95,7 +95,7 @@ class MeasParamFloat(MeasParam):
         return self._value
 
     @property
-    def sweep_type(self) -> Union[Literal['binary', 'range'], None]:
+    def sweep_type(self) -> Union[Literal['binary', 'range', 'list'], None]:
         return "range"
 
     @value.setter
@@ -123,7 +123,7 @@ class MeasParamBool(MeasParam):
     """
 
     @property
-    def sweep_type(self) -> Union[Literal['binary', 'range'], None]:
+    def sweep_type(self) -> Union[Literal['binary', 'range', 'list'], None]:
         return "binary"
 
     def __init__(self, value=None, unit=None, extra_type=None):
@@ -136,6 +136,10 @@ class MeasParamList(MeasParam):
     Aside from the MeasParam arguments, needs the `options` argument, a list of all possible selections. Gets rendered
     as a drop-down menu in LabExT GUI.
     """
+    
+    @property
+    def sweep_type(self) -> Union[Literal['binary', 'range', 'list'], None]:
+        return "list"
 
     def __init__(self, options, value=None, unit=None, extra_type=None):
         """Constructor.

--- a/LabExT/View/Controls/SweepParameterFrame.py
+++ b/LabExT/View/Controls/SweepParameterFrame.py
@@ -262,7 +262,7 @@ class RangeEntry(Frame):
                 )
 
             step_count = int(np.floor((to - from_) / step))
-            return (pd.Series([from_ + i * step for i in range(step_count)]), "step_size")
+            return (pd.Series([from_ + i * step for i in range(step_count + 1)]), "step_size")
 
         elif category == self._selection["step_count_linear"]:
             step_size = (to - from_) / (step - 1)

--- a/LabExT/View/Controls/SweepParameterFrame.py
+++ b/LabExT/View/Controls/SweepParameterFrame.py
@@ -20,7 +20,7 @@ from LabExT.Measurements.MeasAPI.Measparam import MeasParam, MeasParamInt, MeasP
 
 if TYPE_CHECKING:
     CategoryType = Literal[
-        "step_size", "step_count_linear", "step_count_logarithmic", "step_count_repetition", "binary"
+        "step_size", "step_count_linear", "step_count_logarithmic", "step_count_repetition", "binary", "list"
     ]
 
     RangeRepresentation = Tuple[pd.Series, CategoryType]
@@ -320,6 +320,16 @@ class RangeEntry(Frame):
         self.__setup__()
 
 
+class BinaryEntry(Label):
+    pass
+
+
+class ListEntry(Label):
+    def __init__(self, options: List, *args, **kwargs) :
+        super().__init__(*args, **kwargs)
+        self.options = options.copy()
+
+
 class SweepParameterFrame(CustomFrame):
     """A table allowing the user to choose parameters to sweep and set their ranges."""
 
@@ -351,7 +361,7 @@ class SweepParameterFrame(CustomFrame):
 
         self._logger.debug(f"Setting up SweepParameterFrame with parameters: {self._remaining_parameters}")
 
-        self._ranges: List[Tuple[OptionMenu, Union[RangeEntry, Label], StringVar]] = list()
+        self._ranges: List[Tuple[OptionMenu, Union[RangeEntry, BinaryEntry, ListEntry], StringVar]] = list()
 
         self._minus_button = Button(self, text="-", command=self.on_minus)
         self._plus_button = Button(self, text="+", command=self.on_plus)
@@ -456,7 +466,12 @@ class SweepParameterFrame(CustomFrame):
             param_name: the name of the parameter.
         """
         if self._parameters[param_name].sweep_type == "binary":
-            return Label(self, text="Will be True and False")
+            return BinaryEntry(master=self, text="Will be True and False.")
+        elif self._parameters[param_name].sweep_type == "list":
+            return ListEntry(
+                options=self._parameters[param_name].options,
+                master=self,
+                text="Will cycle through all list options.")
         elif self._parameters[param_name].sweep_type == "range":
             param_value_low = self._parameters[param_name].value
             param_value_high = 2 * (abs(param_value_low) + 1)
@@ -473,7 +488,7 @@ class SweepParameterFrame(CustomFrame):
         else:
             raise AssertionError(
                 "SweepParameterFrame should not receive parameters"
-                + "whose sweep type differ from 'binary' and 'range'."
+                + "whose sweep type differ from 'binary' and 'range' and 'list'."
             )
 
     def __setup__(self):
@@ -524,8 +539,12 @@ class SweepParameterFrame(CustomFrame):
         for _, range_entry, text in self._ranges:
             if type(range_entry) == RangeEntry:
                 out_dict[text.get()] = range_entry.results()
-            else:
+            elif type(range_entry) == BinaryEntry:
                 out_dict[text.get()] = (pd.Series([True, False]), "binary")
+            elif type(range_entry) == ListEntry:
+                out_dict[text.get()] = (pd.Series(range_entry.options), "list")
+            else:
+                raise ValueError('Unknown range entry type: ' + str(range_entry))
         return out_dict
 
     def serialize(

--- a/LabExT/View/EditMeasurementWizard/WizardEntry/SaveButtons.py
+++ b/LabExT/View/EditMeasurementWizard/WizardEntry/SaveButtons.py
@@ -13,7 +13,7 @@ from LabExT.View.EditMeasurementWizard.WizardEntry.FinishedError import WizardFi
 from LabExT.Experiments.ToDo import ToDo, DictionaryWrapper
 from LabExT.Wafer.Device import Device
 from LabExT.Measurements.MeasAPI.Measurement import Measurement
-from LabExT.Measurements.MeasAPI.Measparam import MeasParam
+from LabExT.Measurements.MeasAPI.Measparam import MeasParamInt
 
 from LabExT.View.Controls.SweepParameterFrame import JSONRepresentation
 
@@ -58,7 +58,10 @@ class SaveButtonsController(WizardEntryController):
             new_meas.parameters = measurement.parameters.copy()
             for name, value in zip(row.index, row):
                 new_param = measurement.parameters[name].copy()
-                new_param.value = value
+                if type(new_param) == MeasParamInt:
+                    new_param.value = int(value)
+                else:
+                    new_param.value = value
                 new_meas.parameters[name] = new_param
 
             parameters.loc[index, 'id'] = new_meas.id.hex


### PR DESCRIPTION
Just adding the option to setup a sweep through all entries in a `MeasParamList` parameter of a measurement.

Also, fixed two bugs:
* `MeasParamInt` was not able to be swept as it tried to assign a float value to an int param
* There was an off-by-one error setting up the sweep of type `step_size`.

![image](https://github.com/LabExT/LabExT/assets/3842684/4afbfa73-db42-401b-9666-a8576f59dbc3)
