### PR TITLE
LV traces bugfix: commenting/flagging lv trace is now saved in correct file

### DIFF
--- a/LabExT/View/LiveViewer/LiveViewerController.py
+++ b/LabExT/View/LiveViewer/LiveViewerController.py
@@ -211,9 +211,9 @@ class LiveViewerController:
 
         save_file_name = make_filename_compliant("LiveViewerSnapshot_" + ts_iso)
 
-        save_file_path = join(param_output_path, save_file_name)
+        save_file_path = join(param_output_path, save_file_name) + ".json"
 
-        data = AutosaveDict(freq=50, file_path=save_file_path + ".json")
+        data = AutosaveDict(freq=50, file_path=save_file_path)
 
         data["software"] = OrderedDict()
         data["software"]["name"] = "LabExT"


### PR DESCRIPTION
Buggy behavior: commenting/flagging on a saved live viewer trace resulted in not saving said changes to the correct file but the the same file name without file ending.

Corrected behavior: comments/flags get saved in correct file as initially written by live viewer.