### PR TITLE
Bugfix MCS2 drivers: removed separate import MoveMode

### DIFF
--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -1,10 +1,8 @@
 try:
     import smaract.ctl as ctl
-    import smaract.ctl.MoveMode as MoveMode
     MCS_LOADED = True
 except (ImportError, OSError):
     ctl = None
-    MoveMode = None
     MCS_LOADED = False
 
 class ChannelMCS2:
@@ -24,7 +22,7 @@ class ChannelMCS2:
         Speed setting of channel in micrometers/seconds
     _acceleration : float
         Acceleration setting of channel in micrometers/seconds^2
-    movement_mode : MoveMode
+    movement_mode : ctl.MoveMode
         Movement type of the channel
 
     Methods
@@ -62,7 +60,7 @@ class ChannelMCS2:
         self._stage = stage
         self._handle = index
         self._status = None
-        self._movement_mode = MoveMode.CL_RELATIVE
+        self._movement_mode = ctl.MoveMode.CL_RELATIVE
         self._position = None
         self._sensor = None
         self._speed = 0
@@ -133,14 +131,14 @@ class ChannelMCS2:
         self._acceleration = umps2
 
     @property
-    def movement_mode(self) -> MoveMode:
+    def movement_mode(self) -> ctl.MoveMode:
         """Returns movement mode of channel as MoveMode enum."""
         return self._movement_mode
 
     @movement_mode.setter
-    def movement_mode(self, mode: MoveMode) -> None:
+    def movement_mode(self, mode: ctl.MoveMode) -> None:
         """Sets the movement mode of channel as MoveMode enum."""
-        if not isinstance(mode, MoveMode):
+        if not isinstance(mode, ctl.MoveMode):
             raise ValueError(f'Invalid movement mode {mode}')
         ctl.SetProperty_i32(self._stage.handle, self._handle, ctl.Property.MOVE_MODE, mode)
         self._movement_mode = mode
@@ -153,14 +151,14 @@ class ChannelMCS2:
 
     # Movement
 
-    def move(self, value: float, mode: MoveMode) -> None:
+    def move(self, value: float, mode: ctl.MoveMode) -> None:
         """Moves the channel with the specified movement type by the value 'value'.
         Parameters
         ----------
         value : float
             Channel movement measured in micrometers
-        mode : MoveMode
-            Channel movement type (e.g. MoveMode.CL_ABSOLUTE)
+        mode : ctl.MoveMode
+            Channel movement type (e.g. ctl.MoveMode.CL_ABSOLUTE)
         """
         self.movement_mode = mode
         ctl.Move(self._stage.handle, self._handle, self._to_picometer(value))

--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -134,7 +134,7 @@ class ChannelMCS2:
         self._acceleration = umps2
 
     @property
-    def movement_mode(self) -> ctl.MoveMode:
+    def movement_mode(self):
         """Returns movement mode of channel as MoveMode enum."""
         return self._movement_mode
 

--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -154,7 +154,7 @@ class ChannelMCS2:
 
     # Movement
 
-    def move(self, value: float, mode: ctl.MoveMode) -> None:
+    def move(self, value: float, mode) -> None:
         """Moves the channel with the specified movement type by the value 'value'.
         Parameters
         ----------

--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -60,7 +60,10 @@ class ChannelMCS2:
         self._stage = stage
         self._handle = index
         self._status = None
-        self._movement_mode = ctl.MoveMode.CL_RELATIVE
+        if MCS_LOADED:
+            self._movement_mode = ctl.MoveMode.CL_RELATIVE
+        else:
+            self._movement_mode = None
         self._position = None
         self._sensor = None
         self._speed = 0

--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -139,7 +139,7 @@ class ChannelMCS2:
         return self._movement_mode
 
     @movement_mode.setter
-    def movement_mode(self, mode: ctl.MoveMode) -> None:
+    def movement_mode(self, mode) -> None:
         """Sets the movement mode of channel as MoveMode enum."""
         if not isinstance(mode, ctl.MoveMode):
             raise ValueError(f'Invalid movement mode {mode}')

--- a/LabExT/Movement/Stages/ChannelMCS2.py
+++ b/LabExT/Movement/Stages/ChannelMCS2.py
@@ -22,7 +22,7 @@ class ChannelMCS2:
         Speed setting of channel in micrometers/seconds
     _acceleration : float
         Acceleration setting of channel in micrometers/seconds^2
-    movement_mode : ctl.MoveMode
+    movement_mode
         Movement type of the channel
 
     Methods


### PR DESCRIPTION
After using the MCS2 drivers on a fresh install, the drivers failed without giving an error message. I traced this back to a failed import of 
```
smaract.ctl.MoveMode as Modemode
```
in LabExT/Movement/Stages/ChannelMCS2.py. Following the example from SmartAct, I removed the separate import of ModeMode, and called it directly from ctl as ctl.MoveMode. This fixed the problem in my test environment and on a fresh install from LabExt/dev.