### PR TITLE
Updating version of pypi publishing script

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Build binary wheel and source tarball
         run: python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Master branch of the `pypa/gh-action-pypi-publish` we're using has been sunset. Switching to their recommended release branch now.

see https://github.com/pypa/gh-action-pypi-publish/tree/release/v1