### PR TITLE
Bugfix: LV snapshots failed to save if a card did not have parameters associated

### DIFF
--- a/LabExT/View/Controls/ParameterTable.py
+++ b/LabExT/View/Controls/ParameterTable.py
@@ -242,6 +242,7 @@ class ParameterTable(CustomFrame):
     def serialize_to_dict(self, settings: dict):
         """Serializes data in table to dict. Takes a dict as parameter and first converts all the data
         of this parameter table to json-able format and then writes this to the provided dict with the new key 'data'."""
+        settings['data'] = {}
         if self._parameter_source is None:
             return False
         data = {}

--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -196,7 +196,7 @@ class LiveViewerController:
         cards_props = {}
         inst_props = {}
         for _, card in self.model.cards:
-            param_data = {}
+            param_data = {'data': {}}
             card.ptable.serialize_to_dict(param_data)
             cards_props[card.instance_title] = param_data['data']
 


### PR DESCRIPTION
see title

