### PR TITLE
Critical bugfix: live viewer snapshots did not save data at time of clicking, but continuously saved incoming data!

### DIFF
--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -7,7 +7,6 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 
 from typing import TYPE_CHECKING
 
-import uuid
 import datetime
 from collections import OrderedDict
 import json
@@ -15,6 +14,7 @@ from json import JSONDecodeError
 from os import makedirs
 from os.path import dirname, join
 from typing import TYPE_CHECKING, Dict, Tuple
+from copy import deepcopy
 
 from LabExT.Experiments.AutosaveDict import AutosaveDict
 from LabExT.PluginLoader import PluginLoader
@@ -235,12 +235,12 @@ class LiveViewerController:
 
         data["device"] = OrderedDict()
         data["device"]["id"] = 0
-        data["device"]["in_position"] = "Not Available"
-        data["device"]["out_position"] = "Not Available"
-        data["device"]["type"] = "Live Viewed Chip"
+        data["device"]["type"] = "Live Viewer Snapshot"
+        data["device"]["in_position"] = [0, 0]
+        data["device"]["out_position"] = [0, 0]
 
-        data["measurement name"] = "Liveviewer Snapshot"
-        data["measurement name and id"] = "Liveviewer Snapshot"
+        data["measurement name"] = "Live Viewer Snapshot"
+        data["measurement name and id"] = "Live Viewer Snapshot"
         data["instruments"] = inst_props
         data["measurement settings"] = cards_props
         data["values"] = OrderedDict()
@@ -250,8 +250,8 @@ class LiveViewerController:
             this_card = trace_key[0]
             trace_name = trace_key[1]
             fqtn = f"{this_card.instance_title:s}: {trace_name:s}"
-            data["values"][f"{fqtn:s}: y-values"] = plot_trace.y_values
-            data["values"][f"{fqtn:s}: timestamps"] = plot_trace.timestamps
+            data["values"][f"{fqtn:s}: y-values"] = deepcopy(plot_trace.y_values)
+            data["values"][f"{fqtn:s}: timestamps"] = deepcopy(plot_trace.timestamps)
 
         data["finished"] = True
 


### PR DESCRIPTION
I was not deep-copying the lists that keep the values of the live plots. This lead to the behavior of re-saving the live-viewer data every time somebody changed metadata of the snapshots.

This is a critical bugfix that needs to be merged to main ASAP.