### PR TITLE
Adding filtering for device selection table

### DIFF
--- a/LabExT/Tests/View/ExperimentWizard_test.py
+++ b/LabExT/Tests/View/ExperimentWizard_test.py
@@ -109,34 +109,34 @@ class ExperimentWizardTest(TKinterTestCase):
         # select devices step
         #
         device_step = exp_wizard.step_device_selection
+        dataframe_table = device_step.device_table.device_table
         self.assertIsInstance(device_step, DeviceSelection)
-        all_rows = device_step.device_table.device_table.get_tree().get_children()
-        self.assertEqual(len(all_rows), 49)
+        self.assertEqual(len(dataframe_table.get_df()), 49)
 
-        for chip_dev, table_dev in zip(
+        for chip_dev, (_, table_dev) in zip(
             self.expm.chip.devices.values(),
-            (device_step.device_table.device_table.get_tree().item(row) for row in all_rows),
+            dataframe_table.get_df().iterrows()
         ):
-            self.assertEqual(chip_dev.id, str(table_dev["values"][2]))
-            self.assertEqual(chip_dev.in_position[0], float(table_dev["values"][3].split(" ")[0]))
-            self.assertEqual(chip_dev.in_position[1], float(table_dev["values"][3].split(" ")[1]))
-            self.assertEqual(chip_dev.out_position[0], float(table_dev["values"][4].split(" ")[0]))
-            self.assertEqual(chip_dev.out_position[1], float(table_dev["values"][4].split(" ")[1]))
-            self.assertEqual(chip_dev.type, table_dev["values"][5])
+            self.assertEqual(chip_dev.id, str(table_dev["ID"]))
+            self.assertEqual(chip_dev.in_position[0], float(table_dev["In"][0]))
+            self.assertEqual(chip_dev.in_position[1], float(table_dev["In"][1]))
+            self.assertEqual(chip_dev.out_position[0], float(table_dev["Out"][0]))
+            self.assertEqual(chip_dev.out_position[1], float(table_dev["Out"][1]))
+            self.assertEqual(chip_dev.type, table_dev["Type"])
 
         selected_device_ids = random.sample([k for k in self.expm.chip.devices], 3)
         device_step.device_table.mark_items_by_ids(ids=selected_device_ids)
         self.pump_events()
 
         # double check that the table updated first column
-        for chip_dev, table_dev in zip(
+        for chip_dev, (_, table_dev) in zip(
             self.expm.chip.devices.values(),
-            (device_step.device_table.device_table.get_tree().item(row) for row in all_rows),
+            dataframe_table.get_df().iterrows()
         ):
             if chip_dev.id in selected_device_ids:
-                self.assertEqual(table_dev["values"][1], "marked")
+                self.assertEqual(table_dev["Selection"], "marked")
             else:
-                self.assertEqual(table_dev["values"][1], " ")
+                self.assertEqual(table_dev["Selection"], " ")
 
         # continue to next step in wizard
         exp_wizard._next_button.invoke()

--- a/LabExT/View/Controls/CustomTable.py
+++ b/LabExT/View/Controls/CustomTable.py
@@ -5,34 +5,34 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-import logging
-from operator import itemgetter
+from tkinter import Tk
+from typing import List, Literal, Any, Union
 
 from LabExT.View.Controls.CustomTtkWidgets import CustomTreeview, CustomScrollbar
 
 
-class CustomTable(object):
+class CustomTable:
     """Creates a table with entries and scrollbars.
     """
 
     def __init__(self,
-                 parent,
-                 columns,
-                 rows,
-                 col_width=20,
-                 add_checkboxes=False,
-                 selectmode='extended',
-                 showmode='headings',
-                 sortable=True):
+                 parent: Tk,
+                 column_headers: List[str],
+                 rows: List[tuple],
+                 col_width: int = 20,
+                 add_checkboxes: bool = False,
+                 selectmode: Literal["extended", "browse", "none"] = "extended",
+                 showmode: Literal["tree", "headings", "tree headings", ""] = "headings",
+                 sortable: bool = True):
         """Constructor.
 
         Parameters
         ----------
         parent : Tk
             Tkinter window parent
-        columns : list
+        column_headers : List[str]
             Columns for the table
-        rows : list
+        rows : List[tuple]
             List of tuples for the rows of the table
         col_width : int, optional
             Column width
@@ -42,9 +42,9 @@ class CustomTable(object):
         sortable : bool, optional
             Sets ability to sort the table when clicking on the column headers
         """
-        self._col_width = col_width
-        self._root = parent
-        self._columns = columns
+        self.parent = parent
+        self.col_width = col_width
+        self.column_headers = column_headers
         self._rows = rows
         self._tree = None
         self._add_checkboxes = add_checkboxes
@@ -53,162 +53,105 @@ class CustomTable(object):
         self._selection = dict()
         self._sortable = sortable
 
-        self.logger = logging.getLogger()
-        self.logger.debug('Initialised CustomTable with parent: %s columns: %s' +
-                          ' number of rows: %d col_width: %s selectmode: %s showmode: %s' +
-                          ' add checkboxes: %s',
-                          parent, columns, len(rows), col_width, selectmode, showmode, add_checkboxes)
-        self.__setup__()
+        self._build_ui()
         self._build_tree_columns()
-        self.add_all()
+        self._populate_initial_rows()
 
-    def __setup__(self):
-        """Create a Treeview with two scrollbars.
-        """
+    def _build_ui(self):
+        """Create a Treeview with two scrollbars."""
         self._tree = CustomTreeview(
-            self._root,
-            columns=self._columns,
+            self.parent,
+            columns=self.column_headers,
             show=self._show_mode,
             selectmode=self._select_mode)
-        vsb = CustomScrollbar(
-            self._root, orient="vertical", command=self._tree.yview)
-        hsb = CustomScrollbar(
-            self._root, orient="horizontal", command=self._tree.xview)
-
+        vsb = CustomScrollbar(self.parent, orient="vertical", command=self._tree.yview)
+        hsb = CustomScrollbar(self.parent, orient="horizontal", command=self._tree.xview)
         self._tree.configure(xscrollcommand=hsb.set, yscrollcommand=vsb.set)
-        self._tree.grid(column=0, row=0, sticky='nsew', in_=self._root)
-        vsb.grid(column=1, row=0, sticky='wns', in_=self._root)
-        hsb.grid(column=0, row=1, sticky='ew', in_=self._root)
-        self._root.grid_columnconfigure(0, weight=1)
-        self._root.grid_rowconfigure(0, weight=1)
+        self._tree.grid(column=0, row=0, sticky='nsew')
+        vsb.grid(column=1, row=0, sticky='wns')
+        hsb.grid(column=0, row=1, sticky='ew')
+        self.parent.grid_columnconfigure(0, weight=1)
+        self.parent.grid_rowconfigure(0, weight=1)
 
     def get_tree(self) -> CustomTreeview:
-        """Getter for treeview object
-        """
+        """Getter for treeview object"""
         return self._tree
 
-    def select_by_id(self, device_id, id_column=0):
-        """
-        Select an item based on its id. Device id is assumed to be
-        stored in the first column!
+    def select_by_column_value(self, column: Union[str, int], value: Any) -> None:
+        """ Select/focus an item based on the column and value. """
+        column_names = self._tree["columns"]
+        column_idx = column_names.index(column) if isinstance(column, str) else column
 
-        Parameters
-        ----------
-        device_id : str
-            Device ID.
-        id_column : int
-            The column of the table which contains the device IDs
-        """
         children = self._tree.get_children()
-
-        for ix, child in enumerate(children):
-            if self._tree.item(child).get('values')[id_column] == device_id:
+        for idx, child in enumerate(children):
+            if self._tree.item(child).get("values")[column_idx] == value:
                 self._tree.selection_set(child)
                 self._tree.focus(child)
+
+    def select_by_id(self, device_id: str, id_column: int = 0) -> None:
+        """ Select an item based on its id. Device id is assumed to be stored in the first column.
+        This method will be DEPRECATED soon.
+        """
+        self.select_by_column_value(column=id_column, value=device_id)
 
     def _build_tree_columns(self):
         """Build up the tree based on values given in constructor.
         """
-        for col in self._columns:
+        for col in self.column_headers:
             self._tree.heading(
-                col, text=col, command=lambda c=col: sortby(self._tree, c, 0) if self._sortable else None)
+                col, text=col, command=lambda c=col: sort_tree_column(self._tree, c) if self._sortable else None)
             # adjust the column's width
-            self._tree.column(col, width=self._col_width)
+            self._tree.column(col, width=self.col_width)
 
-    def add_all(self):
-        """Fill items into tree
-        """
+    def _populate_initial_rows(self) -> None:
+        """Fill items into tree."""
         for i, item in enumerate(self._rows):
             self._tree.insert('', 'end', values=item)
 
-    def add_item(self, item):
-        """Add an item to the tree.
+    def add_row(self, row_values: tuple) -> None:
+        """Add a single row to the tree."""
+        self._tree.insert('', 'end', values=row_values)
 
-        Parameters
-        ----------
-        item : tuple
-            Row to be inserted
-        """
-        self._tree.insert('', 'end', values=item)
-
-    def remove_item(self, item):
-        """Removes an item from the tree.
-
-        Parameters
-        ----------
-        item : tuple
-            Row to be removed
+    def remove_row(self, row_values: tuple) -> str:
+        """Removes a row based on matching row values.
 
         Returns
         -------
         str
             The removed item's treeview iid.
         """
-        self.logger.debug('Remove item from CustomTable called with:%s', item)
-
-        children = self._tree.get_children()
-        for child in children:
-            val = self._tree.item(child).get('values')
-            # all values have to be the same to remove the item
-            if all(v in val for v in item):
+        for child in self._tree.get_children():
+            current_values = self._tree.item(child).get('values')
+            if tuple(current_values) == row_values:
                 self._tree.delete(child)
                 return child
+        return ""
 
-    def remove_all(self):
-        """
-        Removes all children from the treeview.
-        """
-        self.logger.debug('Remove all items from CustomTable called.')
-        children = self._tree.get_children()
-        for c in children:
+    def remove_all(self) -> None:
+        """Removes all children/rows from the treeview."""
+        for c in self._tree.get_children():
             self._tree.delete(c)
 
 
-def sortby(tree, col, descending):
-    """Sorts tree contents when a column header is clicked on.
+def sort_tree_column(tree: CustomTreeview, column_name: str, descending: bool = False) -> None:
+    """ Sort the treeview by a given column. """
+    row_ids = tree.get_children()
+    column_values = [tree.set(row_id, column_name) for row_id in row_ids]
 
-    Parameters
-    ----------
-    tree : tkinter.Treeview
-        Tree to be sorted.
-    col : string
-        Column by which to sort.
-    descending : bool
-        Sort the tree in descending or ascending order.
-    """
-    # separate out the column data so we can verify it is all the same type
-    column_keys = tree.get_children('')
-    column_values = [tree.set(child, col) for child in column_keys]
+    def prepare(v: Any):
+        if v == "":
+            return float("inf")
+        try:
+            return float(v)
+        except ValueError:
+            return v
 
-    # if the all the data to be sorted is numeric change to float
-    if all(map(is_float, column_values)):
-        column_values = map(lambda item: float('+inf') if item == '' else float(item), column_values)
+    prepared = list(map(prepare, column_values))
+    sorted_pairs = sorted(zip(prepared, row_ids), key=lambda x: x[0], reverse=descending)
 
-    data = zip(column_values, column_keys)
-    
-    # sort the data in place
-    data = sorted(data, key=lambda x: (x, itemgetter(0)), reverse=descending)
+    # reorder rows
+    for index, (_, row_id), in enumerate(sorted_pairs):
+        tree.move(row_id, "", index)
 
-    # move the items' position in the table
-    for ix, item in enumerate(data):
-        tree.move(item[1], '', ix)
-    # switch so tree will sort in opposite direction next time it is clicked
-    tree.heading(
-        col, command=lambda col=col: sortby(tree, col, int(not descending)))
-    
-def is_float(s):
-    """Helper function to check if a string is a float
-    Unfortunately this is the most foolproof method in python
-
-    Parameters
-    ----------
-    s : any
-    """
-    # We convert empty strings to +inf
-    if s == '': return True
-
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
+    # toggle sorting direction on next click
+    tree.heading(column_name, command=lambda col=column_name: sort_tree_column(tree, col, not descending))

--- a/LabExT/View/Controls/DataFrameTable.py
+++ b/LabExT/View/Controls/DataFrameTable.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
 from tkinter import Tk
 from typing import Any, Literal, Union
 

--- a/LabExT/View/Controls/DataFrameTable.py
+++ b/LabExT/View/Controls/DataFrameTable.py
@@ -135,6 +135,9 @@ class TableController:
     def get_df(self) -> pd.DataFrame:
         return self.model.df.copy()
 
+    def get_full_df(self) -> pd.DataFrame:
+        return self.model.full_df.copy()
+
     def update_df(self, df: pd.DataFrame) -> None:
         self.model.update_df(df)
         self.refresh()
@@ -162,6 +165,9 @@ class DataFrameTable:
 
     def get_df(self) -> pd.DataFrame:
         return self.controller.get_df()
+
+    def get_full_df(self) -> pd.DataFrame:
+        return self.controller.get_full_df()
 
     def update_df(self, df: pd.DataFrame) -> None:
         self.controller.update_df(df)

--- a/LabExT/View/Controls/DataFrameTable.py
+++ b/LabExT/View/Controls/DataFrameTable.py
@@ -1,0 +1,170 @@
+from tkinter import Tk
+from typing import Any, Literal, Union
+
+import pandas as pd
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.CustomTtkWidgets import CustomTreeview, CustomScrollbar
+
+
+class DataTable:
+
+    def __init__(self, columns: list[str], rows: list[tuple[Any]]):
+        self._df = pd.DataFrame(rows, columns=columns)
+        self._current_df = self._df.copy()
+
+    @property
+    def df(self) -> pd.DataFrame:
+        return self._current_df
+
+    @property
+    def full_df(self) -> pd.DataFrame:
+        return self._df
+
+    def sync(self) -> None:
+        self._df.update(self._current_df)
+        # handle newly added rows
+        new_rows = self._current_df.index.difference(self._df.index)
+        if not new_rows.empty:
+            self._df = pd.concat([self._df, self._current_df.loc[new_rows]])
+
+    def update_df(self, df: pd.DataFrame) -> None:
+        self._current_df = df
+        self.sync()
+
+    def sort(self, column: str, ascending: bool) -> None:
+        if column in self.df.columns:
+            self._current_df = self._current_df.sort_values(column, ascending=ascending)
+
+
+# ============================================================
+# VIEW: TableView (Tkinter Treeview renderer)
+# ============================================================
+
+
+class TableView:
+    """Tkinter UI element that ONLY handles displaying data."""
+
+    def __init__(self,
+                 parent: Tk,
+                 column_headers: list[str],
+                 col_width: int,
+                 show_mode: Literal["tree", "headings", "tree headings", ""],
+                 select_mode: Literal["extended", "browse", "none"]):
+
+        self.parent = parent
+        self.columns = column_headers
+        self.tree: Union[CustomTreeview, None] = None
+        self._col_width = col_width
+        self._show_mode = show_mode
+        self._select_mode = select_mode
+
+        self._build_ui()
+
+    # --------------------------------------------------------
+
+    def _build_ui(self):
+        """Initialize Treeview with scrollbars."""
+        self.tree = CustomTreeview(
+            self.parent,
+            columns=self.columns,
+            show=self._show_mode,
+            selectmode=self._select_mode
+        )
+
+        vsb = CustomScrollbar(self.parent, orient="vertical", command=self.tree.yview)
+        hsb = CustomScrollbar(self.parent, orient="horizontal", command=self.tree.xview)
+
+        self.tree.configure(xscrollcommand=hsb.set, yscrollcommand=vsb.set)
+
+        self.tree.grid(column=0, row=0, sticky="nsew")
+        vsb.grid(column=1, row=0, sticky="ns")
+        hsb.grid(column=0, row=1, sticky="ew")
+
+        self.parent.grid_columnconfigure(0, weight=1)
+        self.parent.grid_rowconfigure(0, weight=1)
+
+        for col in self.columns:
+            self.tree.heading(col, text=col)
+            self.tree.column(col, width=self._col_width)
+
+    def clear(self):
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+
+    def populate_row(self, values: tuple[Any, ...], iid: Union[int, str, None] = None):
+        self.tree.insert("", "end", iid=iid, values=values)
+
+    def get_selected_row_indices(self) -> list[int]:
+        selected_row_indices = [int(iid) for iid in self.tree.selection()]
+        return selected_row_indices
+
+
+# ============================================================
+# CONTROLLER: TableController
+# ============================================================
+
+
+class TableController:
+    def __init__(self, model: DataTable, view: TableView):
+        self.model = model
+        self.view = view
+
+        self._sort_states = {col: False for col in self.model.df.columns}
+        self._prepare_sorting()
+        self.refresh()
+
+    def _prepare_sorting(self) -> None:
+        for column in self.model.df.columns:
+            self.view.tree.heading(column, command=lambda c=column: self.sort_by_column(c))
+
+    def sort_by_column(self, column: str) -> None:
+        current = self._sort_states[column]
+        self.model.sort(column, ascending=not current)
+        self._sort_states[column] = not current
+        self.refresh()
+
+    def refresh(self) -> None:
+        selected = set(self.view.get_selected_row_indices())
+        self.view.clear()
+        for idx, row_values in self.model.df.iterrows():
+            self.view.populate_row(tuple(row_values), iid=str(idx))
+            if idx in selected:
+                self.view.tree.selection_add(str(idx))
+
+    def get_df(self) -> pd.DataFrame:
+        return self.model.df.copy()
+
+    def update_df(self, df: pd.DataFrame) -> None:
+        self.model.update_df(df)
+        self.refresh()
+
+
+# ============================================================
+# FACADE: CustomTable (drop-in replacement)
+# ============================================================
+
+
+class DataFrameTable:
+
+    def __init__(
+            self,
+            parent: Union[Tk, CustomFrame],
+            column_headers: list[str],
+            rows: list[tuple],
+            col_width: int = 20,
+            select_mode: Literal["extended", "browse", "none"] = "extended",
+            show_mode: Literal["tree", "headings", "tree headings", ""] = "headings",
+    ):
+        self.model = DataTable(column_headers, rows)
+        self.view = TableView(parent, column_headers, col_width, show_mode, select_mode)
+        self.controller = TableController(self.model, self.view)
+
+    def get_df(self) -> pd.DataFrame:
+        return self.controller.get_df()
+
+    def update_df(self, df: pd.DataFrame) -> None:
+        self.controller.update_df(df)
+
+    def get_selected_row_indices(self) -> list[int]:
+        return self.view.get_selected_row_indices()

--- a/LabExT/View/Controls/PlaceholderEntry.py
+++ b/LabExT/View/Controls/PlaceholderEntry.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+from typing import Union
+from tkinter import Entry, Tk, END, Frame
+
+
+class PlaceholderEntry(Entry):
+    def __init__(
+            self,
+            parent: Union[Tk, Frame, None] = None,
+            placeholder: str = "Placeholder",
+            placeholder_color: str = "grey",
+            text_color=None,
+            **kwargs
+    ):
+        super().__init__(parent, **kwargs)
+        self.placeholder = placeholder
+        self.placeholder_color = placeholder_color
+        self.text_color = text_color or self.cget("fg")
+        self._has_placeholder = False
+
+        self.bind("<FocusIn>", self._on_focus_in)
+        self.bind("<FocusOut>", self._on_focus_out)
+
+        self._show_placeholder()
+
+    def _show_placeholder(self):
+        if not self.get():
+            self._set_text(self.placeholder, self.placeholder_color)
+            self._has_placeholder = True
+
+    def _hide_placeholder(self):
+        if self._has_placeholder:
+            self.delete(0, END)
+            self.config(fg=self.text_color)
+            self._has_placeholder = False
+
+    def _on_focus_in(self, _):
+        # Remove placeholder so user can type
+        if self._has_placeholder:
+            self._hide_placeholder()
+
+    def _on_focus_out(self, _):
+        # Restore placeholder if left empty
+        if not self.get():
+            self._show_placeholder()
+
+    def _set_text(self, text, color):
+        self.delete(0, END)
+        self.insert(0, text)
+        self.config(fg=color)
+
+    def get_value(self) -> str:
+        """Return the logical value ('' if only placeholder is shown)."""
+        if self._has_placeholder:
+            return ""
+        return self.get()

--- a/LabExT/View/Controls/Wizard.py
+++ b/LabExT/View/Controls/Wizard.py
@@ -5,12 +5,15 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+from __future__ import annotations
 import logging
-from tkinter import Label, Toplevel, Frame, Button, FLAT, TOP, RIGHT, LEFT, X, Y, BOTH, NORMAL, DISABLED
-from typing import Type
-
+from tkinter import Tk, Toplevel, Label, Frame, Button, FLAT, TOP, RIGHT, LEFT, X, Y, BOTH, NORMAL, DISABLED
+from typing import Union, Callable
 
 from LabExT.View.Controls.CustomFrame import CustomFrame
+
+
+CALLBACK_FN_TYPE = Union[Callable[[], bool], None]
 
 
 class Step:
@@ -23,19 +26,19 @@ class Step:
 
     def __init__(
             self,
-            wizard,
+            wizard: Wizard,
             builder,
-            title=None,
-            on_next=None,
-            on_previous=None,
-            on_reload=None,
-            previous_step_enabled=True,
-            next_step_enabled=True,
-            finish_step_enabled=False) -> None:
+            title: Union[None, str] = None,
+            on_next: CALLBACK_FN_TYPE = None,
+            on_previous: CALLBACK_FN_TYPE = None,
+            on_reload: CALLBACK_FN_TYPE = None,
+            previous_step_enabled: bool = True,
+            next_step_enabled: bool = True,
+            finish_step_enabled: bool = False) -> None:
         """
         Constructor for a Wizard Step.
         """
-        self.wizard: Type[Wizard] = wizard
+        self.wizard = wizard
 
         self.builder = builder
 
@@ -43,24 +46,23 @@ class Step:
         self.on_previous = on_previous
         self.on_reload = on_reload
 
-        self.previous_step: Type[Step] = None
-        self.next_step: Type[Step] = None
+        self.previous_step: Union[Step, None] = None
+        self.next_step: Union[Step, None] = None
 
         self.previous_step_enabled = previous_step_enabled
         self.next_step_enabled = next_step_enabled
         self.finish_step_enabled = finish_step_enabled
 
-        if self.wizard._sidebar_frame and title:
+        self._sidebar_label: Union[Label, None] = None
+        if self.wizard.sidebar_frame and title:
             self._sidebar_label = Label(
-                self.wizard._sidebar_frame,
+                self.wizard.sidebar_frame,
                 anchor="w",
                 text=title,
                 foreground=self.INACTIVE_LABEL_COLOR)
             self._sidebar_label.pack(side=TOP, fill=X, padx=10, pady=5)
-        else:
-            self._sidebar_label = None
 
-    def activate_sidebar_label(self):
+    def activate_sidebar_label(self) -> None:
         """
         Changes sidebar label to active color
         """
@@ -69,7 +71,7 @@ class Step:
 
         self._sidebar_label.config(foreground=self.ACTIVE_LABEL_COLOR)
 
-    def deactivate_sidebar_label(self):
+    def deactivate_sidebar_label(self) -> None:
         """
         Changes sidebar label to inactive color
         """
@@ -79,7 +81,7 @@ class Step:
         self._sidebar_label.config(foreground=self.INACTIVE_LABEL_COLOR)
 
     @property
-    def previous_step_available(self):
+    def previous_step_available(self) -> bool:
         """
         Returns a decision, if a previous step is available.
 
@@ -88,7 +90,7 @@ class Step:
         return self.previous_step is not None and self.previous_step_enabled
 
     @property
-    def next_step_available(self):
+    def next_step_available(self) -> bool:
         """
         Returns a decision, if a next step is available.
 
@@ -96,7 +98,7 @@ class Step:
         """
         return self.next_step is not None and self.next_step_enabled
 
-    def on_next_callback(self):
+    def on_next_callback(self) -> bool:
         """
         Performs on_next callback.
 
@@ -107,7 +109,7 @@ class Step:
 
         return self.on_next()
 
-    def on_previous_callback(self):
+    def on_previous_callback(self) -> bool:
         """
         Performs on_update callback.
 
@@ -118,7 +120,7 @@ class Step:
 
         return self.on_previous()
 
-    def on_reload_callback(self):
+    def on_reload_callback(self) -> None:
         """
         Performs on_reload callback.
 
@@ -140,17 +142,17 @@ class Wizard(Toplevel):
 
     def __init__(
             self,
-            parent,
-            width=640,
-            height=480,
-            on_cancel=None,
-            on_finish=None,
-            with_sidebar=True,
-            with_error=True,
-            next_button_label="Next Step",
-            previous_button_label="Previous Step",
-            cancel_button_label="Cancel",
-            finish_button_label="Finish") -> None:
+            parent: Tk,
+            width: int = 640,
+            height: int = 480,
+            on_cancel: CALLBACK_FN_TYPE = None,
+            on_finish: CALLBACK_FN_TYPE = None,
+            with_sidebar: bool = True,
+            with_error: bool = True,
+            next_button_label: str = "Next Step",
+            previous_button_label: str = "Previous Step",
+            cancel_button_label: str = "Cancel",
+            finish_button_label: str = "Finish") -> None:
         Toplevel.__init__(
             self,
             parent,
@@ -163,17 +165,17 @@ class Wizard(Toplevel):
 
         self.logger = logging.getLogger()
 
-        self._current_step: Type[Step] = None
+        self._current_step: Union[Step, None] = None
 
         self.on_cancel = on_cancel
         self.on_finish = on_finish
 
         # Build Wizard
         if with_sidebar:
-            self._sidebar_frame = CustomFrame(self, width=self.SIDEBAR_WIDTH)
-            self._sidebar_frame.pack(side=LEFT, fill=BOTH, anchor='nw')
+            self.sidebar_frame = CustomFrame(self, width=self.SIDEBAR_WIDTH)
+            self.sidebar_frame.pack(side=LEFT, fill=BOTH, anchor='nw')
         else:
-            self._sidebar_frame = None
+            self.sidebar_frame = None
 
         self._content_frame = Frame(self, borderwidth=0, relief=FLAT)
         self._content_frame.pack(side=RIGHT, fill=BOTH, expand=True)
@@ -243,14 +245,14 @@ class Wizard(Toplevel):
         self.protocol('WM_DELETE_WINDOW', self._cancel)
 
     @property
-    def current_step(self) -> Type[Step]:
+    def current_step(self) -> Union[Step, None]:
         """
         Returns the current step object.
         """
         return self._current_step
 
     @current_step.setter
-    def current_step(self, step: Type[Step]) -> None:
+    def current_step(self, step: Union[Step, None]) -> None:
         """
         Sets the current step, updates the sidebar and resets error.
 
@@ -267,7 +269,7 @@ class Wizard(Toplevel):
         self._current_step = step
         self.__reload__()
 
-    def __reload__(self):
+    def __reload__(self) -> None:
         """
         Updates the Wizard contents.
         """
@@ -292,19 +294,19 @@ class Wizard(Toplevel):
 
         self.update_idletasks()
 
-    def add_step(self, *args, **kwargs) -> Type[Step]:
+    def add_step(self, *args, **kwargs) -> Step:
         """
         Creates and returns a new wizard step.
         """
         return Step(self, *args, **kwargs)
 
-    def set_error(self, message):
+    def set_error(self, message) -> None:
         if not self._error_label:
             return
 
         self._error_label.config(text=message)
 
-    def _finish(self):
+    def _finish(self) -> None:
         """
         Gets called, when user clicks finish button
         """
@@ -314,14 +316,14 @@ class Wizard(Toplevel):
         if self._on_finish_callback():
             self.destroy()
 
-    def _cancel(self):
+    def _cancel(self) -> None:
         """
         Gets called, when user clicks cancel button
         """
         if self._on_cancel_callback():
             self.destroy()
 
-    def _previous_step(self):
+    def _previous_step(self) -> None:
         """
         Gets called, when user clicks previous step button
         """
@@ -333,7 +335,7 @@ class Wizard(Toplevel):
 
         self.current_step = self.current_step.previous_step
 
-    def _next_step(self):
+    def _next_step(self) -> None:
         """
         Gets called, when user clicks next step button
         """

--- a/LabExT/View/ExperimentWizard.py
+++ b/LabExT/View/ExperimentWizard.py
@@ -9,7 +9,7 @@ import logging
 import os.path
 
 from typing import TYPE_CHECKING, Union, List
-from tkinter import Frame, Label, Button, messagebox, StringVar
+from tkinter import Frame, Label, Button, messagebox, StringVar, Entry
 
 from LabExT.Experiments.ToDo import ToDo
 from LabExT.Utils import get_configuration_file_path, get_visa_address
@@ -193,11 +193,11 @@ class MultiDeviceTable(Frame):
         Button(button_frame, text="(un)mark all", command=self.mark_all).grid(
             row=0, column=2, padx=5, sticky="w"
         )
-        Button(button_frame, text="ID contains", command=self.filter_ids_contain).grid(
+        Button(button_frame, text="filter ID (contains)", command=self.filter_ids_contain).grid(
             row=0, column=3, padx=5, sticky="w"
         )
-        Label(button_frame, textvariable=self._contains_string).grid(
-            row=5, column=4, padx=5, sticky="w"
+        Entry(button_frame, textvariable=self._contains_string).grid(
+            row=1, column=3, padx=5, sticky="w"
         )
 
         Label(self.parent, text="The selected devices will be sorted by the original index.").grid(
@@ -205,7 +205,9 @@ class MultiDeviceTable(Frame):
         )
 
     def filter_ids_contain(self) -> None:
-        ...
+        df = self.device_table.get_full_df()
+        df = df[df["ID"].str.contains(self._contains_string.get())]
+        self.device_table.update_df(df)
 
     def mark_items_by_ids(self, ids: list[str]) -> None:
         if not ids:

--- a/LabExT/View/ExperimentWizard.py
+++ b/LabExT/View/ExperimentWizard.py
@@ -8,8 +8,8 @@ import json
 import logging
 import os.path
 
-from typing import TYPE_CHECKING, Union
-from tkinter import Frame, Label, Button, messagebox, TOP
+from typing import TYPE_CHECKING, Union, List
+from tkinter import Frame, Label, Button, messagebox
 
 from LabExT.Experiments.ToDo import ToDo
 from LabExT.Utils import get_configuration_file_path, get_visa_address
@@ -144,22 +144,22 @@ class MultiDeviceTable(Frame):
         """Set up the custom table containing all devices from the chip."""
 
         # set up columns so that they contain all parameters
-        def_columns = ["#", "Selection", "ID", "In", "Out", "Type"]
-        columns = set()
+        column_headers = ["#", "Selection", "ID", "In", "Out", "Type"]
+        column_param_headers = set()
         for device in self.chip.devices.values():
-            for param in device.parameters:
-                columns.add(str(param))
+            for param_name in device.parameters:
+                column_param_headers.add(str(param_name))
 
         saved_ids = self.deserialize_to_list()
-        devices = []
+        rows: List[tuple] = []
         for idx, dev in enumerate(self.chip.devices.values()):
             if dev.id in saved_ids:
                 row_values = (idx + 1, self.MARKED, dev.id, dev.in_position, dev.out_position, dev.type)
                 saved_ids.remove(dev.id)
             else:
                 row_values = (idx + 1, self.UNMARKED, dev.id, dev.in_position, dev.out_position, dev.type)
-            row_values = (*row_values, *[dev.parameters.get(param, "") for param in columns])
-            devices.append(row_values)
+            row_values = (*row_values, *[dev.parameters.get(param, "") for param in column_param_headers])
+            rows.append(row_values)
 
         Label(self.parent, text="Highlight one or more rows, then press mark to select these devices").grid(
             column=0, row=0, padx=5, pady=5, sticky="nswe"
@@ -171,7 +171,7 @@ class MultiDeviceTable(Frame):
         self.parent.grid_rowconfigure(1, weight=1)
         self.parent.grid_columnconfigure(0, weight=1)
 
-        self.device_table = CustomTable(self.table_frame, (def_columns + list(columns)), devices)
+        self.device_table = CustomTable(self.table_frame, (column_headers + list(column_param_headers)), rows)
 
         button_frame = Frame(self.parent)
         button_frame.grid(column=0, row=2, sticky="w")
@@ -272,7 +272,7 @@ class MeasurementSelection(Step):
 
         # create table
         rows = [(0, meas) for meas in sorted(list(self._measurement_names))]
-        self.meas_table = CustomTable(frame, columns=["Order", "Name"], rows=rows)
+        self.meas_table = CustomTable(frame, column_headers=["Order", "Name"], rows=rows)
         tree = self.meas_table.get_tree()
         for idx, iid in enumerate(tree.get_children()):
             tree.item(iid, tags=(str(idx)))
@@ -464,7 +464,7 @@ class ParameterSweep(Step):
 
             sweep_frame.deserialize(data.get(measurement.name, {}))
 
-            sweep_frame.pack(padx=5, pady=10, side=TOP, fill='x', expand=False)
+            sweep_frame.pack(padx=5, pady=10, side="top", fill='x', expand=False)
 
             self.frames.append((measurement, sweep_frame))
 

--- a/LabExT/View/ExperimentWizard.py
+++ b/LabExT/View/ExperimentWizard.py
@@ -9,12 +9,13 @@ import logging
 import os.path
 
 from typing import TYPE_CHECKING, Union, List
-from tkinter import Frame, Label, Button, messagebox
+from tkinter import Frame, Label, Button, messagebox, StringVar
 
 from LabExT.Experiments.ToDo import ToDo
 from LabExT.Utils import get_configuration_file_path, get_visa_address
 from LabExT.View.Controls.CustomTable import CustomTable
 from LabExT.View.Controls.CustomFrame import CustomFrame
+from LabExT.View.Controls.DataFrameTable import DataFrameTable
 from LabExT.View.Controls.InstrumentSelector import InstrumentSelector, InstrumentRole
 from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.View.Controls.SweepParameterFrame import SweepParameterFrame
@@ -138,17 +139,21 @@ class MultiDeviceTable(Frame):
         self._counter_all = 0
         self._counter_selected = 0
 
-        self.__setup__()
+        self._contains_string = StringVar(value="")
 
-    def __setup__(self):
+        self._build_ui()
+
+    def _build_ui(self):
         """Set up the custom table containing all devices from the chip."""
 
         # set up columns so that they contain all parameters
         column_headers = ["#", "Selection", "ID", "In", "Out", "Type"]
-        column_param_headers = set()
+        additional_param_headers = set()
         for device in self.chip.devices.values():
             for param_name in device.parameters:
-                column_param_headers.add(str(param_name))
+                additional_param_headers.add(str(param_name))
+
+        column_headers = (column_headers + list(additional_param_headers))
 
         saved_ids = self.deserialize_to_list()
         rows: List[tuple] = []
@@ -158,7 +163,7 @@ class MultiDeviceTable(Frame):
                 saved_ids.remove(dev.id)
             else:
                 row_values = (idx + 1, self.UNMARKED, dev.id, dev.in_position, dev.out_position, dev.type)
-            row_values = (*row_values, *[dev.parameters.get(param, "") for param in column_param_headers])
+            row_values = (*row_values, *[dev.parameters.get(param, "") for param in additional_param_headers])
             rows.append(row_values)
 
         Label(self.parent, text="Highlight one or more rows, then press mark to select these devices").grid(
@@ -171,7 +176,11 @@ class MultiDeviceTable(Frame):
         self.parent.grid_rowconfigure(1, weight=1)
         self.parent.grid_columnconfigure(0, weight=1)
 
-        self.device_table = CustomTable(self.table_frame, (column_headers + list(column_param_headers)), rows)
+        self.device_table = DataFrameTable(
+            parent=self.table_frame,
+            column_headers=column_headers,
+            rows=rows
+        )
 
         button_frame = Frame(self.parent)
         button_frame.grid(column=0, row=2, sticky="w")
@@ -184,54 +193,53 @@ class MultiDeviceTable(Frame):
         Button(button_frame, text="(un)mark all", command=self.mark_all).grid(
             row=0, column=2, padx=5, sticky="w"
         )
+        Button(button_frame, text="ID contains", command=self.filter_ids_contain).grid(
+            row=0, column=3, padx=5, sticky="w"
+        )
+        Label(button_frame, textvariable=self._contains_string).grid(
+            row=5, column=4, padx=5, sticky="w"
+        )
 
         Label(self.parent, text="The selected devices will be sorted by the original index.").grid(
             row=2, column=0, padx=5, pady=5, sticky="e"
         )
 
+    def filter_ids_contain(self) -> None:
+        ...
+
     def mark_items_by_ids(self, ids: list[str]) -> None:
         if not ids:
             return
-        copied_ids = ids[:]
-        tree = self.device_table.get_tree()
-        for iid in tree.get_children():
-            current_id = str(tree.set(iid, column=2))
-            if current_id not in ids:
-                continue
-            if tree.set(iid, column=1) == self.UNMARKED:
-                tree.set(iid, column=1, value=self.MARKED)
-            else:
-                tree.set(iid, column=1, value=self.UNMARKED)
-            copied_ids.remove(current_id)
-            if not copied_ids:
-                break
+        df = self.device_table.get_df()
+        df.loc[df["ID"].isin(ids), "Selection"] = self.MARKED
+        self.device_table.update_df(df)
 
     def mark_selected_items(self) -> None:
-        """Mark the currently selected rows."""
-        tree = self.device_table.get_tree()
-        for iid in tree.selection():
-            tree.set(iid, column=1, value=self.MARKED)
+        row_indices = self.device_table.get_selected_row_indices()
+        df = self.device_table.get_df()
+        df.loc[row_indices, "Selection"] = self.MARKED
+        self.device_table.update_df(df)
 
     def unmark_selected_items(self) -> None:
-        """Unmark the currently selected rows."""
-        tree = self.device_table.get_tree()
-        for iid in tree.selection():
-            tree.set(iid, column=1, value=self.UNMARKED)
-
-    def _mark_selected_items(self) -> None:
-        """Mark or un-mark the currently selected rows."""
-        tree = self.device_table.get_tree()
-        for iid in tree.selection():
-            if tree.set(iid, column=1) == self.UNMARKED:
-                tree.set(iid, column=1, value=self.MARKED)
-            else:
-                tree.set(iid, column=1, value=self.UNMARKED)
+        row_indices = self.device_table.get_selected_row_indices()
+        df = self.device_table.get_df()
+        df.loc[row_indices, "Selection"] = self.UNMARKED
+        self.device_table.update_df(df)
 
     def mark_all(self) -> None:
-        tree = self.device_table.get_tree()
-        value_to_set = self.MARKED if (self._counter_all % 2 == 0) else self.UNMARKED
-        [tree.set(iid, column=1, value=value_to_set) for iid in tree.get_children()]
+        value_to_set = self.MARKED if not self._counter_all % 2 else self.UNMARKED
+        df = self.device_table.get_df()
+        df["Selection"] = value_to_set
+        self.device_table.update_df(df)
         self._counter_all += 1
+
+    def get_marked_device_ids(self) -> list[str]:
+        df = self.device_table.get_df()
+        marked_ids = df[df["Selection"] == self.MARKED]["ID"].tolist()
+        return marked_ids
+
+    def get_marked_devices(self) -> list[Device]:
+        return [self.chip.devices[dev_id] for dev_id in self.get_marked_device_ids()]
 
     def deserialize_to_list(self) -> list[str]:
         if not os.path.exists(self.SETTINGS_PATH):
@@ -243,16 +251,6 @@ class MultiDeviceTable(Frame):
     def serialize(self) -> None:
         with open(self.SETTINGS_PATH, "w") as f:
             json.dump(self.get_marked_device_ids(), f)
-
-    def get_marked_device_ids(self) -> list[str]:
-        """Return a list of ids from the marked devices sorted according to the original index."""
-        tree = self.device_table.get_tree()
-        marked_iid = [iid for iid in tree.get_children() if tree.set(iid, column=1) == self.MARKED]
-        device_ids = [tree.set(iid, column=2) for iid in marked_iid]
-        return [_id for _, _id in sorted(zip(marked_iid, device_ids))]
-
-    def get_marked_devices(self) -> list[Device]:
-        return [self.chip.devices[dev_id] for dev_id in self.get_marked_device_ids()]
 
 
 class MeasurementSelection(Step):

--- a/LabExT/View/ExperimentWizard.py
+++ b/LabExT/View/ExperimentWizard.py
@@ -9,7 +9,8 @@ import logging
 import os.path
 
 from typing import TYPE_CHECKING, Union, List
-from tkinter import Frame, Label, Button, messagebox, StringVar, Entry
+from tkinter import Frame, Label, Button, messagebox, StringVar
+from tkinter.ttk import OptionMenu
 
 from LabExT.Experiments.ToDo import ToDo
 from LabExT.Utils import get_configuration_file_path, get_visa_address
@@ -18,6 +19,7 @@ from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.DataFrameTable import DataFrameTable
 from LabExT.View.Controls.InstrumentSelector import InstrumentSelector, InstrumentRole
 from LabExT.View.Controls.ParameterTable import ParameterTable
+from LabExT.View.Controls.PlaceholderEntry import PlaceholderEntry
 from LabExT.View.Controls.SweepParameterFrame import SweepParameterFrame
 from LabExT.View.Controls.Wizard import Wizard, Step
 from LabExT.View.TooltipMenu import CreateToolTip
@@ -106,11 +108,11 @@ class DeviceSelection(Step):
         super().__init__(wizard=wizard, builder=self.build, title="Device Selection", on_next=self._on_next)
         self.exp_manager = exp_manager
 
-        self.device_table: Union[MultiDeviceTable, None] = None
+        self.device_table: Union[DeviceTableFrame, None] = None
 
     def build(self, frame: Frame):
         frame.title = "Select Devices"
-        self.device_table = MultiDeviceTable(frame, self.exp_manager.chip)
+        self.device_table = DeviceTableFrame(frame, self.exp_manager.chip)
 
     def _on_next(self) -> bool:
         marked_devices = self.device_table.get_marked_devices()
@@ -122,7 +124,7 @@ class DeviceSelection(Step):
         return True
 
 
-class MultiDeviceTable(Frame):
+class DeviceTableFrame(Frame):
     """Shows a table with all devices of the current chip and lets the user select devices."""
 
     SETTINGS_PATH = get_configuration_file_path("device_selection.json")
@@ -139,7 +141,8 @@ class MultiDeviceTable(Frame):
         self._counter_all = 0
         self._counter_selected = 0
 
-        self._contains_string = StringVar(value="")
+        self._search_string = StringVar(value="")
+        self._selected_column = StringVar(value="ID")
 
         self._build_ui()
 
@@ -147,7 +150,7 @@ class MultiDeviceTable(Frame):
         """Set up the custom table containing all devices from the chip."""
 
         # set up columns so that they contain all parameters
-        column_headers = ["#", "Selection", "ID", "In", "Out", "Type"]
+        column_headers = ["Index", "Selection", "ID", "In", "Out", "Type"]
         additional_param_headers = set()
         for device in self.chip.devices.values():
             for param_name in device.parameters:
@@ -193,20 +196,23 @@ class MultiDeviceTable(Frame):
         Button(button_frame, text="(un)mark all", command=self.mark_all).grid(
             row=0, column=2, padx=5, sticky="w"
         )
-        Button(button_frame, text="filter ID (contains)", command=self.filter_ids_contain).grid(
+        OptionMenu(button_frame, self._selected_column, "ID", *column_headers).grid(
             row=0, column=3, padx=5, sticky="w"
         )
-        Entry(button_frame, textvariable=self._contains_string).grid(
-            row=1, column=3, padx=5, sticky="w"
+        PlaceholderEntry(button_frame, textvariable=self._search_string, placeholder="contains").grid(
+            row=0, column=4, padx=5, sticky="w"
+        )
+        Button(button_frame, text="filter", command=self.filter_contains).grid(
+            row=0, column=5, padx=5, sticky="w"
         )
 
         Label(self.parent, text="The selected devices will be sorted by the original index.").grid(
             row=2, column=0, padx=5, pady=5, sticky="e"
         )
 
-    def filter_ids_contain(self) -> None:
+    def filter_contains(self) -> None:
         df = self.device_table.get_full_df()
-        df = df[df["ID"].str.contains(self._contains_string.get())]
+        df = df[df[self._selected_column.get()].str.contains(self._search_string.get())]
         self.device_table.update_df(df)
 
     def mark_items_by_ids(self, ids: list[str]) -> None:

--- a/LabExT/View/InstrumentConnectionDebugger.py
+++ b/LabExT/View/InstrumentConnectionDebugger.py
@@ -94,7 +94,7 @@ class InstrumentConnectionDebugger:
         avail_instr_frame.rowconfigure(0, weight=1)
 
         self.instr_cfg_table = CustomTable(parent=avail_instr_frame,
-                                           columns=('Instrument type', 'at VISA address', 'used class'),
+                                           column_headers=('Instrument type', 'at VISA address', 'used class'),
                                            rows=self._get_available_instr_cfg(),
                                            selectmode='browse')  # custom table inserts itself into the parent frame
 

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -445,7 +445,7 @@ class StageAssignmentStep(Step):
         CustomTable(
             parent=available_stages_frame,
             selectmode='none',
-            columns=(
+            column_headers=(
                 'ID', 'Description', 'Stage Class', 'Address', 'Connected'
             ),
             rows=[
@@ -1018,7 +1018,7 @@ class CoordinatePairingStep(Step):
         self._coordinate_pairing_table = CustomTable(
             parent=pairings_table_frame,
             selectmode='extended',
-            columns=(
+            column_headers=(
                 'ID',
                 'Stage',
                 'Stage Cooridnate',


### PR DESCRIPTION
This PR adds the possibility to filter the device table so that only rows / devices are shown that contain a given search string.

<img width="1102" height="732" alt="Screenshot 2026-01-06 105816" src="https://github.com/user-attachments/assets/12affb23-1dce-44c7-9629-85efb674df03" />

In the _Multi-Device Multi-Measurement Experiment_ the user first has to choose the devices to perform the measurements on. This can be a tedious process when chip manifests are loaded with a large number of devices of various types. 
The user can now filter the shown devices by selecting a search string that should be contained within the defined column value. In the image above, the table is filtered to only show devices that contain _cutback#3_ in their _Type_ value. The user can then mark the selected devices of the filtered table. This filtering can be done multiple times until all the wanted rows are marked.

What is happening in the back?

- `DataFrameTable` replaces `CustomTable`
The `DataFrameTable` is a UI element that is based on and representation of a pandas DataFrame. This makes it very intuitive and easy to work with and allows features like filtering and other data processing routines.

- `CustomTable` has seen some small refactoring and type hinting.
(Actually this is not used in the end, yet still useful)

- The `Wizard` and `ExperimentWizard` saw small refactorings but mostly type hinting.

- `PlaceholderEntry` is a custom version of the tkinter Entry widget that in addition has a greyed-out placeholder value when nothing is written in the entry field.

