### PR TITLE
remove warning: available stages logging

### DIFF
--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -69,7 +69,7 @@ class Stage(ABC):
     _logger = logging.getLogger()
 
     @classmethod
-    def find_available_stages(cls) -> List[Type[Stage]]:
+    def find_available_stages(cls) -> List[Stage]:
         """
         Returns a list of stage objects. Each object represents a found stage.
         Note: The stage is not yet connected.
@@ -77,7 +77,7 @@ class Stage(ABC):
         try:
             return [cls(address) for address in cls.find_stage_addresses()]
         except StageError as err:
-            cls._logger.error(
+            cls._logger.info(
                 f"Failed to find available stages for {cls.__name__}: {err}")
             return []
 

--- a/LabExT/Movement/Stage.py
+++ b/LabExT/Movement/Stage.py
@@ -77,7 +77,7 @@ class Stage(ABC):
         try:
             return [cls(address) for address in cls.find_stage_addresses()]
         except StageError as err:
-            cls._logger.info(
+            cls._logger.debug(
                 f"Failed to find available stages for {cls.__name__}: {err}")
             return []
 


### PR DESCRIPTION
This is a super small change to remove the logger warnings of stage driver loading errors. Basically we have this information in the "Configure Mover" window anyway. And it is just annoying seeing this warning every time you run LabExT from the terminal or from wherever :)

I put it as debug logging but we can also change it to info logging so it would be saved to the log file (still a bit unnecessary imo).