### PR TITLE
Add references to live snapshot

### DIFF
--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -245,6 +245,7 @@ class LiveViewerController:
         data["measurement settings"] = cards_props
         data["values"] = OrderedDict()
         data["error"] = {}
+        data["references"] = {}
 
         for trace_key, plot_trace in self.model.traces_to_plot.items():
             this_card = trace_key[0]
@@ -252,6 +253,7 @@ class LiveViewerController:
             fqtn = f"{this_card.instance_title:s}: {trace_name:s}"
             data["values"][f"{fqtn:s}: y-values"] = deepcopy(plot_trace.y_values)
             data["values"][f"{fqtn:s}: timestamps"] = deepcopy(plot_trace.timestamps)
+            data["references"][fqtn] = plot_trace.reference_value
 
         data["finished"] = True
 


### PR DESCRIPTION
Makes reference data avalible in live viewer snapshot. For example, a measurement might look like:

```
{
        ...,
  	"values": {
		"Poll OPM 2: Ch1: y-values": [....],
		"Poll OPM 2: Ch1: timestamps": [....],
		"Poll OPM 2: Ch2: y-values": [....],
		"Poll OPM 2: Ch2: timestamps": [....]
	},
	"references": {
		"Poll OPM 2: Ch1": -4.91511589480383,
		"Poll OPM 2: Ch2": -4.719089226367812
	},
}
```

or when references are not set:
```
"references": {
     "Poll OPM 2: Ch1": null,
     "Poll OPM 2: Ch2": null
},
```