### PR TITLE
Type Cleanup in Movement

### DIFF
--- a/LabExT/ExperimentManager.py
+++ b/LabExT/ExperimentManager.py
@@ -76,8 +76,7 @@ class ExperimentManager:
         self.addon_settings = None
         self.chip = chip
         self.mover = MoverNew(experiment_manager=self, chip=chip)
-        self.peak_searcher = PeakSearcher(
-            None, self, mover=self.mover, parent=self.root)
+        self.peak_searcher = PeakSearcher(None, self, mover=self.mover)
         self.live_viewer_model: LiveViewerModel = None
         self.instrument_api = InstrumentAPI(self)
         self.chip_source_api = ChipSourceAPI(self)

--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -267,7 +267,7 @@ class StandardExperiment:
 
             # only move if automatic movement is enabled
             if self.exctrl_auto_move_stages:
-                self._mover.move_to_device(self._chip, device)
+                self._mover.move_to_device(device)
                 self.logger.info("Automatically moved to device:" + str(device))
 
             # execute automatic search for peak

--- a/LabExT/Experiments/StandardExperiment.py
+++ b/LabExT/Experiments/StandardExperiment.py
@@ -18,7 +18,7 @@ from os import rename, makedirs
 from os.path import dirname, join
 from pathlib import Path
 from tkinter import Tk, messagebox
-from typing import TYPE_CHECKING, Type, List, Tuple, Union
+from typing import TYPE_CHECKING, Type, List, Tuple, Union, Optional
 
 from LabExT.Experiments.AutosaveDict import AutosaveDict
 from LabExT.Measurements.MeasAPI.Measurement import Measurement
@@ -57,7 +57,7 @@ class StandardExperiment:
     output data dictionary."""
 
     def __init__(
-        self, experiment_manager: ExperimentManager, parent: Tk, chip: Chip, mover: Union[Type[MoverNew], None] = None
+        self, experiment_manager: ExperimentManager, parent: Tk, chip: Chip, mover: Optional[MoverNew] = None
     ):
         self.logger = logging.getLogger()
 
@@ -66,7 +66,7 @@ class StandardExperiment:
         self._parent = parent
 
         # stage mover class, used to move to device in automated sweeps
-        self._mover: Type[MoverNew] = mover
+        self._mover = mover
         # peak server, used to SfP in automated sweeps
         self._peak_searcher = experiment_manager.peak_searcher
 

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -7,7 +7,7 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, Type, Union, Optional, Protocol
+from typing import TYPE_CHECKING, Type, Union, Optional, Callable
 from functools import wraps
 from contextlib import contextmanager
 from time import sleep
@@ -23,11 +23,6 @@ from LabExT.Movement.Polygons import StagePolygon, SingleModeFiber
 if TYPE_CHECKING:
     from LabExT.Movement.Stage import Stage
     from LabExT.Wafer.Chip import Chip
-
-
-class MoverProtocol(Protocol):
-    def update_main_model(self) -> None:
-        ...
 
 
 class CalibrationError(RuntimeError):
@@ -85,25 +80,25 @@ class Calibration:
 
     @classmethod
     def load(
-        cls: Type[Calibration],
-        mover: MoverProtocol,
-        stage: Stage,
-        calibration_data: dict,
-        chip: Optional[Chip] = None
+            cls: Type[Calibration],
+            stage: Stage,
+            calibration_data: dict,
+            chip: Optional[Chip] = None,
+            on_update: Optional[Callable] = None
     ) -> Calibration:
         """
         Creates a new calibration based on calibration data.
 
         Parameters
         ----------
-        mover : Mover
-            Instance of mover associated with this calibration.
         stage : Stage
             Instance of a stage
         calibration_data : dict
             Dumped calibration data
         chip : Chip
             Instance of Chip
+        on_update : Callable
+
 
         Returns
         -------
@@ -141,27 +136,27 @@ class Calibration:
             stage_polygon = StagePolygon.load(calibration_data["stage_polygon"])
 
         return cls(
-            mover,
             stage,
             orientation=orientation,
             device_port=device_port,
             stage_polygon=stage_polygon,
             axes_rotation=axes_rotation,
             single_point_offset=single_point_offset,
-            kabsch_rotation=kabsch_rotation)
+            kabsch_rotation=kabsch_rotation,
+            on_update=on_update
+        )
 
     def __init__(
-        self,
-        mover: MoverProtocol,
-        stage: Stage,
-        orientation: Orientation,
-        device_port: DevicePort,
-        stage_polygon: Optional[StagePolygon] = None,
-        axes_rotation: Optional[AxesRotation] = None,
-        single_point_offset: Optional[SinglePointOffset] = None,
-        kabsch_rotation: Optional[KabschRotation] = None
+            self,
+            stage: Stage,
+            orientation: Orientation,
+            device_port: DevicePort,
+            stage_polygon: Optional[StagePolygon] = None,
+            axes_rotation: Optional[AxesRotation] = None,
+            single_point_offset: Optional[SinglePointOffset] = None,
+            kabsch_rotation: Optional[KabschRotation] = None,
+            on_update: Optional[Callable] = None
     ) -> None:
-        self.mover = mover
         self.stage = stage
 
         self._orientation = orientation
@@ -176,6 +171,8 @@ class Calibration:
         self._single_point_offset = SinglePointOffset(self._axes_rotation) if single_point_offset is None else single_point_offset
         self._kabsch_rotation = KabschRotation(self._axes_rotation) if kabsch_rotation is None else kabsch_rotation
 
+        self._on_update = on_update
+
         assert self._single_point_offset.axes_rotation == self._axes_rotation, \
             "Axes rotation for single point offset must be the same than for the calibration."
         assert self._kabsch_rotation.axes_rotation == self._axes_rotation, \
@@ -183,7 +180,12 @@ class Calibration:
 
         self._state = State.UNINITIALIZED
         self.determine_state(skip_connection=False)
-        self.mover.update_main_model()
+
+        self.update()
+
+    def update(self) -> None:
+        if self._on_update is not None:
+            self._on_update()
 
     #
     #   Representation
@@ -308,7 +310,7 @@ class Calibration:
             self.stage.connect()
         finally:
             self.determine_state(skip_connection=False)
-            self.mover.update_main_model()
+            self.update()
 
     def disconnect_to_stage(self) -> None:
         """
@@ -318,7 +320,7 @@ class Calibration:
             self.stage.disconnect()
         finally:
             self.determine_state(skip_connection=False)
-            self.mover.update_main_model()
+            self.update()
 
     def update_axes_rotation(self, chip_axis: Axis, direction: Direction, stage_axis: Axis) -> None:
         """
@@ -340,7 +342,7 @@ class Calibration:
             self._axes_rotation.update(chip_axis, direction, stage_axis)
         finally:
             self.determine_state(skip_connection=True)
-            self.mover.update_main_model()
+            self.update()
 
     def update_single_point_offset(self, pairing: CoordinatePairing) -> None:
         """
@@ -356,7 +358,7 @@ class Calibration:
             self._single_point_offset.update(pairing)
         finally:
             self.determine_state(skip_connection=True)
-            self.mover.update_main_model()
+            self.update()
 
     def update_kabsch_rotation(self, pairing: CoordinatePairing) -> None:
         """
@@ -372,7 +374,7 @@ class Calibration:
             self._kabsch_rotation.update(pairing)
         finally:
             self.determine_state(skip_connection=True)
-            self.mover.update_main_model()
+            self.update()
 
     def reset_single_point_offset(self) -> None:
         """
@@ -380,7 +382,7 @@ class Calibration:
         """
         self._single_point_offset.initialize()
         self.determine_state(skip_connection=True)
-        self.mover.update_main_model()
+        self.update()
 
     def reset_kabsch_rotation(self) -> None:
         """
@@ -388,7 +390,7 @@ class Calibration:
         """
         self._kabsch_rotation.initialize()
         self.determine_state(skip_connection=True)
-        self.mover.update_main_model()
+        self.update()
 
     def determine_state(self, skip_connection: bool = False) -> None:
         """

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -244,6 +244,18 @@ class Calibration:
         """
         return self._is_lifted
 
+    @property
+    def single_point_offset(self) -> SinglePointOffset:
+        return self._single_point_offset
+
+    @property
+    def axes_rotation(self) -> AxesRotation:
+        return self._axes_rotation
+
+    @property
+    def kabsch_rotation(self) -> KabschRotation:
+        return self._kabsch_rotation
+
     #
     #   Coordinate System Control
     #

--- a/LabExT/Movement/Calibration.py
+++ b/LabExT/Movement/Calibration.py
@@ -7,22 +7,27 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, Type, Union
+from typing import TYPE_CHECKING, Type, Union, Optional, Protocol
 from functools import wraps
 from contextlib import contextmanager
 from time import sleep
 
 import numpy as np
 
+from LabExT.Movement.Coordinate import ChipCoordinate, StageCoordinate
 from LabExT.Movement.config import DevicePort, Orientation, State, Axis, Direction, CoordinateSystem
-from LabExT.Movement.Transformations import StageCoordinate, ChipCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
+from LabExT.Movement.Transformations import CoordinatePairing, SinglePointOffset, AxesRotation, KabschRotation
 from LabExT.Movement.Stage import StageError
-from LabExT.Movement.PathPlanning import StagePolygon, SingleModeFiber
+from LabExT.Movement.Polygons import StagePolygon, SingleModeFiber
 
 if TYPE_CHECKING:
     from LabExT.Movement.Stage import Stage
-    from LabExT.Movement.MoverNew import MoverNew
     from LabExT.Wafer.Chip import Chip
+
+
+class MoverProtocol(Protocol):
+    def update_main_model(self) -> None:
+        ...
 
 
 class CalibrationError(RuntimeError):
@@ -45,33 +50,26 @@ def assert_minimum_state_for_coordinate_system(
     """
     def assert_state(func):
         @wraps(func)
-        def wrap(calibration: Type["Calibration"], *args, **kwargs):
+        def wrap(calibration: Type[Calibration], *args, **kwargs):
             if calibration.coordinate_system == CoordinateSystem.UNKNOWN:
-                raise CalibrationError(
-                    "Function {} needs a cooridnate system to operate in. Please use the context to set the system.".format(
-                        func.__name__))
+                raise CalibrationError(f"Function {func.__name__} needs a coordinate system to operate in. "
+                                       f"Please use the context to set the system.")
 
             if calibration.coordinate_system == CoordinateSystem.CHIP:
                 if chip_coordinate_system is None:
-                    raise CalibrationError(
-                        "Function {} does not support the chip coordinate system.".format(
-                            func.__name__))
+                    raise CalibrationError(f"Function {func.__name__} does not support the chip coordinate system.")
 
                 if calibration.state < chip_coordinate_system:
-                    raise CalibrationError(
-                        "Function {} needs at least a calibration state of {} to operate in chip coordinate system".format(
-                            func.__name__, chip_coordinate_system))
+                    raise CalibrationError(f"Function {func.__name__} needs at least a calibration state of "
+                                           f"{chip_coordinate_system} to operate in chip coordinate system")
 
             if calibration.coordinate_system == CoordinateSystem.STAGE:
                 if stage_coordinate_system is None:
-                    raise CalibrationError(
-                        "Function {} does not support the stage coordinate system.".format(
-                            func.__name__))
+                    raise CalibrationError(f"Function {func.__name__} does not support the stage coordinate system.")
 
                 if calibration.state < stage_coordinate_system:
-                    raise CalibrationError(
-                        "Function {} needs at least a calibration state of {} to operate in stage coordinate system".format(
-                            func.__name__, stage_coordinate_system))
+                    raise CalibrationError(f"Function {func.__name__} needs at least a calibration state of "
+                                           f"{stage_coordinate_system} to operate in stage coordinate system")
 
             return func(calibration, *args, **kwargs)
         return wrap
@@ -87,12 +85,12 @@ class Calibration:
 
     @classmethod
     def load(
-        cls,
-        mover: Type[MoverNew],
-        stage: Type[Stage],
+        cls: Type[Calibration],
+        mover: MoverProtocol,
+        stage: Stage,
         calibration_data: dict,
-        chip: Type[Chip] = None
-    ) -> Type[Calibration]:
+        chip: Optional[Chip] = None
+    ) -> Calibration:
         """
         Creates a new calibration based on calibration data.
 
@@ -104,6 +102,8 @@ class Calibration:
             Instance of a stage
         calibration_data : dict
             Dumped calibration data
+        chip : Chip
+            Instance of Chip
 
         Returns
         -------
@@ -113,38 +113,32 @@ class Calibration:
         try:
             orientation = Orientation[calibration_data["orientation"]]
             device_port = DevicePort[calibration_data["device_port"]]
-        except KeyError as err:
-            raise CalibrationError(
-                f"The parameter is not defined: {err}. "
-                "Make sure to pass a valid orientation and device port.")
+        except KeyError as e:
+            raise CalibrationError(f"Parameter not defined: {e}. Make sure to pass a valid orientation and device port.")
 
-        axes_rotation = None
+        axes_rotation: Optional[AxesRotation] = None
         if "axes_rotation" in calibration_data:
-            axes_rotation = AxesRotation.load(
-                calibration_data["axes_rotation"])
+            axes_rotation = AxesRotation.load(calibration_data["axes_rotation"])
 
-        single_point_offset = None
+        single_point_offset: Optional[SinglePointOffset] = None
         if "single_point_offset" in calibration_data:
             if axes_rotation is not None and chip is not None:
                 single_point_offset = SinglePointOffset.load(
                     calibration_data["single_point_offset"], chip=chip, axes_rotation=axes_rotation)
             else:
-                cls._logger.debug(
-                    "Cannot set single point offset when axes rotation or chip is not defined")
+                cls._logger.debug("Cannot set single point offset when axes rotation or chip is not defined")
 
-        kabsch_rotation = None
+        kabsch_rotation: Optional[KabschRotation] = None
         if "kabsch_rotation" in calibration_data:
             if axes_rotation is not None and chip is not None:
                 kabsch_rotation = KabschRotation.load(
                     calibration_data["kabsch_rotation"], chip=chip, axes_rotation=axes_rotation)
             else:
-                cls._logger.debug(
-                    "Cannot set kabsch rotation when axes rotation or chip is not defined")
+                cls._logger.debug("Cannot set kabsch rotation when axes rotation or chip is not defined")
 
         stage_polygon = None
         if "stage_polygon" in calibration_data:
-            stage_polygon = StagePolygon.load(
-                calibration_data["stage_polygon"])
+            stage_polygon = StagePolygon.load(calibration_data["stage_polygon"])
 
         return cls(
             mover,
@@ -158,17 +152,17 @@ class Calibration:
 
     def __init__(
         self,
-        mover: Type[MoverNew],
-        stage: Type[Stage],
+        mover: MoverProtocol,
+        stage: Stage,
         orientation: Orientation,
         device_port: DevicePort,
-        stage_polygon: Type[StagePolygon] = None,
-        axes_rotation: Type[AxesRotation] = None,
-        single_point_offset: Type[SinglePointOffset] = None,
-        kabsch_rotation: Type[KabschRotation] = None
+        stage_polygon: Optional[StagePolygon] = None,
+        axes_rotation: Optional[AxesRotation] = None,
+        single_point_offset: Optional[SinglePointOffset] = None,
+        kabsch_rotation: Optional[KabschRotation] = None
     ) -> None:
         self.mover = mover
-        self.stage: Type[Stage] = stage
+        self.stage = stage
 
         self._orientation = orientation
         self._device_port = device_port
@@ -177,24 +171,15 @@ class Calibration:
 
         self._is_lifted = False
 
-        self.stage_polygon = stage_polygon
-        if stage_polygon is None:
-            self.stage_polygon = SingleModeFiber(orientation)
+        self.stage_polygon = SingleModeFiber(orientation) if stage_polygon is None else stage_polygon
+        self._axes_rotation = AxesRotation() if axes_rotation is None else axes_rotation
+        self._single_point_offset = SinglePointOffset(self._axes_rotation) if single_point_offset is None else single_point_offset
+        self._kabsch_rotation = KabschRotation(self._axes_rotation) if kabsch_rotation is None else kabsch_rotation
 
-        self._axes_rotation = axes_rotation
-        if axes_rotation is None:
-            self._axes_rotation = AxesRotation()
-
-        self._single_point_offset = single_point_offset
-        if single_point_offset is None:
-            self._single_point_offset = SinglePointOffset(self._axes_rotation)
-
-        self._kabsch_rotation = kabsch_rotation
-        if kabsch_rotation is None:
-            self._kabsch_rotation = KabschRotation(self._axes_rotation)
-
-        assert self._single_point_offset.axes_rotation == self._axes_rotation, "Axes rotation for single point offset must be the same than for the calibration."
-        assert self._kabsch_rotation.axes_rotation == self._axes_rotation, "Axes rotation for kabsch rotation must be the same than for the calibration"
+        assert self._single_point_offset.axes_rotation == self._axes_rotation, \
+            "Axes rotation for single point offset must be the same than for the calibration."
+        assert self._kabsch_rotation.axes_rotation == self._axes_rotation, \
+            "Axes rotation for kabsch rotation must be the same than for the calibration"
 
         self._state = State.UNINITIALIZED
         self.determine_state(skip_connection=False)
@@ -205,12 +190,11 @@ class Calibration:
     #
 
     def __str__(self) -> str:
-        return "{} Stage ({})".format(str(self.orientation), str(self.stage))
+        return f"{str(self.orientation)} Stage ({str(self.stage)})"
 
     @property
     def short_str(self) -> str:
-        return "{} Stage ({})".format(
-            str(self.orientation), str(self._device_port))
+        return f"{str(self.orientation)} Stage ({str(self._device_port)})"
 
     #
     #   Properties
@@ -231,14 +215,21 @@ class Calibration:
         return self._orientation
 
     @property
-    def is_input_stage(self):
+    def device_port(self) -> DevicePort:
+        """
+        Returns the device port: Input or Output
+        """
+        return self._device_port
+
+    @property
+    def is_input_stage(self) -> bool:
         """
         Returns True if the stage will move to the input of a device.
         """
         return self._device_port == DevicePort.INPUT
 
     @property
-    def is_output_stage(self):
+    def is_output_stage(self) -> bool:
         """
         Returns True if the stage will move to the output of a device.
         """
@@ -276,10 +267,7 @@ class Calibration:
         """
         return self.coordinate_system == CoordinateSystem.STAGE
 
-    def set_coordinate_system(
-        self,
-        system: CoordinateSystem
-    ) -> None:
+    def set_coordinate_system(self, system: CoordinateSystem) -> None:
         """
         Sets the current coordinate system
 
@@ -289,19 +277,15 @@ class Calibration:
             If the requested system is not supported.
         """
         if not isinstance(system, CoordinateSystem):
-            raise ValueError(
-                f"Requested coordinate system {system} for {self} is invalid.")
-
-        self._logger.debug(
-            f"Set coordinate system for {self} to {system}")
+            raise ValueError(f"Requested coordinate system {system} for {self} is invalid.")
 
         self._coordinate_system = system
+        self._logger.debug(f"Set coordinate system for {self} to {system}")
 
     @contextmanager
     def perform_in_system(self, system: CoordinateSystem):
         """
         Context manager to execute a block of instructions in requested coordinates.
-
         Resets the system at the end.
         """
         prior_coordinate_system = self.coordinate_system
@@ -336,11 +320,7 @@ class Calibration:
             self.determine_state(skip_connection=False)
             self.mover.update_main_model()
 
-    def update_axes_rotation(
-            self,
-            chip_axis: Axis,
-            direction: Direction,
-            stage_axis: Axis) -> None:
+    def update_axes_rotation(self, chip_axis: Axis, direction: Direction, stage_axis: Axis) -> None:
         """
         Updates the axis rotation of the calibration.
         After the update, the state of the calibration is recalculated.
@@ -362,8 +342,7 @@ class Calibration:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
 
-    def update_single_point_offset(
-            self, pairing: Type[CoordinatePairing]) -> None:
+    def update_single_point_offset(self, pairing: CoordinatePairing) -> None:
         """
         Updates the single point offset transformation of the calibration.
         After the update, the state of the calibration is recalculated.
@@ -379,7 +358,7 @@ class Calibration:
             self.determine_state(skip_connection=True)
             self.mover.update_main_model()
 
-    def update_kabsch_rotation(self, pairing: Type[CoordinatePairing]) -> None:
+    def update_kabsch_rotation(self, pairing: CoordinatePairing) -> None:
         """
         Updates the kabsch transformation of the calibration.
         After the update, the state of the calibration is recalculated.
@@ -411,7 +390,7 @@ class Calibration:
         self.determine_state(skip_connection=True)
         self.mover.update_main_model()
 
-    def determine_state(self, skip_connection=False) -> None:
+    def determine_state(self, skip_connection: bool = False) -> None:
         """
         Determines the status of the calibration independently of the status variables of the instance.
         1. Checks whether the stage responds. If yes, status is at least CONNECTED.
@@ -456,63 +435,29 @@ class Calibration:
     #   Coordinate translation
     #
 
-    def transform_chip_to_stage_coordinate(
-        self,
-        chip_coordinate: Type[ChipCoordinate]
-    ) -> Type[StageCoordinate]:
+    def transform_chip_to_stage_coordinate(self, chip_coordinate: ChipCoordinate) -> StageCoordinate:
         """
         Translates a chip coordinate into a stage coordinate.
         The single-point transformation or the Kabsch transformation is used based on the calibration state.
-        Parameters
-        ----------
-        chip_coordinate : ChipCoordinate
-            Coordinate in the chip system to be translated.
-        Returns
-        -------
-        stage_coordinate : StageCoordinate
-            Translated coordinate in the stage system.
-        Raises
-        ------
-        CalibrationError
-            If state is insufficient to translate the coordinate.
         """
         if self.state == State.FULLY_CALIBRATED:
-            return self._kabsch_rotation.chip_to_stage(
-                chip_coordinate)
+            return self._kabsch_rotation.chip_to_stage(chip_coordinate)
         elif self.state == State.SINGLE_POINT_FIXED:
-            return self._single_point_offset.chip_to_stage(
-                chip_coordinate)
+            return self._single_point_offset.chip_to_stage(chip_coordinate)
         else:
-            raise CalibrationError(
-                "Insufficient calibration state to transform coordinate in stage coordinates.")
+            raise CalibrationError("Insufficient calibration state to transform coordinate in stage coordinates.")
 
-    def transform_stage_to_chip_coordinate(
-        self,
-        stage_coordinate: Type[StageCoordinate]
-    ) -> Type[ChipCoordinate]:
+    def transform_stage_to_chip_coordinate(self, stage_coordinate: StageCoordinate) -> ChipCoordinate:
         """
         Translates a stage coordinate into a chip coordinate.
         The single-point transformation or the Kabsch transformation is used based on the calibration state.
-        Parameters
-        ----------
-        stage_coordinate : StageCoordinate
-            Coordinate in the stage system to be translated.
-        Returns
-        -------
-        chip_coordinate : ChipCoordinate
-            Translated coordinate in the chip system.
-        Raises
-        ------
-        CalibrationError
-            If state is insufficient to translate the coordinate.
         """
         if self.state == State.FULLY_CALIBRATED:
             return self._kabsch_rotation.stage_to_chip(stage_coordinate)
         elif self.state == State.SINGLE_POINT_FIXED:
             return self._single_point_offset.stage_to_chip(stage_coordinate)
         else:
-            raise CalibrationError(
-                "Insufficient calibration state to transform coordinate in chip coordinates.")
+            raise CalibrationError("Insufficient calibration state to transform coordinate in chip coordinates.")
 
     #
     #   Position method
@@ -521,8 +466,7 @@ class Calibration:
     @assert_minimum_state_for_coordinate_system(
         stage_coordinate_system=State.CONNECTED,
         chip_coordinate_system=State.SINGLE_POINT_FIXED)
-    def get_position(
-            self) -> Union[Type[StageCoordinate], Type[ChipCoordinate]]:
+    def get_position(self) -> Union[StageCoordinate, ChipCoordinate]:
         """
         Method to read out the current position of the stage.
         This method can display the position in stage and chip coordinates,
@@ -540,16 +484,15 @@ class Calibration:
         RuntimeError
             If coordinate system is unsupported.
         """
+
         stage_position = StageCoordinate.from_list(self.stage.get_position())
 
         if self.is_stage_coordinate_system_set:
             return stage_position
         elif self.is_chip_coordinate_system_set:
-            return self.transform_stage_to_chip_coordinate(
-                stage_coordinate=stage_position)
+            return self.transform_stage_to_chip_coordinate(stage_coordinate=stage_position)
         else:
-            RuntimeError(
-                f"Unsupported coordinate system {self.coordinate_system} to return the stage position")
+            raise RuntimeError(f"Unsupported coordinate system {self.coordinate_system} to return the stage position")
 
     #
     #   Movement methods
@@ -558,10 +501,7 @@ class Calibration:
     @assert_minimum_state_for_coordinate_system(
         stage_coordinate_system=State.CONNECTED,
         chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
-    def move_relative(self,
-                      offset: Union[Type[StageCoordinate],
-                                    Type[ChipCoordinate]],
-                      wait_for_stopping: bool = True) -> None:
+    def move_relative(self, offset: Union[StageCoordinate, ChipCoordinate], wait_for_stopping: bool = True) -> None:
         """
         Moves the stage relative in its coordinate system.
         The offset can be passed a stage or chip coordinate,
@@ -571,6 +511,8 @@ class Calibration:
         ----------
         offset: StageCoordinate | ChipCoordinate
             Relative offset in stage or chip coordinates.
+        wait_for_stopping : bool
+            When set to true, execution will stop until all movement has come to a halt.
 
         Raises
         ------
@@ -584,8 +526,7 @@ class Calibration:
         elif self.is_chip_coordinate_system_set:
             stage_offset = self._axes_rotation.chip_to_stage(offset)
         else:
-            RuntimeError(
-                f"Unsupported coordinate system {self.coordinate_system} to move the stage relatively.")
+            raise RuntimeError(f"Unsupported coordinate system {self.coordinate_system} to move the stage relatively.")
 
         self.stage.move_relative(
             x=stage_offset.x,
@@ -596,10 +537,7 @@ class Calibration:
     @assert_minimum_state_for_coordinate_system(
         stage_coordinate_system=State.CONNECTED,
         chip_coordinate_system=State.SINGLE_POINT_FIXED)
-    def move_absolute(self,
-                      coordinate: Union[Type[StageCoordinate],
-                                        Type[ChipCoordinate]],
-                      wait_for_stopping: bool = True) -> None:
+    def move_absolute(self, coordinate: Union[StageCoordinate, ChipCoordinate], wait_for_stopping: bool = True) -> None:
         """
         Moves the stage absolute to the given coordinate.
         The coordinate can be passed in stage or chip coordinates,
@@ -609,6 +547,8 @@ class Calibration:
         ----------
         coordinate: StageCoordinate | ChipCoordinate
             Coordinate offset in stage or chip coordinates.
+        wait_for_stopping : bool
+            When set to true, execution will stop until all movement has come to a halt.
 
         Raises
         ------
@@ -620,11 +560,9 @@ class Calibration:
         if self.is_stage_coordinate_system_set:
             stage_coordinate = coordinate
         elif self.is_chip_coordinate_system_set:
-            stage_coordinate = self.transform_chip_to_stage_coordinate(
-                chip_coordinate=coordinate)
+            stage_coordinate = self.transform_chip_to_stage_coordinate(chip_coordinate=coordinate)
         else:
-            RuntimeError(
-                f"Unsupported coordinate system {self.coordinate_system} to move the stage absolutely.")
+            raise RuntimeError(f"Unsupported coordinate system {self.coordinate_system} to move the stage absolutely.")
 
         self.stage.move_absolute(
             x=stage_coordinate.x,
@@ -636,7 +574,7 @@ class Calibration:
         """
         Lifts the stage absolutely or relatively.
         Lifts stage absolutely if calibration is fully calibrated.
-        Lifts stage relatively if calibration is single point fixex or coordinate system fixed.
+        Lifts stage relatively if calibration is single point fixed or coordinate system fixed.
         Parameters
         ----------
         z_lift: float
@@ -644,15 +582,14 @@ class Calibration:
         Raises
         ------
         CalibrationError
-            If stage cannot lifted in the current state.
+            If stage cannot be lifted in the current state.
         """
         if self.state == State.FULLY_CALIBRATED:
             self.lift_stage_absolute(z_lift)
         elif self.state == State.SINGLE_POINT_FIXED or self.state == State.COORDINATE_SYSTEM_FIXED:
             self.lift_stage_relative(z_lift)
         else:
-            raise CalibrationError(
-                f"Cannot lift stage {self}: Calibration must be at least in coordinate fixed state.")
+            raise CalibrationError(f"Cannot lift stage {self}: Calibration must be at least in coordinate fixed state.")
 
     def lower_stage(self, z_lift: float) -> None:
         """
@@ -666,18 +603,16 @@ class Calibration:
         Raises
         ------
         CalibrationError
-            If stage cannot lowered in the current state.
+            If stage cannot be lowered in the current state.
         """
         if self.state == State.FULLY_CALIBRATED:
             self.lower_stage_absolute()
         elif self.state == State.SINGLE_POINT_FIXED or self.state == State.COORDINATE_SYSTEM_FIXED:
             self.lower_stage_relative(z_lift)
         else:
-            raise CalibrationError(
-                f"Cannot lower stage {self}: Calibration must be at least in coordinate fixed state.")
+            raise CalibrationError(f"Cannot lower stage {self}: Calibration must be at least in coordinate fixed state.")
 
-    @assert_minimum_state_for_coordinate_system(
-        chip_coordinate_system=State.FULLY_CALIBRATED)
+    @assert_minimum_state_for_coordinate_system(chip_coordinate_system=State.FULLY_CALIBRATED)
     def lift_stage_absolute(self, z_lift: float) -> None:
         """
         Lifts the stage absolutely.
@@ -695,29 +630,24 @@ class Calibration:
             Amount in um to move the stage up.
         """
         if self.is_lifted:
-            self._logger.warn(
-                f"Stage {self} is already lifted. Skipping lift.")
+            self._logger.warning(f"Stage {self} is already lifted. Skipping lift.")
             return
 
-        self._logger.debug(
-            f"Lifting {self} to {z_lift} z-plane (um)")
+        self._logger.debug(f"Lifting {self} to {z_lift} z-plane (um)")
 
         with self.perform_in_system(CoordinateSystem.CHIP):
             current_chip_position = self.get_position()
             target_lift_coordinate = ChipCoordinate(
                 x=current_chip_position.x, y=current_chip_position.y, z=z_lift)
             try:
-                self.move_absolute(
-                    target_lift_coordinate,
-                    wait_for_stopping=True)
+                self.move_absolute(target_lift_coordinate, wait_for_stopping=True)
             except BaseException:
                 self._is_lifted = False
                 raise
 
             self._is_lifted = True
 
-    @assert_minimum_state_for_coordinate_system(
-        chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
+    @assert_minimum_state_for_coordinate_system(chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
     def lift_stage_relative(self, z_lift: float) -> None:
         """
         Lifts the stage relatively.
@@ -731,12 +661,10 @@ class Calibration:
             Amount in um to move the stage up.
         """
         if self.is_lifted:
-            self._logger.warn(
-                f"Stage {self} is already lifted. Skipping lift.")
+            self._logger.warning(f"Stage {self} is already lifted. Skipping lift.")
             return
 
-        self._logger.debug(
-            f"Lifting {self} relative up {z_lift} um")
+        self._logger.debug(f"Lifting {self} relative up {z_lift} um")
 
         with self.perform_in_system(CoordinateSystem.CHIP):
             target_offset = ChipCoordinate(x=0, y=0, z=z_lift)
@@ -748,8 +676,7 @@ class Calibration:
 
             self._is_lifted = True
 
-    @assert_minimum_state_for_coordinate_system(
-        chip_coordinate_system=State.FULLY_CALIBRATED)
+    @assert_minimum_state_for_coordinate_system(chip_coordinate_system=State.FULLY_CALIBRATED)
     def lower_stage_absolute(self) -> None:
         """
         Lowers the stage absolutely.
@@ -761,29 +688,23 @@ class Calibration:
         Does not lower the stage if the stage is in a lifted state.
         """
         if not self.is_lifted:
-            self._logger.warn(
-                f"Stage {self} is not lifted. Skipping lowering.")
+            self._logger.warning(f"Stage {self} is not lifted. Skipping lowering.")
             return
 
-        self._logger.debug(
-            f"Lowering {self} to zero z-plane.")
+        self._logger.debug(f"Lowering {self} to zero z-plane.")
 
         with self.perform_in_system(CoordinateSystem.CHIP):
             current_chip_position = self.get_position()
-            target_lower_coordinate = ChipCoordinate(
-                x=current_chip_position.x, y=current_chip_position.y, z=0)
+            target_lower_coordinate = ChipCoordinate(x=current_chip_position.x, y=current_chip_position.y, z=0)
             try:
-                self.move_absolute(
-                    target_lower_coordinate,
-                    wait_for_stopping=True)
+                self.move_absolute(target_lower_coordinate, wait_for_stopping=True)
             except BaseException:
                 self._is_lifted = True
                 raise
 
             self._is_lifted = False
 
-    @assert_minimum_state_for_coordinate_system(
-        chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
+    @assert_minimum_state_for_coordinate_system(chip_coordinate_system=State.COORDINATE_SYSTEM_FIXED)
     def lower_stage_relative(self, z_lift: float) -> None:
         """
         Lowers the stage relatively.
@@ -797,12 +718,10 @@ class Calibration:
             Amount in um to move the stage down.
         """
         if not self.is_lifted:
-            self._logger.warn(
-                f"Stage {self} is already lowered. Skipping lowering.")
+            self._logger.warning(f"Stage {self} is already lowered. Skipping lowering.")
             return
 
-        self._logger.debug(
-            f"Lowering {self} relative by {z_lift} um")
+        self._logger.debug(f"Lowering {self} relative by {z_lift} um")
 
         with self.perform_in_system(CoordinateSystem.CHIP):
             target_offset = ChipCoordinate(x=0, y=0, z=-z_lift)
@@ -819,7 +738,8 @@ class Calibration:
             wiggle_axis: Axis,
             wiggle_distance: float = 1e3,
             wiggle_speed: float = 1e3,
-            wait_time: float = 2) -> None:
+            wait_time: float = 2
+    ) -> None:
         """
         Wiggles an axis of the stage.
         Moves the axis first in a positive direction then in a negative direction.
@@ -843,8 +763,7 @@ class Calibration:
         self.stage.set_speed_xy(wiggle_speed)
         self.stage.set_speed_z(wiggle_speed)
 
-        wiggle_difference = np.array(
-            [wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
+        wiggle_difference = np.array([wiggle_distance if wiggle_axis == axis else 0 for axis in Axis])
 
         with self.perform_in_system(CoordinateSystem.CHIP):
             self.move_relative(ChipCoordinate.from_numpy(wiggle_difference))
@@ -867,20 +786,19 @@ class Calibration:
         calibration_dump = {
             "stage_identifier": self.stage.identifier,
             "orientation": self.orientation.value,
-            "device_port": self._device_port.value}
+            "device_port": self._device_port.value
+        }
 
         if axes_rotation and self._axes_rotation.is_valid:
             calibration_dump["axes_rotation"] = self._axes_rotation.dump()
 
         if single_point_offset and self._single_point_offset.is_valid:
-            calibration_dump["single_point_offset"] = self._single_point_offset.dump(
-            )
+            calibration_dump["single_point_offset"] = self._single_point_offset.dump()
 
         if kabsch_rotation and self._kabsch_rotation.is_valid:
             calibration_dump["kabsch_rotation"] = self._kabsch_rotation.dump()
 
         if stage_polygon and self.stage_polygon is not None:
-            calibration_dump["stage_polygon"] = self.stage_polygon.dump(
-                stringify=True)
+            calibration_dump["stage_polygon"] = self.stage_polygon.dump(stringify=True)
 
         return calibration_dump

--- a/LabExT/Movement/Coordinate.py
+++ b/LabExT/Movement/Coordinate.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY;
+for details see LICENSE file.
+"""
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar, Type
+
+import numpy as np
+from numpy.typing import NDArray
+
+CoordinateT = TypeVar("CoordinateT", bound="Coordinate")
+
+
+class Coordinate(ABC, Generic[CoordinateT]):
+    """
+    Abstract base class of a coordinate with X, Y and Z values.
+
+    The base class cannot be initialised directly.
+    """
+    @classmethod
+    def from_list(cls: Type[CoordinateT], _list: list) -> CoordinateT:
+        """
+        Returns a new coordinate, created from a list.
+        """
+        return cls(*_list[:3])
+
+    @classmethod
+    def from_numpy(cls: Type[CoordinateT], array: NDArray[np.float64]) -> CoordinateT:
+        """
+        Returns a new coordinate created from a one-dimensional numpy array.
+        """
+        if array.ndim != 1:
+            raise ValueError("The given array is not a 1D-Array.")
+
+        return cls(*array.tolist()[:3])
+
+    @abstractmethod
+    def __init__(self, x: float = 0, y: float = 0, z: float = 0) -> None:
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __str__(self) -> str:
+        return f"[{self.x:.2f}, {self.y:.2f}, {self.z:.2f}]"
+
+    def __add__(self, other: CoordinateT) -> CoordinateT:
+        """
+        Adds two coordinates. Returns a new coordinate of the same type.
+        Raises TypeError if both coordinates are not the same type.
+        """
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Invalid types: {type(self)} and {type(other)} cannot be added.")
+
+        return type(self).from_numpy(self.to_numpy() + other.to_numpy())
+
+    def __sub__(self, other: CoordinateT) -> CoordinateT:
+        """
+        Subtracts two coordinates. Returns a new coordinate of the same type.
+        Raises TypeError if both coordinates are not the same type.
+        """
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Invalid types: {type(self)} and {type(other)} cannot be added.")
+
+        return type(self).from_numpy(self.to_numpy() - other.to_numpy())
+
+    def __eq__(self, other: CoordinateT) -> bool:
+        """
+        Compares two coordinates.
+        Two coordinates are equal, if they are of the same type and all values are equal.
+        """
+        if not isinstance(other, type(self)):
+            return False
+
+        return other.x == self.x and other.y == self.y and other.z == self.z
+
+    def __mul__(self, scalar: float) -> CoordinateT:
+        """
+        Multiplies the coordinate by a scalar.
+        Returns a new coordinate of the same type.
+        """
+        return type(self).from_numpy(self.to_numpy() * scalar)
+
+    @property
+    def is_zero(self) -> bool:
+        """
+        Returns True if the coordinate is equal to [0,0,0]
+        """
+        return bool(np.all(self.to_numpy() == 0))
+
+    def to_list(self) -> list:
+        """
+        Returns the coordinate as a list.
+        """
+        return [self.x, self.y, self.z]
+
+    def to_numpy(self) -> NDArray[np.float64]:
+        """
+        Returns the coordinate as a numpy array.
+        """
+        return np.array(self.to_list())
+
+
+class StageCoordinate(Coordinate):
+    """
+    A Coordinate in the coordinate system of a stage.
+    """
+
+    def __init__(self, x: float = 0, y: float = 0, z: float = 0) -> None:
+        super().__init__(x, y, z)
+
+
+class ChipCoordinate(Coordinate):
+    """
+    A Coordinate in the coordinate system of a chip.
+    """
+
+    def __init__(self, x: float = 0, y: float = 0, z: float = 0) -> None:
+        super().__init__(x, y, z)

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -22,6 +22,7 @@ from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, Devic
 from LabExT.Movement.Stage import Stage
 from LabExT.Movement.Transformations import AxesRotation
 from LabExT.Movement.PathPlanning import PathPlanning, CollisionAvoidancePlanning, SingleStagePlanning
+from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.Polygons import StagePolygon
 
 from LabExT.Utils import get_configuration_file_path
@@ -31,7 +32,6 @@ from LabExT.Wafer.Device import Device
 
 if TYPE_CHECKING:
     from LabExT.ExperimentManager import ExperimentManager
-    from LabExT.Movement.Calibration import Calibration
 
 
 def assert_connected_stages(func):
@@ -347,8 +347,6 @@ class MoverNew:
 
         Returns new calibration instance.
         """
-        # lazy import to avoid circular import
-        from LabExT.Movement.Calibration import Calibration
 
         if not isinstance(port, DevicePort):
             raise ValueError("{} is an invalid port".format(port))
@@ -365,12 +363,12 @@ class MoverNew:
             raise MoverError(f"A stage has already been assigned for {orientation}.")
 
         calibration = Calibration(
-            mover=self,
             stage=stage,
             orientation=orientation,
             device_port=port,
             stage_polygon=stage_polygon,
-            axes_rotation=self.load_stored_axes_rotation_for_stage(stage=stage)
+            axes_rotation=self.load_stored_axes_rotation_for_stage(stage=stage),
+            on_update=self.update_main_model()
         )
 
         if stage in self.active_stages:
@@ -392,13 +390,11 @@ class MoverNew:
         """
         Restores a calibration for given stage and calibration data.
         """
-        # lazy import to avoid circular import
-        from LabExT.Movement.Calibration import Calibration
 
         if stage in self.active_stages:
             raise MoverError(f"Stage {stage} has already an assignment.")
 
-        calibration = Calibration.load(self, stage, calibration_data, self._chip)
+        calibration = Calibration.load(stage, calibration_data, self._chip, on_update=self.update_main_model())
         self._port_by_orientation.put(calibration.orientation, calibration.device_port, OnDup(key=RAISE))
         self._calibrations.put((calibration.orientation, calibration.device_port), calibration, OnDup(key=RAISE))
 

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -368,7 +368,7 @@ class MoverNew:
             device_port=port,
             stage_polygon=stage_polygon,
             axes_rotation=self.load_stored_axes_rotation_for_stage(stage=stage),
-            on_update=self.update_main_model()
+            on_update=self.update_main_model
         )
 
         if stage in self.active_stages:
@@ -394,7 +394,7 @@ class MoverNew:
         if stage in self.active_stages:
             raise MoverError(f"Stage {stage} has already an assignment.")
 
-        calibration = Calibration.load(stage, calibration_data, self._chip, on_update=self.update_main_model())
+        calibration = Calibration.load(stage, calibration_data, self._chip, on_update=self.update_main_model)
         self._port_by_orientation.put(calibration.orientation, calibration.device_port, OnDup(key=RAISE))
         self._calibrations.put((calibration.orientation, calibration.device_port), calibration, OnDup(key=RAISE))
 

--- a/LabExT/Movement/MoverNew.py
+++ b/LabExT/Movement/MoverNew.py
@@ -4,7 +4,7 @@
 LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
-
+from __future__ import annotations
 import json
 import os
 import logging
@@ -12,21 +12,26 @@ import logging
 from time import sleep, time
 from os.path import dirname, join
 from bidict import bidict, ValueDuplicationError, KeyDuplicationError, OnDup, RAISE
-from typing import Dict, Tuple, Type, List
+from typing import Dict, Tuple, List, Optional, TYPE_CHECKING
 from functools import wraps
 from datetime import datetime
 from contextlib import contextmanager
 
+from LabExT.Movement.Coordinate import ChipCoordinate
 from LabExT.Movement.config import CLOCKWISE_ORDERING, State, Orientation, DevicePort, CoordinateSystem
-from LabExT.Movement.Calibration import Calibration
-from LabExT.Movement.Stage import Stage, StageError
-from LabExT.Movement.Transformations import ChipCoordinate, AxesRotation
-from LabExT.Movement.PathPlanning import PathPlanning, CollisionAvoidancePlanning, SingleStagePlanning, StagePolygon
+from LabExT.Movement.Stage import Stage
+from LabExT.Movement.Transformations import AxesRotation
+from LabExT.Movement.PathPlanning import PathPlanning, CollisionAvoidancePlanning, SingleStagePlanning
+from LabExT.Movement.Polygons import StagePolygon
 
 from LabExT.Utils import get_configuration_file_path
 from LabExT.PluginLoader import PluginLoader
 from LabExT.Wafer.Chip import Chip
 from LabExT.Wafer.Device import Device
+
+if TYPE_CHECKING:
+    from LabExT.ExperimentManager import ExperimentManager
+    from LabExT.Movement.Calibration import Calibration
 
 
 def assert_connected_stages(func):
@@ -38,9 +43,8 @@ def assert_connected_stages(func):
     @wraps(func)
     def wrapper(mover, *args, **kwargs):
         if not mover.has_connected_stages:
-            raise MoverError(
-                "Function {} needs at least one connected stage. Please use the connection functions beforehand".format(
-                    func.__name__))
+            raise MoverError(f"Function {func.__name__} needs at least one connected stage. "
+                             f"Please use the connection functions beforehand")
 
         return func(mover, *args, **kwargs)
     return wrapper
@@ -56,7 +60,7 @@ class MoverNew:
     """
 
     # For range constants: See SmarAct Control Guide for more details.
-    # Both ranges are inclusive, e.g speed in [SPEED_LOWER_BOUND,
+    # Both ranges are inclusive, e.g. speed in [SPEED_LOWER_BOUND,
     # SPEED_UPPER_BOUND]
     SPEED_LOWER_BOUND = 0
     SPEED_UPPER_BOUND = 1e5
@@ -78,11 +82,7 @@ class MoverNew:
     CALIBRATIONS_SETTINGS_FILE = get_configuration_file_path(
         config_file_path_in_settings_dir="mover_calibrations.json")
 
-    def __init__(
-        self,
-        experiment_manager=None,
-        chip=None
-    ) -> None:
+    def __init__(self, experiment_manager: Optional[ExperimentManager] = None, chip: Optional[Chip] = None) -> None:
         """Constructor.
 
         Parameters
@@ -95,14 +95,14 @@ class MoverNew:
         self.logger = logging.getLogger()
 
         self.experiment_manager = experiment_manager
-        self._chip: Type[Chip] = chip
+        self._chip = chip
 
         # Stage classes plugin
         self._stage_classes: Dict[str, Stage] = {}
         self._plugin_loader = PluginLoader()
         self._plugin_loader_stats: Dict[str, int] = {}
         # Available Stages
-        self._available_stages: List[Type[Stage]] = []
+        self._available_stages: List[Stage] = []
 
         # Mover calibrations
         self._calibrations = bidict()
@@ -139,9 +139,9 @@ class MoverNew:
     #   Set chip
     #
 
-    def set_chip(self, chip: Type[Chip]) -> None:
+    def set_chip(self, chip: Chip) -> None:
         """
-        Sets the the current chip.
+        Sets the current chip.
         This method will reset single point offset and kabsch rotation.
         """
         if self._chip == chip:
@@ -169,10 +169,8 @@ class MoverNew:
         if not _main_window:
             return
 
-        _main_window.model.status_mover_connected_stages.set(
-            self.has_connected_stages)
-        _main_window.model.status_mover_can_move_to_device.set(
-            self.can_move_absolutely)
+        _main_window.model.status_mover_connected_stages.set(self.has_connected_stages)
+        _main_window.model.status_mover_can_move_to_device.set(self.can_move_absolutely)
 
         _main_window.refresh_context_menu()
 
@@ -190,11 +188,8 @@ class MoverNew:
             search_paths += self.experiment_manager.addon_settings['addon_search_directories']
 
         for path in search_paths:
-            imported_stage_classes = self._plugin_loader.load_plugins(
-                path, plugin_base_class=Stage, recursive=True)
-            unique_stage_classes = {
-                k: v for k,
-                v in imported_stage_classes.items() if k not in self._stage_classes}
+            imported_stage_classes = self._plugin_loader.load_plugins(path, plugin_base_class=Stage, recursive=True)
+            unique_stage_classes = {k: v for k, v in imported_stage_classes.items() if k not in self._stage_classes}
 
             self._plugin_loader_stats[path] = len(unique_stage_classes)
             self._stage_classes.update(unique_stage_classes)
@@ -202,12 +197,8 @@ class MoverNew:
             for stage_cls in unique_stage_classes.values():
                 self._available_stages += stage_cls.find_available_stages()
 
-        self.logger.debug(
-            'Available stage classes loaded. Found: %s', [
-                k for k in self._stage_classes.keys()])
-        self.logger.debug(
-            'Discovered stages. Found: %s',
-            list(map(str, self._available_stages)))
+        self.logger.debug(f'Available stage classes loaded. Found: {self._stage_classes.keys()}')
+        self.logger.debug(f'Discovered stages. Found: {list(map(str, self._available_stages))}')
 
     #
     #   Properties
@@ -229,7 +220,7 @@ class MoverNew:
         return self._stage_classes
 
     @property
-    def available_stages(self) -> List[Type[Stage]]:
+    def available_stages(self) -> List[Stage]:
         """
         Returns a list of stages available to the computer (all possible connection types)
         For example: For SmarAct Stages, this function returns all USB-connected stages.
@@ -238,18 +229,15 @@ class MoverNew:
         return self._available_stages
 
     @property
-    def calibrations(
-        self
-    ) -> Dict[Tuple[Orientation, DevicePort], Type[Calibration]]:
+    def calibrations(self) -> Dict[Tuple[Orientation, DevicePort], Calibration]:
         """
         Returns a mapping: Calibration -> (orientation, device_port) instance
         Read-only. Use add_stage_calibration to register a new stage.
         """
-
         return self._calibrations
 
     @property
-    def active_stages(self) -> List[Type[Stage]]:
+    def active_stages(self) -> List[Stage]:
         """
         Returns a list of all active stages. A stage is called active if it has been assigned
         to an orientation and device port
@@ -257,7 +245,7 @@ class MoverNew:
         return [c.stage for c in self._calibrations.values()]
 
     @property
-    def connected_stages(self) -> List[Type[Stage]]:
+    def connected_stages(self) -> List[Stage]:
         """
         Returns a list of all connected stages.
         """
@@ -288,8 +276,8 @@ class MoverNew:
         if not self.calibrations:
             return False
 
-        return all(c.state == State.SINGLE_POINT_FIXED or c.state ==
-                   State.FULLY_CALIBRATED for c in self.calibrations.values())
+        return all(c.state == State.SINGLE_POINT_FIXED or
+                   c.state == State.FULLY_CALIBRATED for c in self.calibrations.values())
 
     @property
     def can_move_relatively(self) -> bool:
@@ -299,32 +287,31 @@ class MoverNew:
         if not self.calibrations:
             return False
 
-        return all(
-            c.state >= State.COORDINATE_SYSTEM_FIXED for c in self.calibrations.values())
+        return all(c.state >= State.COORDINATE_SYSTEM_FIXED for c in self.calibrations.values())
 
     @property
-    def left_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        orientation=Orientation.LEFT)
+    def left_calibration(self) -> Calibration:
+        return self._get_calibration(orientation=Orientation.LEFT)
 
     @property
-    def right_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        orientation=Orientation.RIGHT)
+    def right_calibration(self) -> Calibration:
+        return self._get_calibration(orientation=Orientation.RIGHT)
 
     @property
-    def top_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        orientation=Orientation.TOP)
+    def top_calibration(self) -> Calibration:
+        return self._get_calibration(orientation=Orientation.TOP)
 
     @property
-    def bottom_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        orientation=Orientation.BOTTOM)
+    def bottom_calibration(self) -> Calibration:
+        return self._get_calibration(orientation=Orientation.BOTTOM)
 
     @property
-    def input_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        port=DevicePort.INPUT)
+    def input_calibration(self) -> Calibration:
+        return self._get_calibration(port=DevicePort.INPUT)
 
     @property
-    def output_calibration(self) -> Type[Calibration]: return self._get_calibration(
-        port=DevicePort.OUTPUT)
+    def output_calibration(self) -> Calibration:
+        return self._get_calibration(port=DevicePort.OUTPUT)
 
     @property
     def has_input_calibration(self) -> bool:
@@ -346,11 +333,11 @@ class MoverNew:
 
     def add_stage_calibration(
         self,
-        stage: Type[Stage],
+        stage: Stage,
         orientation: Orientation,
         port: DevicePort,
-        stage_polygon: Type[StagePolygon] = None
-    ) -> Type[Calibration]:
+        stage_polygon: Optional[StagePolygon] = None
+    ) -> Calibration:
         """
         Creates a new Calibration instance for a stage.
         Adds this instance to the list of connected stages.
@@ -360,6 +347,9 @@ class MoverNew:
 
         Returns new calibration instance.
         """
+        # lazy import to avoid circular import
+        from LabExT.Movement.Calibration import Calibration
+
         if not isinstance(port, DevicePort):
             raise ValueError("{} is an invalid port".format(port))
 
@@ -368,14 +358,11 @@ class MoverNew:
                 "{} is an invalid orientation".format(orientation))
 
         try:
-            self._port_by_orientation.put(
-                orientation, port, OnDup(key=RAISE))
+            self._port_by_orientation.put(orientation, port, OnDup(key=RAISE))
         except ValueDuplicationError:
-            raise MoverError(
-                "A stage has already been assigned for the {} port.".format(port))
+            raise MoverError(f"A stage has already been assigned for the {port} port.")
         except KeyDuplicationError:
-            raise MoverError(
-                "A stage has already been assigned for {}.".format(orientation))
+            raise MoverError(f"A stage has already been assigned for {orientation}.")
 
         calibration = Calibration(
             mover=self,
@@ -383,17 +370,14 @@ class MoverNew:
             orientation=orientation,
             device_port=port,
             stage_polygon=stage_polygon,
-            axes_rotation=self.load_stored_axes_rotation_for_stage(
-                stage=stage))
+            axes_rotation=self.load_stored_axes_rotation_for_stage(stage=stage)
+        )
 
         if stage in self.active_stages:
             del self._port_by_orientation[orientation]
-            raise MoverError(
-                "Stage {} has already an assignment.".format(stage))
+            raise MoverError(f"Stage {stage} has already an assignment.")
 
-        self._calibrations.put(
-            (orientation, port), calibration, OnDup(
-                key=RAISE))
+        self._calibrations.put((orientation, port), calibration, OnDup(key=RAISE))
 
         # Stage successfully as stage registered
         calibration.connect_to_stage()
@@ -404,33 +388,19 @@ class MoverNew:
 
         return calibration
 
-    def restore_stage_calibration(
-        self,
-        stage: Type[Stage],
-        calibration_data: dict
-    ) -> Type[Calibration]:
+    def restore_stage_calibration(self, stage: Stage, calibration_data: dict) -> Calibration:
         """
         Restores a calibration for given stage and calibration data.
         """
+        # lazy import to avoid circular import
+        from LabExT.Movement.Calibration import Calibration
+
         if stage in self.active_stages:
-            raise MoverError(
-                "Stage {} has already an assignment.".format(stage))
+            raise MoverError(f"Stage {stage} has already an assignment.")
 
-        calibration = Calibration.load(
-            self, stage, calibration_data, self._chip)
-
-        self._port_by_orientation.put(
-            calibration._orientation,
-            calibration._device_port,
-            OnDup(
-                key=RAISE))
-
-        self._calibrations.put(
-            (calibration._orientation,
-             calibration._device_port),
-            calibration,
-            OnDup(
-                key=RAISE))
+        calibration = Calibration.load(self, stage, calibration_data, self._chip)
+        self._port_by_orientation.put(calibration.orientation, calibration.device_port, OnDup(key=RAISE))
+        self._calibrations.put((calibration.orientation, calibration.device_port), calibration, OnDup(key=RAISE))
 
         return calibration
 
@@ -443,8 +413,7 @@ class MoverNew:
         """
         Sets the coordinate system of all connected stages to the requested one.
         """
-        prior_coordinate_systems = {
-            c: c.coordinate_system for c in self.calibrations.values()}
+        prior_coordinate_systems = {c: c.coordinate_system for c in self.calibrations.values()}
 
         for calibration in self.calibrations.values():
             calibration.set_coordinate_system(system)
@@ -484,8 +453,8 @@ class MoverNew:
         try:
             for stage in self.connected_stages:
                 stage.set_speed_xy(umps)
-        except RuntimeError as exec:
-            raise MoverError("Setting xy speed failed: {}".format(exec))
+        except RuntimeError as e:
+            raise MoverError(f"Setting xy speed failed: {e}")
 
         self._speed_xy = umps
 
@@ -514,8 +483,8 @@ class MoverNew:
         try:
             for stage in self.connected_stages:
                 stage.set_speed_z(umps)
-        except RuntimeError as exec:
-            raise MoverError("Setting z speed failed: {}".format(exec))
+        except RuntimeError as e:
+            raise MoverError(f"Setting z speed failed: {e}")
 
         self._speed_z = umps
 
@@ -545,8 +514,8 @@ class MoverNew:
         try:
             for stage in self.connected_stages:
                 stage.set_acceleration_xy(umps2)
-        except RuntimeError as exec:
-            raise MoverError("Acceleration xy speed failed: {}".format(exec))
+        except RuntimeError as e:
+            raise MoverError(f"Acceleration xy speed failed: {e}")
 
         self._acceleration_xy = umps2
 
@@ -582,24 +551,19 @@ class MoverNew:
     #   Movement Methods
     #
 
-    def get_path_planning_strategy(self) -> Type[PathPlanning]:
+    def get_path_planning_strategy(self) -> PathPlanning:
         """
         Returns a PathPlanning based on number of stages
         """
         if len(self.connected_stages) == 1:
-            return SingleStagePlanning(
-                max_lift_correction=100,
-                correction_tolerance=10)
+            return SingleStagePlanning(max_lift_correction=100, correction_tolerance=10)
         else:
-            return CollisionAvoidancePlanning(
-                chip=self._chip,
-                abort_local_minimum=3)
+            return CollisionAvoidancePlanning(chip=self._chip, abort_local_minimum=3)
 
     @assert_connected_stages
     def move_absolute(
         self,
-        movement_commands: Dict[Orientation, Type[ChipCoordinate]],
-        chip: Type[Chip],
+        movement_commands: Dict[Orientation, ChipCoordinate],
         with_lifted_stages: bool = False,
         wait_for_stopping: bool = True,
         wait_timeout: float = 2.0
@@ -613,11 +577,14 @@ class MoverNew:
         ----------
         movement_commands : Dict[Orientation, Type[ChipCoordinate]]
             A mapping between orientation and target chip coordinate.
-            For example, if the mapping `Orientation.LEFT: ChipCoordinate(1,2,3)` exists, the left stage is moved to the chip co-ordinate x=1, y=2, z=3
-        wait_for_stopping: bool = True
-            Whether each stage should have completed its movement before the next one moves.
+            For example, if the mapping `Orientation.LEFT: ChipCoordinate(1,2,3)` exists,
+            the left stage is moved to the chip coordinate x=1, y=2, z=3
         with_lifted_stages: bool = False
             Indicates whether the stages should be lifted before movement.
+        wait_for_stopping: bool = True
+            Whether each stage should have completed its movement before the next one moves.
+        wait_timeout: float = 2.0
+            Only relevant if wait_for_stopping is False. Through an error if timeout is reached.
 
         Raises
         ------
@@ -635,13 +602,12 @@ class MoverNew:
 
             # Resolves movement commands
             # Checks if for each orientation a calibration exits
-            # Set ups Path Planning
+            # Sets up Path Planning
             resolved_calibrations = {}
             for orientation, target in movement_commands.items():
                 calibration = self._get_calibration(orientation=orientation)
                 if calibration is None:
-                    raise MoverError(
-                        f"No {orientation} stage configured, but target coordinate for {orientation} passed.")
+                    raise MoverError(f"No {orientation} stage configured, but target coordinate for {orientation} passed.")
 
                 if with_lifted_stages:
                     calibration.lift_stage(self.z_lift)
@@ -655,8 +621,9 @@ class MoverNew:
             for calibration_waypoints in path_planning.trajectory():
                 for calibration, waypoint in calibration_waypoints.items():
                     calibration.move_absolute(
-                        coordinate=waypoint.coordinate, wait_for_stopping=(
-                            wait_for_stopping or waypoint.wait_for_stopping))
+                        coordinate=waypoint.coordinate,
+                        wait_for_stopping=(wait_for_stopping or waypoint.wait_for_stopping)
+                    )
 
                 # Wait for all stages to stop if stages move simultaneously.
                 if not wait_for_stopping:
@@ -665,11 +632,9 @@ class MoverNew:
                         sleep(0.05)
 
                         if time() - busy_spinning_start >= wait_timeout:
-                            raise RuntimeError(
-                                f"Stages did not stop after {wait_timeout} seconds. Abort.")
+                            raise RuntimeError(f"Stages did not stop after {wait_timeout} seconds. Abort.")
 
-                        if all(c.stage.is_stopped
-                               for c in calibration_waypoints.keys()):
+                        if all(c.stage.is_stopped for c in calibration_waypoints.keys()):
                             break
 
             # Movement complete and lower stages (if requested)
@@ -681,8 +646,8 @@ class MoverNew:
     @assert_connected_stages
     def move_relative(
         self,
-        movement_commands: Dict[Orientation, Type[ChipCoordinate]],
-        ordering: List[Orientation] = CLOCKWISE_ORDERING,
+        movement_commands: Dict[Orientation, ChipCoordinate],
+        ordering: Optional[List[Orientation]] = None,
         wait_for_stopping: bool = True
     ) -> None:
         """
@@ -695,6 +660,7 @@ class MoverNew:
             A mapping between orientation and requested offset in chip coordinates.
             For example, if the mapping `Orientation.LEFT: ChipCoordinate(1,2,3)` exists, the left stage is moved relatively
             with an offset of x=1, y=2, z=3.
+        ordering: List[Orientation]
         wait_for_stopping: bool = True
             Whether each stage should have completed its movement before the next one moves.
         Raises
@@ -705,19 +671,22 @@ class MoverNew:
         """
         if not self.can_move_relatively:
             raise MoverError(
-                f"Cannot perform relative movement, not all active stages are calibrated correctly."
-                "Note for each stage the coordinate system must be fixed.")
+                "Cannot perform relative movement, not all active stages are calibrated correctly."
+                "Note for each stage the coordinate system must be fixed."
+            )
 
         if not movement_commands:
             return
+
+        if ordering is None:
+            ordering = CLOCKWISE_ORDERING
 
         # Makes sure that a calibration exists for each movement command.
         resolved_calibrations = {}
         for orientation in movement_commands:
             calibration = self._get_calibration(orientation=orientation)
             if calibration is None:
-                raise MoverError(
-                    f"No {orientation} stage configured, but offset for {orientation} passed.")
+                raise MoverError(f"No {orientation} stage configured, but offset for {orientation} passed.")
 
             resolved_calibrations[orientation] = calibration
 
@@ -733,7 +702,7 @@ class MoverNew:
                 calibration.move_relative(requested_target, wait_for_stopping)
 
     @assert_connected_stages
-    def move_to_device(self, chip: Type[Chip], device: Type[Device]):
+    def move_to_device(self, device: Device) -> None:
         """
         Moves stages to device.
 
@@ -741,17 +710,13 @@ class MoverNew:
 
         Parameters
         ----------
-        chip: Chip
-            Instance of a imported chip.
         device: Device
             Device to which the stages should move.
         """
         movement_commands = {}
 
-        input_orientation = self._port_by_orientation.inverse.get(
-            DevicePort.INPUT)
-        output_orientation = self._port_by_orientation.inverse.get(
-            DevicePort.OUTPUT)
+        input_orientation = self._port_by_orientation.inverse.get(DevicePort.INPUT)
+        output_orientation = self._port_by_orientation.inverse.get(DevicePort.OUTPUT)
 
         if input_orientation:
             movement_commands[input_orientation] = device.input_coordinate
@@ -759,10 +724,7 @@ class MoverNew:
         if output_orientation:
             movement_commands[output_orientation] = device.output_coordinate
 
-        self.move_absolute(
-            movement_commands,
-            chip=chip,
-            with_lifted_stages=True)
+        self.move_absolute(movement_commands, with_lifted_stages=True)
 
     #
     #   Load and store mover settings
@@ -780,8 +742,7 @@ class MoverNew:
             json.dump({
                 "chip_name": _chip_name,
                 "last_updated_at": datetime.now().isoformat(),
-                "calibrations": [
-                    c.dump() for c in self.calibrations.values()]
+                "calibrations": [c.dump() for c in self.calibrations.values()]
             }, fp, indent=2)
 
     def dump_axes_rotations(self) -> None:
@@ -821,59 +782,47 @@ class MoverNew:
             with open(self.MOVER_SETTINGS_FILE) as fp:
                 mover_settings = json.load(fp)
         except (OSError, json.decoder.JSONDecodeError) as err:
-            self.logger.error(
-                f"Failed to load/decode settings file {self.MOVER_SETTINGS_FILE}: {err}")
+            self.logger.error(f"Failed to load/decode settings file {self.MOVER_SETTINGS_FILE}: {err}")
             return
 
         self._speed_xy = mover_settings.get("speed_xy", self.DEFAULT_SPEED_XY)
         self._speed_z = mover_settings.get("speed_z", self.DEFAULT_SPEED_Z)
-        self._acceleration_xy = mover_settings.get(
-            "acceleration_xy", self.DEFAULT_ACCELERATION_XY)
+        self._acceleration_xy = mover_settings.get("acceleration_xy", self.DEFAULT_ACCELERATION_XY)
         self._z_lift = mover_settings.get("z_lift", self.DEFAULT_SPEED_Z)
 
         self.logger.debug(
             f"Restored mover settings: xy-speed = {self._speed_xy}; z-speed = {self._speed_z}; "
-            f"xy-acceleration = {self._acceleration_xy}; z-lift = {self.z_lift}")
+            f"xy-acceleration = {self._acceleration_xy}; z-lift = {self.z_lift}"
+        )
 
-    def load_stored_axes_rotation_for_stage(
-        self,
-        stage: Type[Stage]
-    ) -> Type[AxesRotation]:
+    def load_stored_axes_rotation_for_stage(self, stage: Stage) -> AxesRotation:
         """
         Returns a restored AxesRotation from file if available.
-
         If not available, returns a default identity rotation.
         """
         try:
             with open(self.AXES_ROTATIONS_FILE, "r") as fp:
                 saved_axes_rotations = json.load(fp)
         except (OSError, json.decoder.JSONDecodeError) as err:
-            self.logger.error(
-                f"Failed to load/decode axes rotation file {self.AXES_ROTATIONS_FILE}: {err}")
+            self.logger.error(f"Failed to load/decode axes rotation file {self.AXES_ROTATIONS_FILE}: {err}")
             return AxesRotation()
 
         if stage.identifier not in saved_axes_rotations:
             return AxesRotation()
 
         self.logger.debug(
-            f"Found saved axes rotation for {stage.identifier} in {self.AXES_ROTATIONS_FILE}. "
-            "Restoring it.")
+            f"Found saved axes rotation for {stage.identifier} in {self.AXES_ROTATIONS_FILE}. Restoring it.")
 
         try:
-            return AxesRotation.load(
-                mapping=saved_axes_rotations[stage.identifier]["axes_rotation"])
+            return AxesRotation.load(mapping=saved_axes_rotations[stage.identifier]["axes_rotation"])
         except Exception as err:
             self.logger.error(
                 f"Failed to restore axes rotation for {stage.identifier} from {self.AXES_ROTATIONS_FILE}: {err}")
             return AxesRotation()
 
-    def load_stored_calibrations_for_chip(
-        self,
-        chip: Type[Chip]
-    ) -> dict:
+    def load_stored_calibrations_for_chip(self, chip: Chip) -> dict:
         """
         Returns restored calibrations from file if available.
-
         If not available, returns an empty dict.
         """
         if chip is None or chip.name is None:
@@ -882,15 +831,14 @@ class MoverNew:
         try:
             with open(self.CALIBRATIONS_SETTINGS_FILE, "r") as fp:
                 calibration_settings = json.load(fp)
-                chip_name = calibration_settings.get("chip_name")
-                calibrations = calibration_settings.get("calibrations", [])
-                if chip_name == chip.name and len(calibrations) > 0:
-                    return calibration_settings
-                else:
-                    return {}
+            chip_name = calibration_settings.get("chip_name")
+            calibrations = calibration_settings.get("calibrations", [])
+            if chip_name == chip.name and len(calibrations) > 0:
+                return calibration_settings
+            else:
+                return {}
         except (OSError, json.decoder.JSONDecodeError) as err:
-            self.logger.error(
-                f"Failed to load/decode calibration file {self.AXES_ROTATIONS_FILE}: {err}")
+            self.logger.error(f"Failed to load/decode calibration file {self.AXES_ROTATIONS_FILE}: {err}")
             return {}
 
     @property
@@ -906,9 +854,10 @@ class MoverNew:
 
     def _get_calibration(
             self,
-            port=None,
-            orientation=None,
-            default=None) -> Type[Calibration]:
+            port: Optional[DevicePort] = None,
+            orientation: Optional[Orientation] = None,
+            default = None
+    ) -> Calibration:
         """
         Get safely calibration by port and orientation.
         """

--- a/LabExT/Movement/PathPlanning.py
+++ b/LabExT/Movement/PathPlanning.py
@@ -10,29 +10,26 @@ import logging
 import numpy as np
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Any, Dict, NamedTuple, Tuple, Type, Generator
+from typing import TYPE_CHECKING, List, Any, Dict, NamedTuple, Generator
 
+from numpy.typing import NDArray
 from scipy.spatial.distance import pdist
 
-from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.config import CoordinateSystem, Orientation
+from LabExT.Movement.Coordinate import ChipCoordinate
+from LabExT.Movement.config import CoordinateSystem
+from LabExT.Wafer.Chip import Chip
 
 if TYPE_CHECKING:
     from LabExT.Movement.Calibration import Calibration
-    from LabExT.Wafer.Chip import Chip
 
 
 class Waypoint(NamedTuple):
     """
     Represents one waypoint calculated by a path planning algorithm.
     """
-    calibration: Type["Calibration"]
-    coordinate: Type[ChipCoordinate]
+    calibration: Calibration
+    coordinate: ChipCoordinate
     wait_for_stopping: bool = False
-
-
-# Type alias: Defines a mapping from calibration to waypoint
-WaypointCommand = Dict[Type["Calibration"], Type[Waypoint]]
 
 
 class PathPlanningError(RuntimeError):
@@ -42,222 +39,7 @@ class PathPlanningError(RuntimeError):
     pass
 
 
-class StagePolygon(ABC):
-    """
-    Abstract base class to generate polygons for stages.
-
-    This class cannot be initialised.
-    """
-
-    @classmethod
-    def load(cls, polygon_data: dict) -> Type[StagePolygon]:
-        """
-        Returns a stage polygon reconstructed from polygon data.
-        """
-        polygon_name = polygon_data.get("polygon_cls")
-        if not polygon_name:
-            raise ValueError(
-                "Cannot find and load stage polygon without polygon class name. "
-                "Please provide a key 'polygon_cls' in polygon_data argument.")
-
-        if (isinstance(polygon_name, type) and
-                issubclass(polygon_name, StagePolygon)):
-            polygon_cls = polygon_name
-        elif isinstance(polygon_name, str):
-            available_classes = StagePolygon.find_polygon_classes()
-            try:
-                polygon_cls = next(
-                    pg for pg in available_classes if pg.__name__ == polygon_name)
-            except StopIteration:
-                available_classes_str = ", ".join(
-                    map(lambda pg: pg.__name__, available_classes))
-                raise ValueError(
-                    f"No polygon class found with name {polygon_name}. The following are available: "
-                    f"{available_classes_str}")
-        else:
-            raise ValueError(
-                f"Cannot restore stage polygon class with 'polygon_cls' equal to {polygon_name} of type {type(polygon_name)}. "
-                "Please provide a value for 'polygon_cls' of type str or StagePolygon. "
-                "If you provide a string, it must be the name of the polygon class.")
-
-        try:
-            orientation = Orientation[polygon_data["orientation"]]
-        except KeyError as err:
-            raise ValueError(
-                f"The parameter 'orientation' in polygon_data is not defined: {err}. "
-                f"Make sure to pass a valid orientation: {', '.join(map(str, list(Orientation)))}")
-
-        return polygon_cls(
-            orientation=orientation,
-            parameters=polygon_data.get("parameters", {}))
-
-    @classmethod
-    def find_polygon_classes(cls) -> List[StagePolygon]:
-        """
-        Returns a list of available polygon classes.
-        """
-        return cls.__subclasses__()
-
-    @classmethod
-    def get_default_parameters(cls) -> Dict[str, Any]:
-        """
-        Returns default polygon configuration parameter
-        """
-        return {}
-
-    def __init__(
-        self,
-        orientation: Orientation,
-        parameters: Dict[str, Any] = {}
-    ) -> None:
-        """
-        Constructor for base  polygon
-        Parameters
-        ----------
-        orientation: Orientation
-            Polygon orientation in chip space
-        parameters: Dict[str, Any] = {}
-            Optional parameters to configure the polygon
-        """
-        self.orientation = orientation
-
-        self.parameters = parameters
-        if not self.parameters:
-            self.parameters = self.get_default_parameters()
-
-    @abstractmethod
-    def stage_in_meshgrid(
-        self,
-        position: Type[ChipCoordinate],
-        mesh_x: np.ndarray,
-        mesh_y: np.ndarray,
-        grid_size: float
-    ) -> np.ndarray:
-        """
-        Returns a mask if a point in the meshgrid is in the stage.
-        """
-        pass
-
-    def dump(self, stringify: bool = True) -> dict:
-        """
-        Returns polygon parameters as dict
-        """
-        if stringify:
-            polygon_cls = self.__class__.__name__
-        else:
-            polygon_cls = self.__class__
-
-        return {
-            "polygon_cls": polygon_cls,
-            "orientation": self.orientation.value,
-            "parameters": self.parameters}
-
-
-class SingleModeFiber(StagePolygon):
-    """
-    Polygon for single mode fiber.
-    """
-
-    @classmethod
-    def get_default_parameters(cls) -> Dict[str, Any]:
-        """
-        Returns default parameter to set up a single mode fiber polygon
-        """
-        return {
-            "Fiber Length": 8e4,        # [um] (8cm)
-            "Fiber Radius": 75.0,       # [um]
-            "Safety Distance": 75.0     # [um]
-        }
-
-    def stage_in_meshgrid(
-        self,
-        position: Type[ChipCoordinate],
-        mesh_x: np.ndarray,
-        mesh_y: np.ndarray,
-        grid_size: float
-    ) -> np.ndarray:
-        """
-        Returns a mask if a point of the single mode fiber in the meshgrid is in the stage.
-
-        Parameters
-        ----------
-        position : ChipCoordinate
-            Current position of the stage in Chip-Coordinates
-        mesh_x : np.ndarray
-            X values of the meshgrid
-        mesh_y : np.ndarray
-            Y values of the meshgrid
-        grid_size : float
-            Grid size of meshgrid
-        """
-        x_min, x_max, y_min, y_max = self._create_outline(position, grid_size)
-        return np.logical_and(
-            np.logical_and(x_min <= mesh_x, mesh_x <= x_max),
-            np.logical_and(y_min <= mesh_y, mesh_y <= y_max))
-
-    def _create_outline(
-        self,
-        position: Type[ChipCoordinate],
-        grid_size: float,
-        grid_epsilon: float = 10
-    ) -> Tuple[float, float, float, float]:
-        """
-        Returns a tuple with the X- and Y-axis limits.
-
-        Performs a case distinction according to the orientation of the stage.
-
-        Artificially enlarges the outline, if it is too small for the grid:
-        e.g. If the distance between x_max and x_min is less than or equal to the grid size,
-        half the grid size plus an absolute epsilon is added/substracted.
-
-        Parameters
-        ----------
-        position : ChipCoordinate
-            Current position of the stage in Chip-Coordinates
-        grid_size : float
-            Grid size of meshgrid
-        grid_epsilon : float
-            Absolute summand to artificially enlarge the obstacle
-            if it is too small for the meshgrid.
-
-        Raises
-        ------
-        ValueError
-            If no outline is defined for the given orientation.
-        """
-        fiber_radius = float(self.parameters.get("Fiber Radius", 75.0))
-        fiber_length = float(self.parameters.get("Fiber Length", 8e4))
-        safety_distance = float(self.parameters.get("Safety Distance", 75.0))
-
-        safe_fiber_radius = fiber_radius + safety_distance
-
-        x_min = position.x - safe_fiber_radius
-        x_max = position.x + safe_fiber_radius
-        y_min = position.y - safe_fiber_radius
-        y_max = position.y + safe_fiber_radius
-
-        if self.orientation == Orientation.LEFT:
-            x_min -= fiber_length
-        elif self.orientation == Orientation.RIGHT:
-            x_max += fiber_length
-        elif self.orientation == Orientation.BOTTOM:
-            y_min -= fiber_length
-        elif self.orientation == Orientation.TOP:
-            y_max += fiber_length
-        else:
-            raise ValueError(
-                f"No Stage Polygon defined for orientation {self.orientation}")
-
-        # Make sure, that outline fits into meshgrid
-        if np.abs(x_max - x_min) <= grid_size:
-            x_max += grid_size / 2 + grid_epsilon
-            x_min -= grid_size / 2 + grid_epsilon
-
-        if np.abs(y_max - y_min) <= grid_size:
-            y_max += grid_size / 2 + grid_epsilon
-            y_min -= grid_size / 2 + grid_epsilon
-
-        return x_min, x_max, y_min, y_max
+WaypointCommand = Dict["Calibration", Waypoint]
 
 
 class PathPlanning(ABC):
@@ -270,13 +52,9 @@ class PathPlanning(ABC):
         super().__init__()
 
     @abstractmethod
-    def set_stage_target(
-        self,
-        calibration: Type["Calibration"],
-        target: Type[ChipCoordinate]
-    ) -> None:
+    def set_stage_target(self, calibration: Calibration, target: ChipCoordinate) -> None:
         """
-        Sets a new traget for given calibration.
+        Sets a new target for given calibration.
 
         Parameters
         ----------
@@ -285,7 +63,7 @@ class PathPlanning(ABC):
         target: ChipCoordinate
             3D coordinate in the chip system as a target for the passed calibration.
         """
-        pass
+        ...
 
     @abstractmethod
     def trajectory(self) -> Generator[WaypointCommand, Any, Any]:
@@ -297,7 +75,7 @@ class PathPlanning(ABC):
         the calibration coordinate, and a `wait_for_stopping` specifying
         whether the stage should wait until this waypoint command has been executed.
         """
-        pass
+        ...
 
 
 class PotentialField:
@@ -324,8 +102,8 @@ class PotentialField:
 
     def __init__(
         self,
-        calibration: Type["Calibration"],
-        target_coordinate: Type[ChipCoordinate],
+        calibration: Calibration,
+        target_coordinate: ChipCoordinate,
         grid_size: float = 50.0,
         grid_outline: tuple = ((-5000, 5000), (-5000, 5000)),
         repulsive_gain: float = 10000.0,
@@ -376,37 +154,35 @@ class PotentialField:
         self.cx, self.cy = np.meshgrid(self.x_coords, self.y_coords)
 
         # Get current Idx of field tile
-        self.current_idx = np.array(
-            [np.argmin(np.abs(self.x_coords - self.start_coordinate.x)),
-                np.argmin(np.abs(self.y_coords - self.start_coordinate.y))])
+        self.current_idx = np.array([
+            np.argmin(np.abs(self.x_coords - self.start_coordinate.x)),
+            np.argmin(np.abs(self.y_coords - self.start_coordinate.y))
+        ])
 
         # current position in terms of field tiles
         self.current_position = ChipCoordinate(
             x=self.x_coords[self.current_idx[0]],
             y=self.y_coords[self.current_idx[1]],
-            z=self.start_coordinate.z)
+            z=self.start_coordinate.z
+        )
 
         # field target
         self.target_coordinate = target_coordinate
 
-        if not np.isclose(
-                self.start_coordinate.z,
-                self.target_coordinate.z,
-                rtol=1.e-5,
-                atol=10e-3):
+        if not np.isclose(self.start_coordinate.z, self.target_coordinate.z, rtol=1.e-5, atol=10e-3):
             raise ValueError(
                 f"Start z level {self.start_coordinate.z} is not close to target z level {self.target_coordinate.z}. "
-                "The Path Planning algorithm assumes that start and target are on the same z level.")
+                "The Path Planning algorithm assumes that start and target are on the same z level."
+            )
 
         # Calculate potential field
         self.attractive_potential_field = self.attractive_gain * \
             np.hypot(self.cx - self.target_coordinate.x, self.cy - self.target_coordinate.y)
-        self.potential_field = np.zeros_like(
-            self.cx) + self.attractive_potential_field
+        self.potential_field = np.zeros_like(self.cx) + self.attractive_potential_field
 
     def next_waypoint(self) -> Waypoint:
         """
-        Generates iterativly the next waypoint in the given potential field.
+        Generates iteratively the next waypoint in the given potential field.
 
         It calculates an infinite number of waypoints with the last waypoints being the actual destination.
 
@@ -416,7 +192,8 @@ class PotentialField:
         """
         distance_to_target = np.hypot(
             self.current_position.x - self.target_coordinate.x,
-            self.current_position.y - self.target_coordinate.y)
+            self.current_position.y - self.target_coordinate.y
+        )
 
         if distance_to_target <= self.grid_size:
             self.current_position = self.target_coordinate
@@ -428,16 +205,9 @@ class PotentialField:
                 y=self.y_coords[self.current_idx[1]],
                 z=self.start_coordinate.z)
 
-        return Waypoint(
-            calibration=self.calibration,
-            coordinate=self.current_position,
-            wait_for_stopping=False)
+        return Waypoint(self.calibration, self.current_position, wait_for_stopping=False)
 
-    def set_stage_obstacles(
-        self,
-        *calibrations: List[Type["Calibration"]],
-        safety_multiplier: int = 5
-    ) -> None:
+    def set_stage_obstacles(self, *calibrations: List[Calibration], safety_multiplier: int = 5) -> None:
         """
         Creates an obstacle in the potential field for each passed calibration.
 
@@ -448,8 +218,7 @@ class PotentialField:
         safety_multiplier: int
             Multiplier of the fiber radius to calculate the field mask
         """
-        self.potential_field = np.zeros_like(
-            self.cx) + self.attractive_potential_field
+        self.potential_field = np.zeros_like(self.cx) + self.attractive_potential_field
 
         for calibration in calibrations:
             with calibration.perform_in_system(CoordinateSystem.CHIP):
@@ -457,7 +226,8 @@ class PotentialField:
                     calibration.get_position(),
                     self.cx,
                     self.cy,
-                    self.grid_size)
+                    self.grid_size
+                )
 
             for ox, oy in zip(self.cx[stage_mask], self.cy[stage_mask]):
                 o_dist = np.hypot(self.cx - ox, self.cy - oy)
@@ -466,7 +236,7 @@ class PotentialField:
 
                 self.potential_field[field_mask] += rep_field[field_mask]
 
-    def _find_lowest_potential(self) -> np.ndarray:
+    def _find_lowest_potential(self) -> NDArray[np.float64]:
         """
         Finds lowest potential around current position.
 
@@ -474,7 +244,7 @@ class PotentialField:
         -------
         Returns the index of the lowest potential.
         """
-        curr_potenial = self.potential_field[self.current_idx[1],
+        curr_potential = self.potential_field[self.current_idx[1],
                                              self.current_idx[0]]
         curr_idx = self.current_idx.copy()
 
@@ -482,8 +252,8 @@ class PotentialField:
             possible_idx = self.current_idx + np.array([mx, my])
             possible_potential = self.potential_field[possible_idx[1],
                                                       possible_idx[0]]
-            if possible_potential < curr_potenial:
-                curr_potenial = possible_potential
+            if possible_potential < curr_potential:
+                curr_potential = possible_potential
                 curr_idx = possible_idx
 
         return curr_idx
@@ -495,34 +265,26 @@ class CollisionAvoidancePlanning(PathPlanning):
     using the potential field algorithm.
     """
 
-    def __init__(
-        self,
-        chip,
-        abort_local_minimum: int = 3
-    ) -> None:
+    def __init__(self, chip: Chip, abort_local_minimum: int = 3) -> None:
         """
         Constructor for the Path Planning.
         Parameters
         ----------
         chip: Chip
-            Instance of the a chip
+            Instance of a chip
         abort_local_minimum: int = 3
             Number of identical movements before an error is raised.
         """
-        self.chip: Type[Chip] = chip
-        self.grid_size, self.grid_outline = self._get_grid_properties(
-            padding=100)
+        super().__init__()
+        self.chip = chip
+        self.grid_size, self.grid_outline = self._get_grid_properties(padding=100)
 
         self.abort_local_minimum = abort_local_minimum
 
         self.potential_fields = {}
         self.last_moves = []
 
-    def set_stage_target(
-        self,
-        calibration: Type["Calibration"],
-        target: Type[ChipCoordinate]
-    ) -> None:
+    def set_stage_target(self, calibration: Calibration, target: ChipCoordinate) -> None:
         """
         Registers a target for the given calibration.
 
@@ -537,7 +299,8 @@ class CollisionAvoidancePlanning(PathPlanning):
             calibration,
             target,
             self.grid_size,
-            self.grid_outline)
+            self.grid_outline
+        )
 
     def trajectory(self) -> Generator[WaypointCommand, None, None]:
         """
@@ -552,30 +315,26 @@ class CollisionAvoidancePlanning(PathPlanning):
         PathPlanningError
             If no progress has been made.
         """
-        while not all(f.current_position ==
-                      f.target_coordinate for f in self.potential_fields.values()):
+        while not all(f.current_position == f.target_coordinate for f in self.potential_fields.values()):
 
             next_move = {}
 
             for calibration, potential_field in self.potential_fields.items():
                 potential_field.set_stage_obstacles(*[
-                    obstacle_calibration for obstacle_calibration in self.potential_fields.keys() if obstacle_calibration != calibration
+                    obstacle_calibration for obstacle_calibration in self.potential_fields.keys()
+                    if obstacle_calibration != calibration
                 ])
 
                 next_move[calibration] = potential_field.next_waypoint()
 
             if self._last_waypoints_equal(next_move):
-                raise PathPlanningError(
-                    f"Path-finding algorithm makes no progress. The last {self.abort_local_minimum} movements were identical!")
+                raise PathPlanningError(f"Path-finding algorithm makes no progress. "
+                                        f"The last {self.abort_local_minimum} movements were identical!")
 
             self.last_moves.append(next_move)
             yield next_move
 
-    def _get_grid_properties(
-        self,
-        padding: float = 0,
-        maximum_gird_size: float = 100
-    ) -> tuple:
+    def _get_grid_properties(self, padding: float = 0, maximum_gird_size: float = 100) -> tuple:
         """
         Dynamically calculates the grid outline based on the points of the chip.
 
@@ -630,11 +389,7 @@ class SingleStagePlanning(PathPlanning):
     Path planning for single stage movements.
     """
 
-    def __init__(
-        self,
-        max_lift_correction: float = 100,
-        correction_tolerance: float = 10
-    ) -> None:
+    def __init__(self, max_lift_correction: float = 100, correction_tolerance: float = 10) -> None:
         """
         Constructor for the single stage path planning.
         Parameters
@@ -656,13 +411,9 @@ class SingleStagePlanning(PathPlanning):
         self.start_chip_coordinate = None
         self.start_stage_coordinate = None
 
-    def set_stage_target(
-        self,
-        calibration: Type["Calibration"],
-        target: Type[ChipCoordinate]
-    ) -> None:
+    def set_stage_target(self, calibration: Calibration, target: ChipCoordinate) -> None:
         """
-        Sets the traget coordinate for given calibrations.
+        Sets the target coordinate for given calibrations.
         """
         if self.calibration is not None:
             raise PathPlanningError(
@@ -708,9 +459,9 @@ class SingleStagePlanning(PathPlanning):
             Waypoint(
                 self.calibration,
                 self.target_chip_coordinate,
-                wait_for_stopping=True)]:
-            yield {
-                self.calibration: waypoint}
+                wait_for_stopping=True)
+        ]:
+            yield {self.calibration: waypoint}
 
     def _z_level_correction(self) -> float:
         """
@@ -728,11 +479,9 @@ class SingleStagePlanning(PathPlanning):
         PathPlanningError
             If new z level height is greater than max_lift_correction
         """
-        start_target_z_delta = np.ceil(np.abs(
-            self.target_stage_coordinate.z - self.start_stage_coordinate.z))
+        start_target_z_delta = np.ceil(np.abs(self.target_stage_coordinate.z - self.start_stage_coordinate.z))
 
-        self.logger.debug(
-            f"[{self.calibration}] Z-delta between start and target: {start_target_z_delta} um")
+        self.logger.debug(f"[{self.calibration}] Z-delta between start and target: {start_target_z_delta} um")
 
         z_correction = start_target_z_delta + self.correction_tolerance
         self.logger.debug(

--- a/LabExT/Movement/Polygons.py
+++ b/LabExT/Movement/Polygons.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+from abc import ABC, abstractmethod
+from typing import TypeVar, Type, Dict, Any, List, Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from LabExT.Movement.Coordinate import ChipCoordinate
+from LabExT.Movement.config import Orientation
+
+StagePolygonT = TypeVar("StagePolygonT", bound="StagePolygon")
+
+
+class StagePolygon(ABC):
+    """
+    Abstract base class to generate polygons for stages.
+    """
+
+    @classmethod
+    def load(cls: Type[StagePolygonT], polygon_data: Dict[str, Any]) -> StagePolygonT:
+        """
+        Returns a stage polygon reconstructed from polygon data.
+        """
+        polygon_raw = polygon_data.get("polygon_cls")
+        if polygon_raw is None:
+            raise ValueError("Cannot find and load stage polygon without polygon class name. "
+                             "Please provide a key 'polygon_cls' in polygon_data argument.")
+
+        # --- Case 1: polygon_cls is already a class subclassing StagePolygon ---
+        if isinstance(polygon_raw, type) and issubclass(polygon_raw, StagePolygon):
+            polygon_cls: Type[StagePolygonT] = polygon_raw
+
+        # --- Case 2: polygon_cls is a string with a class name ---
+        elif isinstance(polygon_raw, str):
+            available = cls.find_polygon_classes()
+            try:
+                polygon_cls = next(pgc for pgc in available if pgc.__name__ == polygon_raw)
+            except StopIteration:
+                names = ", ".join(pgc.__name__ for pgc in available)
+                raise ValueError(f"No polygon class found with name {polygon_raw}. Available subclasses: {names}")
+
+        else:
+            raise TypeError(f"Invalid value for 'polygon_cls': {polygon_raw!r} (type {type(polygon_raw).__name__}). "
+                            f"Expected a subclass of StagePolygon or its class name.")
+
+        try:
+            orientation = Orientation(polygon_data["orientation"])
+        except KeyError as e:
+            valid = ", ".join(o.name for o in Orientation)
+            raise ValueError(f"Invalid or missing 'orientation': {e}. Valid orientations: {valid}")
+
+        parameters = polygon_data.get("parameters", {})
+
+        return polygon_cls(orientation=orientation, parameters=parameters)
+
+    @classmethod
+    def find_polygon_classes(cls) -> List[Type[StagePolygonT]]:
+        """
+        Returns a list of available polygon classes.
+        """
+        return cls.__subclasses__()
+
+    @classmethod
+    def get_default_parameters(cls) -> Dict[str, Any]:
+        """
+        Returns default polygon configuration parameter
+        """
+        return {}
+
+    def __init__(self, orientation: Orientation, parameters: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Constructor for base  polygon
+        Parameters
+        ----------
+        orientation: Orientation
+            Polygon orientation in chip space
+        parameters: Dict[str, Any] = {}
+            Optional parameters to configure the polygon
+        """
+        self.orientation = orientation
+        self.parameters = self.get_default_parameters() if parameters is None else parameters
+
+    @abstractmethod
+    def stage_in_meshgrid(
+        self,
+        position: ChipCoordinate,
+        mesh_x: NDArray[np.float64],
+        mesh_y: NDArray[np.float64],
+        grid_size: float
+    ) -> NDArray[np.float64]:
+        """
+        Returns a mask if a point in the meshgrid is in the stage.
+        """
+        ...
+
+    def dump(self, stringify: bool = True) -> dict:
+        """
+        Returns polygon parameters as dict
+        """
+        if stringify:
+            polygon_cls = self.__class__.__name__
+        else:
+            polygon_cls = self.__class__
+
+        return {
+            "polygon_cls": polygon_cls,
+            "orientation": self.orientation.value,
+            "parameters": self.parameters
+        }
+
+
+class SingleModeFiber(StagePolygon):
+    """
+    Polygon for single mode fiber.
+    """
+
+    @classmethod
+    def get_default_parameters(cls) -> Dict[str, Any]:
+        """
+        Returns default parameter to set up a single mode fiber polygon
+        """
+        return {
+            "Fiber Length": 8e4,        # [um] (8cm)
+            "Fiber Radius": 75.0,       # [um]
+            "Safety Distance": 75.0     # [um]
+        }
+
+    def stage_in_meshgrid(
+        self,
+        position: ChipCoordinate,
+        mesh_x: NDArray[np.float64],
+        mesh_y: NDArray[np.float64],
+        grid_size: float
+    ) -> NDArray[np.float64]:
+        """
+        Returns a mask if a point of the single mode fiber in the meshgrid is in the stage.
+
+        Parameters
+        ----------
+        position : ChipCoordinate
+            Current position of the stage in Chip-Coordinates
+        mesh_x : np.ndarray
+            X values of the meshgrid
+        mesh_y : np.ndarray
+            Y values of the meshgrid
+        grid_size : float
+            Grid size of meshgrid
+        """
+        x_min, x_max, y_min, y_max = self._create_outline(position, grid_size)
+        return np.logical_and(
+            np.logical_and(x_min <= mesh_x, mesh_x <= x_max),
+            np.logical_and(y_min <= mesh_y, mesh_y <= y_max))
+
+    def _create_outline(
+        self,
+        position: ChipCoordinate,
+        grid_size: float,
+        grid_epsilon: float = 10
+    ) -> Tuple[float, float, float, float]:
+        """
+        Returns a tuple with the X- and Y-axis limits.
+
+        Performs a case distinction according to the orientation of the stage.
+
+        Artificially enlarges the outline, if it is too small for the grid:
+        e.g. If the distance between x_max and x_min is less than or equal to the grid size,
+        half the grid size plus an absolute epsilon is added/subtracted.
+
+        Parameters
+        ----------
+        position : ChipCoordinate
+            Current position of the stage in Chip-Coordinates
+        grid_size : float
+            Grid size of meshgrid
+        grid_epsilon : float
+            Absolute summand to artificially enlarge the obstacle
+            if it is too small for the meshgrid.
+
+        Raises
+        ------
+        ValueError
+            If no outline is defined for the given orientation.
+        """
+        fiber_radius = float(self.parameters.get("Fiber Radius", 75.0))
+        fiber_length = float(self.parameters.get("Fiber Length", 8e4))
+        safety_distance = float(self.parameters.get("Safety Distance", 75.0))
+
+        safe_fiber_radius = fiber_radius + safety_distance
+
+        x_min = position.x - safe_fiber_radius
+        x_max = position.x + safe_fiber_radius
+        y_min = position.y - safe_fiber_radius
+        y_max = position.y + safe_fiber_radius
+
+        if self.orientation == Orientation.LEFT:
+            x_min -= fiber_length
+        elif self.orientation == Orientation.RIGHT:
+            x_max += fiber_length
+        elif self.orientation == Orientation.BOTTOM:
+            y_min -= fiber_length
+        elif self.orientation == Orientation.TOP:
+            y_max += fiber_length
+        else:
+            raise ValueError(f"No Stage Polygon defined for orientation {self.orientation}")
+
+        # Make sure, that outline fits into meshgrid
+        if np.abs(x_max - x_min) <= grid_size:
+            x_max += grid_size / 2 + grid_epsilon
+            x_min -= grid_size / 2 + grid_epsilon
+
+        if np.abs(y_max - y_min) <= grid_size:
+            y_max += grid_size / 2 + grid_epsilon
+            y_min -= grid_size / 2 + grid_epsilon
+
+        return x_min, x_max, y_min, y_max

--- a/LabExT/Movement/Stages/Stage6DSmarActMCS2.py
+++ b/LabExT/Movement/Stages/Stage6DSmarActMCS2.py
@@ -10,7 +10,7 @@ from enum import Enum
 from tkinter import TclError
 from typing import List
 
-from LabExT.Movement.config import Axis_Ch123, Axis_Ch456
+from LabExT.Movement.config import AxisCh123, AxisCh456
 from LabExT.Movement.Stage import Stage, assert_driver_loaded, StageError, assert_stage_connected
 from LabExT.Movement.Stages.ChannelMCS2 import ChannelMCS2
 from LabExT.View.Controls.DriverPathDialog import DriverPathDialog
@@ -71,10 +71,10 @@ class Stage6DSmarActMCS2(Stage):
         self.handle = None
         self.channels = {}
         if "Ch1-3" in address:
-            self.Axis = Axis_Ch123
+            self.Axis = AxisCh123
             self.open_new_connection = True
         elif "Ch4-6" in address:
-            self.Axis = Axis_Ch456
+            self.Axis = AxisCh456
             self.open_new_connection = False
         else:
             raise StageError('Stage address does not contain channel suffix.')

--- a/LabExT/Movement/Transformations.py
+++ b/LabExT/Movement/Transformations.py
@@ -8,11 +8,13 @@ for details see LICENSE file.
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, Any, NamedTuple, Tuple, Type
-from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
+from typing import TYPE_CHECKING, Any, NamedTuple, Tuple, Type, TypeVar, Dict, Optional, Callable, List
+from abc import ABC, abstractmethod
 from functools import wraps
 import numpy as np
+from numpy.typing import NDArray
 
+from LabExT.Movement.Coordinate import StageCoordinate, ChipCoordinate
 from LabExT.Movement.config import Axis, Direction
 
 if TYPE_CHECKING:
@@ -23,145 +25,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger()
 
-
-class Coordinate(ABC):
-    """
-    Abstract base class of a coordinate with X, Y and Z values.
-
-    The base class cannot be initialised directly.
-    """
-    @classmethod
-    def from_list(cls, list: list) -> Type[Coordinate]:
-        """
-        Returns a new coordinate, created from a list.
-        """
-        return cls(*list[:3])
-
-    @classmethod
-    def from_numpy(cls, array: np.ndarray) -> Type[Coordinate]:
-        """
-        Returns a new coordinate created from a one-dimensional numpy array.
-        """
-        if array.ndim != 1:
-            raise ValueError("The given array is not a 1D-Array.")
-
-        return cls(*array.tolist()[:3])
-
-    @abstractmethod
-    def __init__(self, x=0, y=0, z=0) -> None:
-        """
-        Constructor.
-        """
-        self.x = x
-        self.y = y
-        self.z = z
-
-        self.type: Coordinate = type(self)
-
-    def __str__(self) -> str:
-        """
-        Prints coordinate rounded to 2 digits
-        """
-        return "[{:.2f}, {:.2f}, {:.2f}]".format(self.x, self.y, self.z)
-
-    def __add__(self, other) -> Type[Coordinate]:
-        """
-        Adds two coordinates.
-        Returns a new coordinate of the same type.
-
-        Raises TypeError if both coordinates are not the same type.
-        """
-        if not isinstance(other, self.type):
-            raise TypeError(
-                "Invalid types: {} and {} cannot be added.".format(
-                    self.type, type(other)))
-
-        return self.type.from_numpy(self.to_numpy() + other.to_numpy())
-
-    def __sub__(self, other) -> Type[Coordinate]:
-        """
-        Subtracts two coordinates.
-        Returns a new coordinate of the same type.
-
-        Raises TypeError if both coordinates are not the same type.
-        """
-        if not isinstance(other, self.type):
-            raise TypeError(
-                "Invalid types: {} and {} cannot be added.".format(
-                    self.type, type(other)))
-
-        return self.type.from_numpy(self.to_numpy() - other.to_numpy())
-
-    def __eq__(self, o: object) -> bool:
-        """
-        Compares two coordinates.
-
-        Two coordinates are equal, if they are of the same type and all
-        values are equal.
-        """
-        if not isinstance(o, self.type):
-            return False
-
-        return o.x == self.x and o.y == self.y and o.z == self.z
-
-    def __mul__(self, scalar) -> Type[Coordinate]:
-        """
-        Multiplies the coordinate by a scalar.
-        Returns a new coordinate of the same type.
-        """
-        return self.type.from_numpy(self.to_numpy() * scalar)
-
-    @property
-    def is_zero(self) -> bool:
-        """
-        Returns True if the coordinate is equal to [0,0,0]
-        """
-        return np.all(self.to_numpy() == 0)
-
-    def to_list(self) -> list:
-        """
-        Returns the coordinate as a list.
-        """
-        return [self.x, self.y, self.z]
-
-    def to_numpy(self) -> np.ndarray:
-        """
-        Returns the coordinate as a numpy array.
-        """
-        return np.array(self.to_list())
-
-
-class StageCoordinate(Coordinate):
-    """
-    A Coordinate in the coordinate system of a stage.
-    """
-
-    def __init__(self, x=0, y=0, z=0) -> None:
-        super().__init__(x, y, z)
-
-
-class ChipCoordinate(Coordinate):
-    """
-    A Coordinate in the coordinate system of a chip.
-    """
-
-    def __init__(self, x=0, y=0, z=0) -> None:
-        super().__init__(x, y, z)
+TransformationT = TypeVar("TransformationT", bound="Transformation")
+FuncT = TypeVar("FuncT")
 
 
 class CoordinatePairing(NamedTuple):
-    calibration: Type[Calibration]
-    stage_coordinate: Type[StageCoordinate]
-    device: Type[Device]
-    chip_coordinate: Type[ChipCoordinate]
+    calibration: Optional[Calibration]
+    stage_coordinate: StageCoordinate
+    device: Optional[Device]
+    chip_coordinate: ChipCoordinate
 
     @classmethod
     def load(
         cls,
-        pairing: dict,
-        device: Type[Device] = None,
-        calibration: Type[Calibration] = None
-    ) -> Type[CoordinatePairing]:
+        pairing: Dict[str, Any],
+        device: Optional[Device] = None,
+        calibration: Optional[Calibration] = None
+    ) -> CoordinatePairing:
         """
         Creates a new coordinate pairing for given data.
 
@@ -184,113 +64,98 @@ class CoordinatePairing(NamedTuple):
         CoordinatePairing based on the given data
         """
         if "stage_coordinate" not in pairing or "chip_coordinate" not in pairing:
-            raise ValueError(
-                f"Cannot create coordinate paring. Stage and Chip coordinate are required.")
+            raise ValueError("Cannot create coordinate paring. Stage and Chip coordinate are required.")
 
         return cls(
             calibration=calibration,
-            stage_coordinate=StageCoordinate.from_list(
-                pairing["stage_coordinate"]),
+            stage_coordinate=StageCoordinate.from_list(pairing["stage_coordinate"]),
             device=device,
-            chip_coordinate=StageCoordinate.from_list(
-                pairing["chip_coordinate"]))
+            chip_coordinate=StageCoordinate.from_list(pairing["chip_coordinate"])
+        )
 
-    def dump(self, include_device_id: bool = True) -> dict:
+    def dump(self, include_device_id: bool = True) -> Dict[str, Any]:
         """
-        Returns the pairing as dict.
-
-        Includes device ID if required.
+        Returns the pairing as dict. Includes device ID if required.
         """
-        pairing = {
+        pairing: Dict[str, Any] = {
             "stage_coordinate": self.stage_coordinate.to_list(),
-            "chip_coordinate": self.chip_coordinate.to_list()}
+            "chip_coordinate": self.chip_coordinate.to_list()
+        }
 
-        if not include_device_id:
-            return pairing
-
-        if self.device:
+        if include_device_id and self.device is not None:
             pairing["device_id"] = self.device.id
+
         return pairing
 
 
 class Transformation(ABC):
     """
-    Abstract interface for transformations.
-
-    The base class cannot be initialised directly.
+    Abstract interface for transformations. The base class cannot be initialised directly.
     """
 
-    @abstractclassmethod
-    def load(cls, data: Any, *args, **kwargs) -> Type[Transformation]:
+    @classmethod
+    @abstractmethod
+    def load(cls: Type[TransformationT], *args, **kwargs) -> TransformationT:
         """
         Creates a new Transformation from data
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __init__(self) -> None:
-        pass
+        ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_valid(self) -> bool:
         """
         Returns True if the transformation is valid.
         """
-        pass
+        ...
 
     @abstractmethod
     def initialize(self) -> None:
         """
         Initializes the transformation.
         """
-        pass
+        ...
 
     @abstractmethod
-    def chip_to_stage(
-            self,
-            chip_coordinate: Type[ChipCoordinate]) -> Type[StageCoordinate]:
+    def chip_to_stage(self, chip_coordinate: ChipCoordinate) -> StageCoordinate:
         """
         Transforms a coordinate in chip space to stage space.
         """
-        pass
+        ...
 
     @abstractmethod
-    def stage_to_chip(
-            self,
-            stage_coordinate: Type[StageCoordinate]) -> Type[ChipCoordinate]:
+    def stage_to_chip(self, stage_coordinate: StageCoordinate) -> ChipCoordinate:
         """
         Transforms a coordinate in stage space to chip space.
         """
-        pass
+        ...
 
     def dump(self, *args, **kwargs) -> Any:
         """
         Dumps transformation into storable format.
         """
-        pass
+        ...
 
 
 class TransformationError(RuntimeError):
     pass
 
 
-def assert_valid_transformation(func):
+def assert_valid_transformation(func: Callable[..., FuncT]) -> Callable[..., FuncT]:
     """
     Decorator to assert that a transformation is valid.
-
-    Raises
-    ------
-    TransformationError
-        If transformation is not valid.
     """
     @wraps(func)
-    def warp(transformation, *args, **kwargs):
+    def wrapper(transformation: TransformationT, *args, **kwargs) -> FuncT:
         if not transformation.is_valid:
-            raise TransformationError(
-                "Cannot transform with invalid transformation.")
+            raise TransformationError("Cannot transform with invalid transformation.")
 
         return func(transformation, *args, **kwargs)
-    return warp
+    return wrapper
 
 
 class AxesRotation(Transformation):
@@ -305,7 +170,7 @@ class AxesRotation(Transformation):
     """
 
     @classmethod
-    def load(cls, mapping: dict) -> Type[AxesRotation]:
+    def load(cls: Type[AxesRotation], mapping: Dict[str, (str, str)], *args, **kwargs) -> AxesRotation:
         """
         Creates a new axes rotation transformation based on axes mapping.
 
@@ -336,25 +201,21 @@ class AxesRotation(Transformation):
                 chip_axis = Axis[chip_axis]
                 direction = Direction[direction]
                 stage_axis = Axis[stage_axis]
-            except KeyError as err:
+            except KeyError as e:
                 raise TransformationError(
-                    f"The parameter is not defined: {err}. "
+                    f"The parameter is not defined: {e}. "
                     "Make sure to pass a mapping of valid directions and axes.")
 
             axes_rotation.update(chip_axis, direction, stage_axis)
 
         if not axes_rotation.is_valid:
-            raise TransformationError(
-                "Cannot create axes rotation from stored mapping. Mapping is invalid")
+            raise TransformationError("Cannot create axes rotation from stored mapping. Mapping is invalid")
 
         return axes_rotation
 
     def __init__(self) -> None:
-        self.initialize()
-
-    def initialize(self) -> None:
         """
-        Initalises the transformation by defining an identity matrix as a rotation matrix
+        Initialises the transformation by defining an identity matrix as a rotation matrix
         and defining the associated mapping.
         """
         self.matrix = np.identity(len(Axis))
@@ -364,11 +225,28 @@ class AxesRotation(Transformation):
             Axis.Z: (Direction.POSITIVE, Axis.Z),
         }
 
-    def update(
-            self,
-            chip_axis: Axis,
-            direction: Direction,
-            stage_axis: Axis) -> None:
+    def initialize(self) -> None:
+        """
+        Initialises the transformation by defining an identity matrix as a rotation matrix
+        and defining the associated mapping.
+        """
+        self.matrix = np.identity(len(Axis))
+        self.mapping = {
+            Axis.X: (Direction.POSITIVE, Axis.X),
+            Axis.Y: (Direction.POSITIVE, Axis.Y),
+            Axis.Z: (Direction.POSITIVE, Axis.Z),
+        }
+
+    @property
+    def is_valid(self) -> bool:
+        """
+        Checks if given matrix is a permutation matrix.
+        A matrix is a permutation matrix if the sum of each row and column is exactly 1.
+        """
+        abs_matrix = np.absolute(self.matrix)
+        return (abs_matrix.sum(axis=0) == 1).all() and (abs_matrix.sum(axis=1) == 1).all()
+
+    def update(self, chip_axis: Axis, direction: Direction, stage_axis: Axis) -> None:
         """
         Updates the axes rotation matrix.
         Replaces the column vector of given chip with signed (direction) i-th unit vector (i is stage)
@@ -397,71 +275,23 @@ class AxesRotation(Transformation):
 
         self.mapping[chip_axis] = (direction, stage_axis)
 
-        # Replacing column of chip with signed (direction) i-th unit vector (i
-        # is stage)
+        # Replacing column of chip with signed (direction) i-th unit vector (i is stage)
         self.matrix[:, chip_axis.value] = np.eye(
             1, 3, stage_axis.value) * direction.value
 
-    @property
-    def is_valid(self) -> bool:
+    @assert_valid_transformation
+    def chip_to_stage(self, chip_coordinate: ChipCoordinate) -> StageCoordinate:
         """
-        Checks if given matrix is a permutation matrix.
-        A matrix is a permutation matrix if the sum of each row and column is exactly 1.
+        Rotates the chip coordinate according to the axis rotation i.e. axes_rotation.dot(chip_coordinate)
         """
-        abs_matrix = np.absolute(self.matrix)
-        return (
-            abs_matrix.sum(
-                axis=0) == 1).all() and (
-            abs_matrix.sum(
-                axis=1) == 1).all()
+        return StageCoordinate.from_numpy(self.matrix.dot(chip_coordinate.to_numpy()))
 
     @assert_valid_transformation
-    def chip_to_stage(
-            self,
-            chip_coordinate: Type[ChipCoordinate]) -> Type[StageCoordinate]:
-        """
-        Rotates the chip coordinate according to the axes rotation.
-        i.e axes_rotation.dot(chip_coordinate)
-
-        Parameters
-        ----------
-        chip_coordinate: ChipCoordinate
-
-        Returns
-        -------
-        stage_coordinate: StageCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid, i.e. the current rotation is not a permutation matrix.
-        """
-        return StageCoordinate.from_numpy(
-            self.matrix.dot(chip_coordinate.to_numpy()))
-
-    @assert_valid_transformation
-    def stage_to_chip(
-            self,
-            stage_coordinate: Type[StageCoordinate]) -> Type[ChipCoordinate]:
+    def stage_to_chip(self, stage_coordinate: StageCoordinate) -> ChipCoordinate:
         """
         Rotates the stage coordinate according to the inverse axes rotation.
-        i.e np.linalg.inv(axes_rotation).dot(chip_coordinate)
-
-        Parameters
-        ----------
-        stage_coordinate: StageCoordinate
-
-        Returns
-        -------
-        chip_coordinate: ChipCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid, i.e. the current rotation is not a permutation matrix.
         """
-        return ChipCoordinate.from_numpy(
-            np.linalg.inv(self.matrix).dot(stage_coordinate.to_numpy()))
+        return ChipCoordinate.from_numpy(np.linalg.inv(self.matrix).dot(stage_coordinate.to_numpy()))
 
     def dump(self) -> dict:
         """
@@ -469,31 +299,35 @@ class AxesRotation(Transformation):
         """
         return {
             chip_axis.name: (direction.name, stage_axis.name)
-            for chip_axis, (direction, stage_axis) in self.mapping.items()}
+            for chip_axis, (direction, stage_axis) in self.mapping.items()
+        }
 
 
 class SinglePointOffset(Transformation):
     """
     Transformation to convert chip coordinates into stage coordinates and vice versa.
 
-    The transformation requires a correct stage-axis rotation (90 degrees) beforehand, meaning that stage and chip axes are identical after the rotation.
+    The transformation requires a correct stage-axis rotation (90 degrees) beforehand, meaning that stage and chip axes
+    are identical after the rotation.
 
     Functionality:
     - Input is a single stage-chip coordinate pair.
-    - The chip coordinate is rotated by the axis rotation to then calculate an offset between the rotated chip coordinate and the stage coordinate. This offset is stored.
+    - The chip coordinate is rotated by the axis rotation to then calculate an offset between the rotated chip
+      coordinate and the stage coordinate. This offset is stored.
     - Stage-To-Chip: The offset is added to the given stage coordinate. The sum is then rotated to a chip coordinate.
     - Chip-To-Stage: The give chip coordinate is rotated into the stage coordinate system and then the offset is subtracted.
 
-    Note: The transformation assumes that the stage and chip axes are parallel. This is not the case in reality, so this transformation is only an approximation.
+    Note: The transformation assumes that the stage and chip axes are parallel. This is not the case in reality,
+    so this transformation is only an approximation.
     """
 
     @classmethod
     def load(
-        cls,
-        pairing: Any,
-        chip: Type[Chip],
-        axes_rotation: Type[AxesRotation]
-    ) -> Type[SinglePointOffset]:
+        cls: Type[SinglePointOffset],
+        pairing: dict,
+        chip: Chip,
+        axes_rotation: AxesRotation
+    ) -> SinglePointOffset:
         """
         Creates a new single point transformation based on pairing.
 
@@ -520,54 +354,52 @@ class SinglePointOffset(Transformation):
         _device_id = pairing.get("device_id")
         device = chip.devices.get(_device_id)
         if device is None:
-            raise TransformationError(
-                f"Could not find Device with ID {_device_id} for given chip {chip}")
+            raise TransformationError(f"Could not find Device with ID {_device_id} for given chip {chip}")
 
         try:
             pairing = CoordinatePairing.load(pairing, device=device)
-        except Exception as err:
-            raise TransformationError(
-                f"Could not create pairing for {pairing}: {err}")
+        except Exception as e:
+            raise TransformationError(f"Could not create pairing for {pairing}: {e}")
 
         transformation = cls(axes_rotation)
         transformation.update(pairing)
 
         if not transformation.is_valid:
-            raise TransformationError(
-                "Cannot create single point offset from stored pairing. Pairing is invalid")
+            raise TransformationError("Cannot create single point offset from stored pairing. Pairing is invalid")
 
         return transformation
 
-    def __init__(self, axes_rotation: Type[AxesRotation]) -> None:
-        self.axes_rotation: Type[AxesRotation] = axes_rotation
+    def __init__(self, axes_rotation: AxesRotation) -> None:
+        self.axes_rotation = axes_rotation
+        self.pairing: Optional[CoordinatePairing] = None
+        self.stage_offset: Optional[StageCoordinate] = None
 
         if not self.axes_rotation.is_valid:
             raise RuntimeError("The given axes rotation is invalid.")
 
         self.initialize()
 
-    def initialize(self):
+    def initialize(self) -> None:
         """
-        Initalises the transformation by unsetting all coordinates and offsets.
+        Initialise the transformation by unsetting all coordinates and offsets.
         """
         self.pairing = None
-        self.stage_offset: Type[StageCoordinate] = None
+        self.stage_offset = None
 
     def __str__(self) -> str:
         if self.stage_offset is None:
             return "No single point fixed"
 
-        return "Stage-Coordinate {} fixed with Chip-Coordinate {}".format(
-            self.pairing.stage_coordinate, self.pairing.chip_coordinate)
+        return f"Stage-Coordinate {self.pairing.stage_coordinate} fixed with Chip-Coordinate {self.pairing.chip_coordinate}"
 
     @property
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """
-        Returns True if single point transformation is defined, i.e. a offset is defined.
+        Returns True if single point transformation is defined, i.e. an offset is defined.
         """
         return self.stage_offset is not None and self.axes_rotation.is_valid
 
-    def update(self, pairing: Type[CoordinatePairing]) -> None:
+    def update(self, pairing: CoordinatePairing) -> None:
         """
         Updates the offset based on a coordinate pairing.
 
@@ -585,56 +417,23 @@ class SinglePointOffset(Transformation):
             raise ValueError("Incomplete Pairing")
 
         self.pairing = pairing
-        self.stage_offset = self.axes_rotation.chip_to_stage(
-            pairing.chip_coordinate) - pairing.stage_coordinate
+        self.stage_offset = self.axes_rotation.chip_to_stage(pairing.chip_coordinate) - pairing.stage_coordinate
 
     @assert_valid_transformation
-    def chip_to_stage(
-            self,
-            chip_coordinate: Type[ChipCoordinate]) -> Type[StageCoordinate]:
+    def chip_to_stage(self, chip_coordinate: ChipCoordinate) -> StageCoordinate:
         """
         Transforms a chip coordinate into a stage coordinate.
-        Rotates the given chip coordinate to a stage cooridnate and subtracts the stage offset.
-
-        Parameters
-        ----------
-        chip_coordinate: ChipCoordinate
-
-        Returns
-        -------
-        stage_coordinate: StageCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid, i.e. the offset is not defined.
+        Rotates the given chip coordinate to a stage coordinate and subtracts the stage offset.
         """
-        return self.axes_rotation.chip_to_stage(
-            chip_coordinate) - self.stage_offset
+        return self.axes_rotation.chip_to_stage(chip_coordinate) - self.stage_offset
 
     @assert_valid_transformation
-    def stage_to_chip(
-            self,
-            stage_coordinate: Type[StageCoordinate]) -> Type[ChipCoordinate]:
+    def stage_to_chip(self, stage_coordinate: StageCoordinate) -> ChipCoordinate:
         """
         Transforms a stage coordinate into a chip coordinate.
         Adds the stage offset to the given stage coordinate and rotates the result to a chip coordinate.
-
-        Parameters
-        ----------
-        stage_coordinate: StageCoordinate
-
-        Returns
-        -------
-        chip_coordinate: ChipCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid, i.e. the offset is not defined.
         """
-        return self.axes_rotation.stage_to_chip(
-            stage_coordinate + self.stage_offset)
+        return self.axes_rotation.stage_to_chip(stage_coordinate + self.stage_offset)
 
     def dump(self) -> dict:
         """
@@ -658,12 +457,7 @@ class KabschRotation(Transformation):
     MIN_POINTS = 3
 
     @classmethod
-    def load(
-        cls,
-        pairings: list,
-        chip: Type[Chip],
-        axes_rotation: Type[KabschRotation]
-    ) -> Type[Transformation]:
+    def load(cls: Type[KabschRotation], pairings: list, chip: Chip, axes_rotation: AxesRotation) -> KabschRotation:
         """
         Creates a new kabsch rotation based on pairings.
 
@@ -689,36 +483,47 @@ class KabschRotation(Transformation):
         """
         kabsch_rotation = cls(axes_rotation)
         for pairing in pairings:
-            device = chip.devices.get(pairing["device_id"])
+            device_id = pairing["device_id"]
+            device = chip.devices.get(device_id)
             if device is None:
-                raise TransformationError(
-                    f"Could not find Device with ID {pairing['device_id']} for given chip {chip}")
+                raise TransformationError(f"Could not find Device with ID {device_id} for given chip {chip}")
 
             try:
                 pairing = CoordinatePairing.load(pairing, device=device)
-            except Exception as err:
-                raise TransformationError(
-                    f"Could not create pairing for {pairing}: {err}")
+            except Exception as e:
+                raise TransformationError(f"Could not create pairing for {pairing}: {e}")
 
             kabsch_rotation.update(pairing)
 
         if not kabsch_rotation.is_valid:
-            raise TransformationError(
-                "Cannot create kabsch rotation from stored pairings. Rotation is invalid.")
+            raise TransformationError("Cannot create kabsch rotation from stored pairings. Rotation is invalid.")
 
         return kabsch_rotation
 
-    def __init__(self, axes_rotation: Type[AxesRotation]) -> None:
-        self.axes_rotation = axes_rotation
+    def __init__(self, axes_rotation: AxesRotation) -> None:
 
-        if not self.axes_rotation.is_valid:
+        if not axes_rotation.is_valid:
             raise RuntimeError("The given axes rotation is invalid.")
+
+        self.axes_rotation = axes_rotation
+        self.pairings: List[CoordinatePairing] = []
+
+        # Both will be 3xN matrices
+        self.chip_coordinates = np.empty((3, 0), dtype=float)
+        self.stage_coordinates = np.empty((3, 0), dtype=float)
+
+        # TODO: fix type annotations
+        self.rotation_to_chip = None
+        self.translation_to_chip = None
+
+        self.rotation_to_stage = None
+        self.translation_to_stage = None
 
         self.initialize()
 
     def initialize(self) -> None:
         """
-        Initalises the transformation by unsetting all coordinates and offsets.
+        Initialises the transformation by unsetting all coordinates and offsets.
         """
         self.pairings = []
 
@@ -734,8 +539,7 @@ class KabschRotation(Transformation):
 
     def __str__(self) -> str:
         if not self.is_valid:
-            return "No valid rotation defined ({}/{} Points set)".format(
-                len(self.pairings), self.MIN_POINTS)
+            return f"No valid rotation defined ({len(self.pairings)}/{self.MIN_POINTS} Points set)."
 
         return f"Rotation defined with {len(self.pairings)} Points"
 
@@ -746,7 +550,7 @@ class KabschRotation(Transformation):
         """
         return len(self.pairings) >= self.MIN_POINTS
 
-    def update(self, pairing: Type[CoordinatePairing]) -> None:
+    def update(self, pairing: CoordinatePairing) -> None:
         """
         Updates the transformation by adding a new pairing.
         Add the stage coordinate and chip coordinates to a matrix and recalculates the rotation.
@@ -759,16 +563,14 @@ class KabschRotation(Transformation):
         Raises
         ------
         ValueError
-           If the pairing is not well defined or a pairing for the chip has already been set.
+           If the pairing is not well-defined or a pairing for the chip has already been set.
         """
         if not isinstance(pairing, CoordinatePairing) or (
                 pairing.device is None or pairing.chip_coordinate is None or pairing.stage_coordinate is None):
-            raise ValueError(
-                "Use a complete CoordinatePairing object to update the rotation. ")
+            raise ValueError("Use a complete CoordinatePairing object to update the rotation. ")
 
         if any(p.device == pairing.device for p in self.pairings):
-            raise ValueError(
-                "A pairing with this device has already been saved.")
+            raise ValueError("A pairing with this device has already been saved.")
 
         self.pairings.append(pairing)
 
@@ -792,10 +594,15 @@ class KabschRotation(Transformation):
         # -> R * Chip-Coordinates + t = Stage-Coordinates
         # -> R^-1 * Stage-Coordinates + t' = Chip-Coordinates
 
-        self.rotation_to_stage, self.translation_to_stage, self.rotation_to_chip, self.translation_to_chip = rigid_transform_with_orientation_preservation(
-            S=self.chip_coordinates, T=self.stage_coordinates, axes_rotation=self.axes_rotation.matrix)
+        self.rotation_to_stage, self.translation_to_stage, self.rotation_to_chip, self.translation_to_chip = (
+            rigid_transform_with_orientation_preservation(
+                S=self.chip_coordinates,
+                T=self.stage_coordinates,
+                axes_rotation=self.axes_rotation.matrix
+            )
+        )
 
-    def get_z_plane_angles(self) -> Tuple[float, float, float]:
+    def get_z_plane_angles(self) -> Optional[Tuple[float, float, float]]:
         """
         Calculates the angle between the XY plane
         and the plane reconstructed by the Kabsch.
@@ -812,8 +619,7 @@ class KabschRotation(Transformation):
         xy_plane_normal = np.array([0, 0, 1])
         chip_plane_normal = self.rotation_to_stage.dot(xy_plane_normal)
 
-        cos = np.abs(xy_plane_normal.dot(chip_plane_normal)) / \
-            (np.linalg.norm(chip_plane_normal))
+        cos = np.abs(xy_plane_normal.dot(chip_plane_normal)) / (np.linalg.norm(chip_plane_normal))
 
         angle_rad = np.arccos(cos)
         angle_deg = np.rad2deg(angle_rad)
@@ -822,65 +628,35 @@ class KabschRotation(Transformation):
         return angle_rad, angle_deg, angle_per
 
     @assert_valid_transformation
-    def chip_to_stage(
-            self,
-            chip_coordinate: Type[ChipCoordinate]) -> Type[StageCoordinate]:
+    def chip_to_stage(self, chip_coordinate: ChipCoordinate) -> StageCoordinate:
         """
         Transforms a chip coordinate into a stage coordinate.
-
-        Parameters
-        ----------
-        chip_coordinate: ChipCoordinate
-
-        Returns
-        -------
-        stage_coordinate: StageCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid.
         """
         return StageCoordinate.from_numpy((
             self.rotation_to_stage.dot(chip_coordinate.to_numpy()) +
             self.translation_to_stage.T).flatten())
 
-    def stage_to_chip(
-            self,
-            stage_coordinate: Type[StageCoordinate]) -> Type[ChipCoordinate]:
+    @assert_valid_transformation
+    def stage_to_chip(self, stage_coordinate: StageCoordinate) -> ChipCoordinate:
         """
         Transforms a stage coordinate into a chip coordinate.
-
-        Parameters
-        ----------
-        stage_coordinate: StageCoordinate
-
-        Returns
-        -------
-        chip_coordinate: ChipCoordinate
-
-        Raises
-        ------
-        TransformationError: RuntimeError
-            If transformation is not valid.
         """
         return ChipCoordinate.from_numpy((
             self.rotation_to_chip.dot(stage_coordinate.to_numpy()) +
             self.translation_to_chip.T).flatten())
 
-    def dump(self) -> Any:
+    def dump(self) -> List[Any]:
         """
         Returns a list of pairings defining the rotation.
         """
-        return [
-            p.dump(include_device_id=True) for p in self.pairings]
+        return [p.dump(include_device_id=True) for p in self.pairings]
 
 
 def rigid_transform_with_orientation_preservation(
-    S: np.ndarray,
-    T: np.ndarray,
-    axes_rotation: np.ndarray = None
-) -> None:
+    S: NDArray[np.float64],
+    T: NDArray[np.float64],
+    axes_rotation: Optional[NDArray[np.float64]] = None
+) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
     """
     Calculates a rotation matrix that provides optimal rotation with respect
     to least squares error between two sets of 3D coordinates.
@@ -892,21 +668,20 @@ def rigid_transform_with_orientation_preservation(
 
     Parameters
     ----------
-    target_dataset : np.ndarray
-        3xN dataset of N 3-D coordinates (later referenced as T)
-    start_dataset : np.ndarray
-        3xN dataset of N-3D coordinates (later referenced as S)
+    S : NDArray[np.float64]
+        3xN dataset of N-3D coordinates (also referred to as start_dataset)
+    T : NDArray[np.float64]
+        3xN dataset of N-3D coordinates (also referred to as target_dataset)
     axes_rotation : np.ndarray
         3x3 ground truth axes rotation used for orientation preservation
 
-    The algorihm computes a matrix R and translation vector t, such that:
+    The algorithm computes a matrix R and translation vector t, such that:
         RS + t = T
 
     More details: https://github.com/nghiaho12/rigid_transform_3D/blob/master/rigid_transform_3D.py
     """
     if axes_rotation is not None and axes_rotation.shape != (3, 3):
-        raise ValueError(
-            f"Axes rotation matrix must be 3x3, got shape {axes_rotation.shape}")
+        raise ValueError(f"Axes rotation matrix must be 3x3, got shape {axes_rotation.shape}")
 
     if not S.shape == T.shape:
         raise ValueError("Start and target dataset must have the same shape")
@@ -915,12 +690,10 @@ def rigid_transform_with_orientation_preservation(
     start_num_rows, start_num_cols = S.shape
 
     if target_num_rows != 3:
-        raise ValueError(
-            f"Target dataset is not Nx3, got shape {target_num_rows}x{target_num_cols}")
+        raise ValueError(f"Target dataset is not Nx3, got shape {target_num_rows}x{target_num_cols}")
 
     if start_num_rows != 3:
-        raise ValueError(
-            f"Start dataset is not Nx3, got shape {start_num_rows}x{start_num_cols}")
+        raise ValueError(f"Start dataset is not Nx3, got shape {start_num_rows}x{start_num_cols}")
 
     # Centroid col wise
     t_centroid = np.mean(T, axis=1, keepdims=True)
@@ -948,8 +721,7 @@ def rigid_transform_with_orientation_preservation(
     # autocorrect orientation
     if axes_rotation is not None:
         correction_matrix = np.identity(3)
-        for i, unit_vector in enumerate(
-                [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]):
+        for i, unit_vector in enumerate([np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]):
             ground_truth = axes_rotation @ unit_vector
             if ground_truth.dot(R @ unit_vector) < 0:
                 correction_matrix[i, i] = -1
@@ -961,7 +733,7 @@ def rigid_transform_with_orientation_preservation(
     # Find translation for start to target: RS + t = T <=> t = T - RS
     t_start_to_target = t_centroid - R @ s_centroid
 
-    # Find translation for traget to start: R^-1T + t = S <=> t = S - R^-1T
+    # Find translation for target to start: R^-1T + t = S <=> t = S - R^-1T
     t_target_to_start = s_centroid - R_inv @ t_centroid
 
     return R, t_start_to_target, R_inv, t_target_to_start

--- a/LabExT/Movement/config.py
+++ b/LabExT/Movement/config.py
@@ -8,10 +8,11 @@ for details see LICENSE file.
 
 from enum import Enum, auto
 from functools import total_ordering
+from typing import List, Any
 
 
 class BaseEnum(Enum):
-    def _generate_next_value_(name, start, count, last_values):
+    def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]):
         return name
 
     def __str__(self) -> str:
@@ -24,23 +25,26 @@ class Axis(BaseEnum):
     Y = 1
     Z = 2
 
-    def __str__(self) -> str: return f"{self.name}-Axis"
+    def __str__(self) -> str:
+        return f"{self.name}-Axis"
 
-class Axis_Ch123(BaseEnum):
+class AxisCh123(BaseEnum):
     """Enumerate different channels. Each channel represents one axis."""
     X = 0
     Y = 1
     Z = 2
 
-    def __str__(self) -> str: return f"{self.name}-Axis"
+    def __str__(self) -> str:
+        return f"{self.name}-Axis"
 
-class Axis_Ch456(BaseEnum):
+class AxisCh456(BaseEnum):
     """Enumerate different channels. Each channel represents one axis."""
     X = 3
     Y = 4
     Z = 5
 
-    def __str__(self) -> str: return f"{self.name}-Axis"
+    def __str__(self) -> str:
+        return f"{self.name}-Axis"
 
 
 class Direction(BaseEnum):
@@ -61,7 +65,8 @@ CLOCKWISE_ORDERING = [
     Orientation.TOP,
     Orientation.RIGHT,
     Orientation.BOTTOM,
-    Orientation.LEFT]
+    Orientation.LEFT
+]
 
 
 class DevicePort(BaseEnum):
@@ -89,22 +94,22 @@ class State(BaseEnum):
     SINGLE_POINT_FIXED = 3
     FULLY_CALIBRATED = 4
 
-    def __str__(self) -> str: return self.name.replace('_', ' ').capitalize()
+    def __str__(self) -> str:
+        return self.name.replace('_', ' ').capitalize()
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """
         Compare two states for equality.
         """
-        if self.__class__ is other.__class__:
+        if isinstance(other, State):
             return self.value == other.value
-
         return NotImplemented
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         """
         Compare two states on "less than".
         """
-        if self.__class__ is other.__class__:
+        if isinstance(other, State):
             return self.value < other.value
-
         return NotImplemented
+

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -9,12 +9,14 @@ import json
 import logging
 import os
 import time
-from typing import Optional
+from typing import Optional, TYPE_CHECKING, Tuple, List, Dict, Any
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.optimize import curve_fit
 
 from LabExT.Measurements.MeasAPI import Measurement, MeasParamInt, MeasParamFloat, MeasParamList
+from LabExT.Measurements.MeasAPI.Measparam import MeasParam
 from LabExT.Movement.MotorProfiles import trapezoidal_velocity_profile_by_integration
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.config import CoordinateSystem
@@ -22,6 +24,9 @@ from LabExT.Movement.Transformations import StageCoordinate
 from LabExT.Utils import get_configuration_file_path
 from LabExT.View.Controls.PlotControl import PlotData
 from LabExT.ViewModel.Utilities.ObservableList import ObservableList
+
+if TYPE_CHECKING:
+    from LabExT.Experiments.StandardExperiment import StandardExperiment
 
 
 class PeakSearcher(Measurement):
@@ -80,7 +85,7 @@ class PeakSearcher(Measurement):
     DIMENSION_NAMES_TWO_STAGES = ['Left X', 'Left Y', 'Right X', 'Right Y']
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
-    def __init__(self, *args, mover: Optional[MoverNew] = None, parent=None, **kwargs) -> None:
+    def __init__(self, *args, mover: Optional[MoverNew] = None, **kwargs) -> None:
         """Constructor
 
         Parameters
@@ -106,25 +111,24 @@ class PeakSearcher(Measurement):
         self.instr_powermeter = None
         self.initialized = False
 
-        self.logger.info(
-            'Initialized Search for Peak with method: ' + str(self.name))
+        self.logger.info('Initialized Search for Peak with method: ' + str(self.name))
 
     @property
-    def settings_path_full(self):
+    def settings_path_full(self) -> str:
         return get_configuration_file_path(self.settings_filename)
 
-    def set_experiment(self, experiment):
+    def set_experiment(self, experiment: StandardExperiment) -> None:
         """Helper function to keep all initializations in the right order
         This line cannot be included in __init__
         """
         self._experiment = experiment
 
     @staticmethod
-    def _gaussian(xdata, a, mu, sigma, offset):
+    def _gaussian(xdata: NDArray[np.float64], a: float, mu: float, sigma: float , offset: float) -> NDArray[np.float64]:
         return a * np.exp(-(xdata - mu) ** 2 / (2 * sigma ** 2)) + offset
 
     @staticmethod
-    def _gaussian_param_initial_guess(x_data, y_data):
+    def _gaussian_param_initial_guess(x_data: NDArray[np.float64], y_data: NDArray[np.float64]) -> List[float]:
         """
         Crudely estimates initial parameters for a gaussian fitting on 2-dimensional data.
         """
@@ -139,7 +143,10 @@ class PeakSearcher(Measurement):
         return [a_init, mu_init, sigma_init, offset_init]
 
     @staticmethod
-    def fit_gaussian(x_data, y_data):
+    def fit_gaussian(
+            x_data: NDArray[np.float64],
+            y_data: NDArray[np.float64]
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Fits a gaussian function of four parameters to the given x and y data.
 
         Parameters
@@ -194,7 +201,7 @@ class PeakSearcher(Measurement):
         return popt, perr_std_dev
 
     @staticmethod
-    def get_default_parameter():
+    def get_default_parameter() -> Dict[str, MeasParam]:
         return {
             'Laser wavelength': MeasParamInt(value=1550, unit='nm'),
             'Laser power': MeasParamFloat(value=0.0, unit='dBm'),
@@ -208,10 +215,10 @@ class PeakSearcher(Measurement):
         }
 
     @staticmethod
-    def get_wanted_instrument():
+    def get_wanted_instrument() -> List[str]:
         return ['Laser', 'Power Meter']
 
-    def search_for_peak(self):
+    def search_for_peak(self) -> Dict[str, Any]:
         """Main Search For Peak routine
         Uses a 2D gaussian fit for all four dimensions.
 

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -27,6 +27,8 @@ from LabExT.ViewModel.Utilities.ObservableList import ObservableList
 
 if TYPE_CHECKING:
     from LabExT.Experiments.StandardExperiment import StandardExperiment
+else:
+    StandardExperiment = None
 
 
 class PeakSearcher(Measurement):

--- a/LabExT/SearchForPeak/PeakSearcher.py
+++ b/LabExT/SearchForPeak/PeakSearcher.py
@@ -9,12 +9,12 @@ import json
 import logging
 import os
 import time
-from typing import Type
+from typing import Optional
 
 import numpy as np
 from scipy.optimize import curve_fit
 
-from LabExT.Measurements.MeasAPI import *
+from LabExT.Measurements.MeasAPI import Measurement, MeasParamInt, MeasParamFloat, MeasParamList
 from LabExT.Movement.MotorProfiles import trapezoidal_velocity_profile_by_integration
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.config import CoordinateSystem
@@ -74,19 +74,13 @@ class PeakSearcher(Measurement):
     - **(swept SfP only) Search time**: Time the mechanical movement across the set measurement range should take in [s].
     - **(swept SfP only) Number of points**: Number of points to collect at the power meter for each separate sweep.
 
-    All parameters labelled `stepped SfP only` are ignored when choosing the swept SfP, all parameters labelled `swept SfP only` are ignored when choosing the stepped SfP.
+    All parameters labeled `stepped SfP only` are ignored when choosing the swept SfP, all parameters labelled `swept SfP only` are ignored when choosing the stepped SfP.
     """
 
     DIMENSION_NAMES_TWO_STAGES = ['Left X', 'Left Y', 'Right X', 'Right Y']
     DIMENSION_NAMES_SINGLE_STAGE = ['X', 'Y']
 
-    def __init__(
-        self,
-        *args,
-        mover: Type[MoverNew] = None,
-        parent=None,
-        **kwargs
-    ) -> None:
+    def __init__(self, *args, mover: Optional[MoverNew] = None, parent=None, **kwargs) -> None:
         """Constructor
 
         Parameters
@@ -96,7 +90,7 @@ class PeakSearcher(Measurement):
         """
         super().__init__(*args, **kwargs)  # calling parent constructor
 
-        self._parent = parent
+        # self._parent = parent
         self.name = "SearchForPeak-2DGaussianFit"
         self.settings_filename = "PeakSearcher_settings.json"
         self.mover = mover
@@ -144,7 +138,8 @@ class PeakSearcher(Measurement):
 
         return [a_init, mu_init, sigma_init, offset_init]
 
-    def fit_gaussian(self, x_data, y_data):
+    @staticmethod
+    def fit_gaussian(x_data, y_data):
         """Fits a gaussian function of four parameters to the given x and y data.
 
         Parameters
@@ -194,10 +189,6 @@ class PeakSearcher(Measurement):
                               ftol=1e-8,
                               maxfev=10000)
 
-        self.logger.debug('Gaussian Fit:')
-        self.logger.debug('a -- mu -- sigma -- offset')
-        self.logger.debug(str(popt))
-
         perr_std_dev = np.sqrt(np.diag(cov))
 
         return popt, perr_std_dev
@@ -232,13 +223,11 @@ class PeakSearcher(Measurement):
         """
         # double check if mover is actually enabled
         if self.mover.left_calibration is None and self.mover.right_calibration is None:
-            raise RuntimeError(
-                "The Search for Peak requires at least one left or right stage configured.")
-
+            raise RuntimeError("The Search for Peak requires at least one left or right stage configured.")
         if self.mover.left_calibration and self.mover.right_calibration:
-            self._dimension_names = self.DIMENSION_NAMES_TWO_STAGES
+            DIMENSION_NAMES = self.DIMENSION_NAMES_TWO_STAGES
         else:
-            self._dimension_names = self.DIMENSION_NAMES_SINGLE_STAGE
+            DIMENSION_NAMES = self.DIMENSION_NAMES_SINGLE_STAGE
 
         # load laser and powermeter
         self.instr_powermeter = self.get_instrument('Power Meter')
@@ -267,7 +256,7 @@ class PeakSearcher(Measurement):
         results = {
             'name': self.name,
             'parameter': {},
-            'start location': None,
+            'start location': [],
             'start through power': None,
             'optimized location': None,
             'optimized through power': None,
@@ -314,23 +303,20 @@ class PeakSearcher(Measurement):
 
                 # find the current positions of the stages as starting point for
                 # SFP
-                _left_start_coordinates = []
-                _right_start_coordinates = []
+                start_coordinates: list[float] = []
                 if self.mover.left_calibration:
-                    _left_start_coordinates = self.mover.left_calibration.get_position().to_list()[
-                        :2]
+                    start_coordinates.extend(self.mover.left_calibration.get_position().to_list()[:2])
                 if self.mover.right_calibration:
-                    _right_start_coordinates = self.mover.right_calibration.get_position().to_list()[
-                        :2]
-                start_coordinates = _left_start_coordinates + _right_start_coordinates
-                current_coordinates = start_coordinates.copy()
+                    start_coordinates.extend(self.mover.right_calibration.get_position().to_list()[:2])
+
+                current_coordinates = list(start_coordinates)
 
                 self.logger.debug(f"Start Position: {start_coordinates}")
 
                 estimated_through_power = -99.0
 
                 # get start statistics
-                results['start location'] = start_coordinates.copy()
+                results['start location'] = start_coordinates
                 results['start through power'] = self.instr_powermeter.power
 
                 # do sweep for every dimension
@@ -338,7 +324,7 @@ class PeakSearcher(Measurement):
                 color_strings = ['C' + str(i) for i in range(10)]
                 for dimidx, p_start in enumerate(start_coordinates):
 
-                    dimension_name = self._dimension_names[dimidx]
+                    dimension_name = DIMENSION_NAMES[dimidx]
 
                     # create new plotting dataset for measurement
                     meas_plot = PlotData(ObservableList(), ObservableList(),
@@ -549,23 +535,23 @@ class PeakSearcher(Measurement):
     def _move_stages_absolute(self, coordinates: list):
         with self.mover.set_stages_coordinate_system(CoordinateSystem.STAGE):
             if self.mover.left_calibration and self.mover.right_calibration:
-                leftz = self.mover.left_calibration.get_position().z
-                rightz = self.mover.right_calibration.get_position().z
+                left_z = self.mover.left_calibration.get_position().z
+                right_z = self.mover.right_calibration.get_position().z
                 assert len(coordinates) == 4
                 self.mover.left_calibration.move_absolute(
-                    StageCoordinate.from_list(coordinates[:2] + [leftz]))
+                    StageCoordinate.from_list(coordinates[:2] + [left_z]))
                 self.mover.right_calibration.move_absolute(
-                    StageCoordinate.from_list(coordinates[2:] + [rightz]))
+                    StageCoordinate.from_list(coordinates[2:] + [right_z]))
             elif self.mover.left_calibration:
-                leftz = self.mover.left_calibration.get_position().z
+                left_z = self.mover.left_calibration.get_position().z
                 assert len(coordinates) == 2
                 self.mover.left_calibration.move_absolute(
-                    StageCoordinate.from_list(coordinates + [leftz]))
+                    StageCoordinate.from_list(coordinates + [left_z]))
             elif self.mover.right_calibration:
-                rightz = self.mover.right_calibration.get_position().z
+                right_z = self.mover.right_calibration.get_position().z
                 assert len(coordinates) == 2
                 self.mover.right_calibration.move_absolute(
-                    StageCoordinate.from_list(coordinates + [rightz]))
+                    StageCoordinate.from_list(coordinates + [right_z]))
             else:
                 raise RuntimeError()
 

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -9,31 +9,65 @@ import unittest
 import numpy as np
 from unittest.mock import Mock, patch, call
 from parameterized import parameterized
-from LabExT.Movement.PathPlanning import SingleModeFiber
 
 from LabExT.Tests.Utils import get_calibrations_from_file
-
+from LabExT.Movement.Coordinate import StageCoordinate, ChipCoordinate
+from LabExT.Movement.Polygons import SingleModeFiber
 from LabExT.Movement.config import State, Orientation, DevicePort, Axis, Direction, CoordinateSystem
 from LabExT.Movement.Stage import StageError
 from LabExT.Movement.Stages.DummyStage import DummyStage
 from LabExT.Movement.MoverNew import MoverNew
-from LabExT.Movement.Transformations import ChipCoordinate, CoordinatePairing, StageCoordinate
-from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
-from ...Wafer.Chip import Chip
+from LabExT.Movement.Transformations import CoordinatePairing
+from LabExT.Wafer.Chip import Chip
 from LabExT.Wafer.Device import Device
 
 EXPECTED_TO_REJECT = [
-    (State.UNINITIALIZED, [State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
-    (State.CONNECTED, [State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
-    (State.COORDINATE_SYSTEM_FIXED, [State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]),
-    (State.SINGLE_POINT_FIXED, [State.FULLY_CALIBRATED])]
+    (
+        State.UNINITIALIZED,
+        [State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]
+    ),
+    (
+        State.CONNECTED,
+        [State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]
+    ),
+    (
+        State.COORDINATE_SYSTEM_FIXED,
+        [State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED]
+    ),
+    (
+        State.SINGLE_POINT_FIXED,
+        [State.FULLY_CALIBRATED]
+    )
+]
 
 EXPECTED_TO_ACCEPT = [
-    (State.UNINITIALIZED, [State.UNINITIALIZED]),
-    (State.CONNECTED, [State.UNINITIALIZED, State.CONNECTED]),
-    (State.COORDINATE_SYSTEM_FIXED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED]),
-    (State.SINGLE_POINT_FIXED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED]),
-    (State.FULLY_CALIBRATED, [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED, State.FULLY_CALIBRATED])]
+    (
+        State.UNINITIALIZED,
+        [State.UNINITIALIZED]
+    ),
+    (
+        State.CONNECTED,
+        [State.UNINITIALIZED, State.CONNECTED]
+    ),
+    (
+        State.COORDINATE_SYSTEM_FIXED,
+        [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED]
+    ),
+    (
+        State.SINGLE_POINT_FIXED,
+        [State.UNINITIALIZED, State.CONNECTED, State.COORDINATE_SYSTEM_FIXED, State.SINGLE_POINT_FIXED]
+    ),
+    (
+        State.FULLY_CALIBRATED,
+        [
+            State.UNINITIALIZED,
+            State.CONNECTED,
+            State.COORDINATE_SYSTEM_FIXED,
+            State.SINGLE_POINT_FIXED,
+            State.FULLY_CALIBRATED
+        ]
+    )
+]
 
 VACHERIN_ROTATION, VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS = get_calibrations_from_file("vacherin.json", "left")
 
@@ -52,120 +86,104 @@ VALID_AXES_MAPPING = [
 
 class CalibrationTestCase(unittest.TestCase):
     def setUp(self) -> None:
+        from LabExT.Movement.Calibration import Calibration
         self.stage = DummyStage('usb:123456789')
-
         self.mover = MoverNew(None)
-
-        self.calibration = Calibration(
-            self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.Calibration = Calibration
+        self.calibration = Calibration(self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
 
     def set_valid_axes_rotation(self):
         for chip_axis, direction, stage_axis in VALID_AXES_MAPPING:
-            self.calibration.update_axes_rotation(
-                chip_axis, direction, stage_axis)
+            self.calibration.update_axes_rotation(chip_axis, direction, stage_axis)
 
     def set_invalid_axes_rotation(self):
         for chip_axis, direction, stage_axis in INVALID_AXES_MAPPING:
-            self.calibration.update_axes_rotation(
-                chip_axis, direction, stage_axis)
+            self.calibration.update_axes_rotation(chip_axis, direction, stage_axis)
 
     def set_valid_single_point_offset(self):
         self.calibration.update_single_point_offset(CoordinatePairing(
             self.calibration,
             StageCoordinate.from_numpy(VACHERIN_STAGE_COORDS[0]),
-            Device(id=1, type='test', in_position=[0,0], out_position=[1,1]),
+            Device(id="1", type='test', in_position=[0,0], out_position=[1,1]),
             ChipCoordinate.from_numpy(VACHERIN_CHIP_COORDS[0])
         ))
 
     def set_valid_kabsch_rotation(self):
-        for device_id, (stage_coord, chip_coord) in enumerate(zip(
-                VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS)):
+        for device_id, (stage_coord, chip_coord) in enumerate(zip(VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS)):
             self.calibration.update_kabsch_rotation(CoordinatePairing(
                 calibration=self.calibration,
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
-                device=Device(id=device_id, in_position=[0,0], out_position=[1,1], type='bla'),
-                chip_coordinate=ChipCoordinate.from_numpy(chip_coord)))
+                device=Device(id=str(device_id), in_position=[0,0], out_position=[1,1], type='bla'),
+                chip_coordinate=ChipCoordinate.from_numpy(chip_coord)
+            ))
 
 
 class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
     def setUp(self) -> None:
+        from LabExT.Movement.Calibration import (
+            Calibration,
+            CalibrationError,
+            assert_minimum_state_for_coordinate_system
+        )
+
+        self.Calibration = Calibration
+        self.CalibrationError = CalibrationError
+        self.assert_min_state = assert_minimum_state_for_coordinate_system
+
         self.calibration = Mock(spec=Calibration)
         self.func = Mock()
         self.func.__name__ = "Dummy Function"
 
-        self.low_state = 0
-        self.high_state = 1
-
-        return super().setUp()
-
     def test_raises_error_if_coordinate_system_is_not_fixed(self):
         self.calibration.coordinate_system = CoordinateSystem.UNKNOWN
 
-        with self.assertRaises(CalibrationError):
-            assert_minimum_state_for_coordinate_system()(self.func)(self.calibration)
+        with self.assertRaises(self.CalibrationError):
+            self.assert_min_state()(self.func)(self.calibration)
 
         self.func.assert_not_called()
 
     @parameterized.expand(EXPECTED_TO_REJECT)
-    def test_rejectes_all_states_higher_than_given_in_chip_system(
-            self,
-            given_state,
-            required_states):
+    def test_rejects_all_states_higher_than_given_in_chip_system(self, given_state, required_states):
         self.calibration.coordinate_system = CoordinateSystem.CHIP
         self.calibration.state = given_state
 
         for required_state in required_states:
-            with self.assertRaises(CalibrationError):
-                assert_minimum_state_for_coordinate_system(
-                    chip_coordinate_system=required_state
-                )(self.func)(self.calibration)
+            self.func.reset_mock()
+            with self.assertRaises(self.CalibrationError):
+                self.assert_min_state(chip_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_not_called()
 
     @parameterized.expand(EXPECTED_TO_REJECT)
-    def test_rejectes_all_states_higher_than_given_in_stage_system(
-            self,
-            given_state,
-            required_states):
+    def test_rejects_all_states_higher_than_given_in_stage_system(self, given_state, required_states):
         self.calibration.coordinate_system = CoordinateSystem.STAGE
         self.calibration.state = given_state
 
         for required_state in required_states:
-            with self.assertRaises(CalibrationError):
-                assert_minimum_state_for_coordinate_system(
-                    stage_coordinate_system=required_state
-                )(self.func)(self.calibration)
+            self.func.reset_mock()
+            with self.assertRaises(self.CalibrationError):
+                self.assert_min_state(stage_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_not_called()
 
     @parameterized.expand(EXPECTED_TO_ACCEPT)
-    def test_accepts_all_states_higher_than_given_in_chip_system(
-            self,
-            given_state,
-            required_states):
+    def test_accepts_all_states_higher_than_given_in_chip_system(self, given_state, required_states):
         self.calibration.coordinate_system = CoordinateSystem.CHIP
         self.calibration.state = given_state
 
         for required_state in required_states:
-            assert_minimum_state_for_coordinate_system(
-                chip_coordinate_system=required_state
-            )(self.func)(self.calibration)
+            self.assert_min_state(chip_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_called_once()
             self.func.reset_mock()
 
     @parameterized.expand(EXPECTED_TO_ACCEPT)
-    def test_accepts_all_states_higher_than_given_in_stage_system(
-            self,
-            given_state,
-            required_states):
+    def test_accepts_all_states_higher_than_given_in_stage_system(self, given_state, required_states):
         self.calibration.coordinate_system = CoordinateSystem.STAGE
         self.calibration.state = given_state
 
         for required_state in required_states:
-            assert_minimum_state_for_coordinate_system(
-                stage_coordinate_system=required_state
-            )(self.func)(self.calibration)
+            self.assert_min_state(stage_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_called_once()
             self.func.reset_mock()
@@ -196,9 +214,7 @@ class CoordinateSystemControlTest(CalibrationTestCase):
     def test_perform_in_valid_system(self, valid_system):
         prior_system = self.calibration.coordinate_system
         with self.calibration.perform_in_system(valid_system):
-            self.assertEqual(
-                self.calibration.coordinate_system,
-                valid_system)
+            self.assertEqual(self.calibration.coordinate_system, valid_system)
 
         self.assertEqual(self.calibration.coordinate_system, prior_system)
 
@@ -209,9 +225,7 @@ class CoordinateSystemControlTest(CalibrationTestCase):
         prior_system = self.calibration.coordinate_system
         with self.assertRaises(ValueError):
             with self.calibration.perform_in_system(invalid_system):
-                self.assertEqual(
-                    self.calibration.coordinate_system,
-                    prior_system)
+                self.assertEqual(self.calibration.coordinate_system, prior_system)
 
         self.assertEqual(self.calibration.coordinate_system, prior_system)
 
@@ -221,18 +235,14 @@ class CoordinateSystemControlTest(CalibrationTestCase):
 
         with self.assertRaises(RuntimeError):
             with self.calibration.perform_in_system(CoordinateSystem.CHIP):
-                self.assertEqual(
-                    self.calibration.coordinate_system,
-                    CoordinateSystem.CHIP)
+                self.assertEqual(self.calibration.coordinate_system, CoordinateSystem.CHIP)
                 func()
 
         self.assertEqual(self.calibration.coordinate_system, CoordinateSystem.UNKNOWN)
 
         with self.assertRaises(RuntimeError):
             with self.calibration.perform_in_system(CoordinateSystem.STAGE):
-                self.assertEqual(
-                    self.calibration.coordinate_system,
-                    CoordinateSystem.STAGE)
+                self.assertEqual(self.calibration.coordinate_system, CoordinateSystem.STAGE)
                 func()
 
         self.assertEqual(self.calibration.coordinate_system, CoordinateSystem.UNKNOWN)
@@ -338,6 +348,7 @@ class DetermineStateTest(CalibrationTestCase):
 class CalibrationTest(CalibrationTestCase):
 
     def test_position_in_stage_coordinate_raises_error_if_unconnected(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -345,8 +356,8 @@ class CalibrationTest(CalibrationTestCase):
             with self.assertRaises(CalibrationError):
                 self.calibration.get_position()
 
-    def test_position_in_chip_coordinate_raises_error_if_not_single_point_fixed(
-            self):
+    def test_position_in_chip_coordinate_raises_error_if_not_single_point_fixed(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_valid_axes_rotation()
         self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
@@ -372,10 +383,8 @@ class CalibrationTest(CalibrationTestCase):
         get_position_mock.assert_called_once()
 
     @patch.object(DummyStage, "get_position")
-    def test_position_in_chip_coordinates_with_single_point_offset(
-            self, get_position_mock):
-        expected_stage_pos, expected_chip_pos = (
-            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+    def test_position_in_chip_coordinates_with_single_point_offset(self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
         get_position_mock.return_value = expected_stage_pos
 
         with self.calibration.perform_in_system(CoordinateSystem.CHIP):
@@ -386,20 +395,13 @@ class CalibrationTest(CalibrationTestCase):
         self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
 
         self.assertIsInstance(position, ChipCoordinate)
-        self.assertTrue(
-            np.allclose(
-                position.to_numpy(),
-                expected_chip_pos,
-                rtol=1,
-                atol=1))
+        self.assertTrue(np.allclose(position.to_numpy(), expected_chip_pos, rtol=1, atol=1))
 
         get_position_mock.assert_called_once()
 
     @patch.object(DummyStage, "get_position")
-    def test_position_in_chip_coordinates_with_kabsch_rotation(
-            self, get_position_mock):
-        expected_stage_pos, expected_chip_pos = (
-            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+    def test_position_in_chip_coordinates_with_kabsch_rotation(self, get_position_mock):
+        expected_stage_pos, expected_chip_pos = (VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
         get_position_mock.return_value = expected_stage_pos
 
         with self.calibration.perform_in_system(CoordinateSystem.CHIP):
@@ -411,17 +413,12 @@ class CalibrationTest(CalibrationTestCase):
         self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
 
         self.assertIsInstance(position, ChipCoordinate)
-        self.assertTrue(
-            np.allclose(
-                position.to_numpy(),
-                expected_chip_pos,
-                rtol=1,
-                atol=1))
+        self.assertTrue(np.allclose(position.to_numpy(), expected_chip_pos, rtol=1, atol=1))
 
         get_position_mock.assert_called_once()
 
-    def test_move_relative_in_stage_coordinate_raises_error_if_unconnected(
-            self):
+    def test_move_relative_in_stage_coordinate_raises_error_if_unconnected(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -429,8 +426,8 @@ class CalibrationTest(CalibrationTestCase):
             with self.assertRaises(CalibrationError):
                 self.calibration.move_relative(StageCoordinate(1, 2, 3))
 
-    def test_move_relative_in_chip_coordinate_raises_error_if_axes_rotation_invalid(
-            self):
+    def test_move_relative_in_chip_coordinate_raises_error_if_axes_rotation_invalid(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_invalid_axes_rotation()
         self.assertEqual(self.calibration.state, State.CONNECTED)
@@ -441,46 +438,42 @@ class CalibrationTest(CalibrationTestCase):
 
     @parameterized.expand([(True,), (False,)])
     @patch.object(DummyStage, "move_relative")
-    def test_move_relative_in_stage_coordinates(
-            self, wait_for_stopping, move_relative_mock):
+    def test_move_relative_in_stage_coordinates(self, wait_for_stopping, move_relative_mock):
         self.set_invalid_axes_rotation()
         required_movement = [100.0, 200.0, 300.0]
 
         with self.calibration.perform_in_system(CoordinateSystem.STAGE):
             self.calibration.connect_to_stage()
-            self.calibration.move_relative(
-                StageCoordinate.from_list(required_movement),
-                wait_for_stopping)
+            self.calibration.move_relative(StageCoordinate.from_list(required_movement), wait_for_stopping)
 
         self.assertEqual(self.calibration.state, State.CONNECTED)
         move_relative_mock.assert_called_once_with(
             x=required_movement[0],
             y=required_movement[1],
             z=required_movement[2],
-            wait_for_stopping=wait_for_stopping)
+            wait_for_stopping=wait_for_stopping
+        )
 
     @parameterized.expand([(True,), (False,)])
     @patch.object(DummyStage, "move_relative")
-    def test_move_relative_in_chip_coordinates_with_axes_rotation(
-            self, wait_for_stopping, move_relative_mock):
+    def test_move_relative_in_chip_coordinates_with_axes_rotation(self, wait_for_stopping, move_relative_mock):
         self.set_valid_axes_rotation()
         required_movement = [100.0, 200.0, 300.0]
 
         with self.calibration.perform_in_system(CoordinateSystem.CHIP):
             self.calibration.connect_to_stage()
-            self.calibration.move_relative(
-                ChipCoordinate.from_list(required_movement),
-                wait_for_stopping)
+            self.calibration.move_relative(ChipCoordinate.from_list(required_movement), wait_for_stopping)
 
         self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
         move_relative_mock.assert_called_once_with(
             x=required_movement[1],
             y=-required_movement[2],
             z=-required_movement[0],
-            wait_for_stopping=wait_for_stopping)
+            wait_for_stopping=wait_for_stopping
+        )
 
-    def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(
-            self):
+    def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -488,8 +481,8 @@ class CalibrationTest(CalibrationTestCase):
             with self.assertRaises(CalibrationError):
                 self.calibration.move_absolute(StageCoordinate(1, 2, 3))
 
-    def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(
-            self):
+    def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(self):
+        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_valid_axes_rotation()
         self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
@@ -500,74 +493,64 @@ class CalibrationTest(CalibrationTestCase):
 
     @parameterized.expand([(True,), (False,)])
     @patch.object(DummyStage, "move_absolute")
-    def test_move_absolute_in_stage_coordinates(
-            self, wait_for_stopping, move_absolute_mock):
+    def test_move_absolute_in_stage_coordinates(self, wait_for_stopping, move_absolute_mock):
         self.set_invalid_axes_rotation()
         required_movement = [100.0, 200.0, 300.0]
 
         with self.calibration.perform_in_system(CoordinateSystem.STAGE):
             self.calibration.connect_to_stage()
-            self.calibration.move_absolute(
-                StageCoordinate.from_list(required_movement),
-                wait_for_stopping)
+            self.calibration.move_absolute(StageCoordinate.from_list(required_movement), wait_for_stopping)
 
         self.assertEqual(self.calibration.state, State.CONNECTED)
         move_absolute_mock.assert_called_once_with(
             x=required_movement[0],
             y=required_movement[1],
             z=required_movement[2],
-            wait_for_stopping=wait_for_stopping)
+            wait_for_stopping=wait_for_stopping
+        )
 
     @patch.object(DummyStage, "move_absolute")
-    def test_move_absolute_in_chip_coordinates_with_single_point_offset(
-            self, move_absolute_mock):
+    def test_move_absolute_in_chip_coordinates_with_single_point_offset(self, move_absolute_mock):
         self.set_valid_single_point_offset()
-        expected_stage_pos, expected_chip_pos = (
-            VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
+        expected_stage_pos, expected_chip_pos = (VACHERIN_STAGE_COORDS[1], VACHERIN_CHIP_COORDS[1])
 
         with self.calibration.perform_in_system(CoordinateSystem.CHIP):
             self.calibration.connect_to_stage()
-            self.calibration.move_absolute(
-                ChipCoordinate.from_numpy(expected_chip_pos),
-                True)
+            self.calibration.move_absolute(ChipCoordinate.from_numpy(expected_chip_pos), True)
 
         self.assertEqual(self.calibration.state, State.SINGLE_POINT_FIXED)
 
         move_absolute_mock.assert_called_once()
 
         _, kwargs = move_absolute_mock.call_args
-        self.assertTrue(
-            np.allclose(
-                expected_stage_pos,
-                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
-                rtol=1,
-                atol=1))
+        self.assertTrue(np.allclose(
+            expected_stage_pos,
+            np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+            rtol=1,
+            atol=1
+        ))
 
     @patch.object(DummyStage, "move_absolute")
-    def test_move_absolute_in_chip_coordinates_with_kabsch_rotation(
-            self, move_absolute_mock):
+    def test_move_absolute_in_chip_coordinates_with_kabsch_rotation(self, move_absolute_mock):
         self.set_valid_single_point_offset()
         self.set_valid_kabsch_rotation()
-        expected_stage_pos, expected_chip_pos = (
-            VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
+        expected_stage_pos, expected_chip_pos = (VACHERIN_STAGE_COORDS[3], VACHERIN_CHIP_COORDS[3])
 
         with self.calibration.perform_in_system(CoordinateSystem.CHIP):
             self.calibration.connect_to_stage()
-            self.calibration.move_absolute(
-                ChipCoordinate.from_numpy(expected_chip_pos),
-                True)
+            self.calibration.move_absolute(ChipCoordinate.from_numpy(expected_chip_pos), True)
 
         self.assertEqual(self.calibration.state, State.FULLY_CALIBRATED)
 
         move_absolute_mock.assert_called_once()
 
         _, kwargs = move_absolute_mock.call_args
-        self.assertTrue(
-            np.allclose(
-                expected_stage_pos,
-                np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
-                rtol=1,
-                atol=1))
+        self.assertTrue(np.allclose(
+            expected_stage_pos,
+            np.array([kwargs.get('x'), kwargs.get('y'), kwargs.get('z')]),
+            rtol=1,
+            atol=1
+        ))
 
     @parameterized.expand([
         (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
@@ -579,16 +562,17 @@ class CalibrationTest(CalibrationTestCase):
             x_movement,
             y_movement,
             z_movement,
-            move_relative_mock):
+            move_relative_mock
+    ):
 
         self.calibration.connect_to_stage()
         self.set_valid_axes_rotation()
-        self.calibration.wiggle_axis(
-            wiggle_axis, wiggle_distance=1000, wait_time=0)
+        self.calibration.wiggle_axis(wiggle_axis, wiggle_distance=1000, wait_time=0)
 
         move_relative_mock.assert_has_calls([
             call(x=y_movement, y=-z_movement, z=-x_movement, wait_for_stopping=True),
-            call(x=-y_movement, y=z_movement, z=x_movement, wait_for_stopping=True)])
+            call(x=-y_movement, y=z_movement, z=x_movement, wait_for_stopping=True)
+        ])
 
     @parameterized.expand([
         (Axis.X, 1000, 0, 0), (Axis.Y, 0, 1000, 0), (Axis.Z, 0, 0, 1000)
@@ -604,26 +588,24 @@ class CalibrationTest(CalibrationTestCase):
             z_movement,
             set_speed_z_mock,
             set_speed_xy_mock,
-            move_relative_mock):
+            move_relative_mock
+    ):
         current_speed_xy = self.stage._speed_xy
         current_speed_z = self.stage._speed_z
 
         self.calibration.connect_to_stage()
 
-        self.calibration.wiggle_axis(
-            wiggle_axis,
-            wiggle_distance=1000,
-            wiggle_speed=5000,
-            wait_time=0)
+        self.calibration.wiggle_axis(wiggle_axis, wiggle_distance=1000, wiggle_speed=5000, wait_time=0)
 
         move_relative_mock.assert_has_calls([
             call(x=x_movement, y=y_movement, z=z_movement, wait_for_stopping=True),
-            call(x=-x_movement, y=-y_movement, z=-z_movement, wait_for_stopping=True)])
+            call(x=-x_movement, y=-y_movement, z=-z_movement, wait_for_stopping=True)
+        ])
         set_speed_z_mock.assert_has_calls([call(5000), call(current_speed_z)])
-        set_speed_xy_mock.assert_has_calls(
-            [call(5000), call(current_speed_xy)])
+        set_speed_xy_mock.assert_has_calls([call(5000), call(current_speed_xy)])
 
     def test_dump_includes_orientation_and_port(self):
+        from LabExT.Movement.Calibration import Calibration
         calibration = Calibration(self.mover, self.stage, Orientation.BOTTOM, DevicePort.INPUT)
         calibration_dump = calibration.dump()
 
@@ -639,70 +621,86 @@ class CalibrationTest(CalibrationTestCase):
         self.set_valid_single_point_offset()
 
         self.assertTrue(self.calibration._single_point_offset.is_valid)
-        self.assertDictEqual(self.calibration.dump()["single_point_offset"], {
-            'stage_coordinate': [23236.35, -7888.67, 18956.06],
-            'chip_coordinate': [-1550.0, 1120.0, 0.0],
-            'device_id': 1
-        })
+        self.assertDictEqual(
+            self.calibration.dump()["single_point_offset"],
+            {
+                'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                'device_id': "1"
+            }
+        )
 
     def test_dump_with_axes_rotation(self):
         self.set_valid_axes_rotation()
 
         self.assertTrue(self.calibration._axes_rotation.is_valid)
-        self.assertDictEqual(self.calibration.dump()["axes_rotation"], {
-            'X': ('NEGATIVE', 'Z'),
-            'Y': ('POSITIVE', 'X'),
-            'Z': ('NEGATIVE', 'Y')
-        })
+        self.assertDictEqual(
+            self.calibration.dump()["axes_rotation"],
+            {
+                'X': ('NEGATIVE', 'Z'),
+                'Y': ('POSITIVE', 'X'),
+                'Z': ('NEGATIVE', 'Y')
+            }
+        )
 
     def test_dump_with_kabsch_rotation(self):
         self.set_valid_kabsch_rotation()
         self.assertTrue(self.calibration._kabsch_rotation.is_valid)
-        self.assertListEqual(self.calibration.dump()["kabsch_rotation"], [
-            {
-                'stage_coordinate': [23236.35, -7888.67, 18956.06],
-                'chip_coordinate': [-1550.0, 1120.0, 0.0],
-                'device_id': 0
-            },
-            {
-                'stage_coordinate': [23744.6, -9172.55, 18956.1],
-                'chip_coordinate': [-1050.0, -160.0, 0.0],
-                'device_id': 1
-            },
-            {
-                'stage_coordinate': [25846.07, -10348.82, 18955.11],
-                'chip_coordinate': [1046.25, -1337.5, 0.0],
-                'device_id': 2
-            },
-            {
-                'stage_coordinate': [25837.8, -7721.47, 18972.08],
-                'chip_coordinate': [1046.25, 1287.5, 0.0],
-                'device_id': 3
-            }])
+        self.assertListEqual(
+            self.calibration.dump()["kabsch_rotation"],
+            [
+                {
+                    'stage_coordinate': [23236.35, -7888.67, 18956.06],
+                    'chip_coordinate': [-1550.0, 1120.0, 0.0],
+                    'device_id': "0"
+                },
+                {
+                    'stage_coordinate': [23744.6, -9172.55, 18956.1],
+                    'chip_coordinate': [-1050.0, -160.0, 0.0],
+                    'device_id': "1"
+                },
+                {
+                    'stage_coordinate': [25846.07, -10348.82, 18955.11],
+                    'chip_coordinate': [1046.25, -1337.5, 0.0],
+                    'device_id': "2"
+                },
+                {
+                    'stage_coordinate': [25837.8, -7721.47, 18972.08],
+                    'chip_coordinate': [1046.25, 1287.5, 0.0],
+                    'device_id': "3"
+                }
+            ]
+        )
 
         
     def test_dump_with_stage_polygon(self):
-        polygon = SingleModeFiber(Orientation.LEFT, parameters={
-            "Fiber Radius": 100.0,
-            "Safety Distance": 100.0,
-            "Fiber Length": 10e4
-        })
-        calibration = Calibration(
-            self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT,
-            stage_polygon=polygon)
-
-        self.assertDictEqual(calibration.dump()["stage_polygon"], {
-            "polygon_cls": "SingleModeFiber",
-            "orientation": "LEFT",
-            "parameters": {
+        from LabExT.Movement.Calibration import Calibration
+        polygon = SingleModeFiber(
+            Orientation.LEFT,
+            parameters={
                 "Fiber Radius": 100.0,
                 "Safety Distance": 100.0,
                 "Fiber Length": 10e4
             }
-        })
+        )
+        calibration = Calibration(self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT, stage_polygon=polygon)
+
+        self.assertDictEqual(
+            calibration.dump()["stage_polygon"],
+            {
+                "polygon_cls": "SingleModeFiber",
+                "orientation": "LEFT",
+                "parameters": {
+                    "Fiber Radius": 100.0,
+                    "Safety Distance": 100.0,
+                    "Fiber Length": 10e4
+                }
+            }
+        )
 
 
     def test_load_with_axes_rotation(self):
+        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         calibration_data = {
             "orientation": "LEFT",
@@ -718,13 +716,14 @@ class CalibrationTest(CalibrationTestCase):
         self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
 
     def test_load_with_single_point_offset(self):
+        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
             path="/example/path",
-            devices=[
-                Device(id=0, in_position=[23236.35, -7888.67, 18956.06], out_position=[0,0], type='bla')
-            ], _serialize_to_disk=False)
+            devices=[Device(id="0", in_position=[23236.35, -7888.67, 18956.06], out_position=[0,0], type='bla')],
+            _serialize_to_disk=False
+        )
 
         calibration_data = {
             "orientation": "LEFT",
@@ -737,7 +736,7 @@ class CalibrationTest(CalibrationTestCase):
             "single_point_offset": {
                 'stage_coordinate': [23236.35, -7888.67, 18956.06],
                 'chip_coordinate': [-1550.0, 1120.0, 0.0],
-                'device_id': 0
+                'device_id': "0"
             }
         }
 
@@ -745,16 +744,19 @@ class CalibrationTest(CalibrationTestCase):
         self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
 
     def test_load_with_kabsch_rotation(self):
+        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
             path="/example/path",
             devices=[
-                Device(id=0, in_position=[0,0], out_position=[1,1], type='bla'),
-                Device(id=1, in_position=[2,2], out_position=[3,3], type='bla'),
-                Device(id=2, in_position=[4,4], out_position=[5,5], type='bla'),
-                Device(id=3, in_position=[6,6], out_position=[7,7], type='bla')
-            ], _serialize_to_disk=False)
+                Device(id="0", in_position=[0,0], out_position=[1,1], type='bla'),
+                Device(id="1", in_position=[2,2], out_position=[3,3], type='bla'),
+                Device(id="2", in_position=[4,4], out_position=[5,5], type='bla'),
+                Device(id="3", in_position=[6,6], out_position=[7,7], type='bla')
+            ],
+            _serialize_to_disk=False
+        )
 
         calibration_data = {
             "orientation": "LEFT",
@@ -767,28 +769,28 @@ class CalibrationTest(CalibrationTestCase):
             "single_point_offset": {
                 'stage_coordinate': [23236.35, -7888.67, 18956.06],
                 'chip_coordinate': [-1550.0, 1120.0, 0.0],
-                'device_id': 1
+                'device_id': "1"
             },
             "kabsch_rotation": [
                 {
                     'stage_coordinate': [23236.35, -7888.67, 18956.06],
                     'chip_coordinate': [-1550.0, 1120.0, 0.0],
-                    'device_id': 0
+                    'device_id': "0"
                 },
                 {
                     'stage_coordinate': [23744.6, -9172.55, 18956.1],
                     'chip_coordinate': [-1050.0, -160.0, 0.0],
-                    'device_id': 1
+                    'device_id': "1"
                 },
                 {
                     'stage_coordinate': [25846.07, -10348.82, 18955.11],
                     'chip_coordinate': [1046.25, -1337.5, 0.0],
-                    'device_id': 2
+                    'device_id': "2"
                 },
                 {
                     'stage_coordinate': [25837.8, -7721.47, 18972.08],
                     'chip_coordinate': [1046.25, 1287.5, 0.0],
-                    'device_id': 3
+                    'device_id': "3"
                 }   
             ]
         }
@@ -797,16 +799,19 @@ class CalibrationTest(CalibrationTestCase):
         self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
 
     def test_load_with_stage_polygon(self):
+        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
             path="/example/path",
             devices=[
-                Device(id=0, in_position=[0,0], out_position=[1,1], type='bla'),
-                Device(id=1, in_position=[2,2], out_position=[3,3], type='bla'),
-                Device(id=2, in_position=[4,4], out_position=[5,5], type='bla'),
-                Device(id=3, in_position=[6,6], out_position=[7,7], type='bla')
-            ], _serialize_to_disk=False)
+                Device(id="0", in_position=[0,0], out_position=[1,1], type='bla'),
+                Device(id="1", in_position=[2,2], out_position=[3,3], type='bla'),
+                Device(id="2", in_position=[4,4], out_position=[5,5], type='bla'),
+                Device(id="3", in_position=[6,6], out_position=[7,7], type='bla')
+            ],
+            _serialize_to_disk=False
+        )
 
         calibration_data = {
             "orientation": "LEFT",
@@ -825,10 +830,12 @@ class CalibrationTest(CalibrationTestCase):
         restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
         
         self.assertIsInstance(restored_calibration.stage_polygon, SingleModeFiber)
-        self.assertDictEqual(restored_calibration.stage_polygon.parameters, {
-            "Fiber Radius": 100.0,
-            "Safety Distance": 100.0,
-            "Fiber Length": 10e4
-        })
+        self.assertDictEqual(
+            restored_calibration.stage_polygon.parameters,
+            {
+                "Fiber Radius": 100.0,
+                "Safety Distance": 100.0,
+                "Fiber Length": 10e4
+            }
+        )
         self.assertEqual(restored_calibration.stage_polygon.orientation, Orientation.LEFT)
-

--- a/LabExT/Tests/Movement/Calibration_test.py
+++ b/LabExT/Tests/Movement/Calibration_test.py
@@ -10,6 +10,7 @@ import numpy as np
 from unittest.mock import Mock, patch, call
 from parameterized import parameterized
 
+from LabExT.Movement.Calibration import Calibration, CalibrationError, assert_minimum_state_for_coordinate_system
 from LabExT.Tests.Utils import get_calibrations_from_file
 from LabExT.Movement.Coordinate import StageCoordinate, ChipCoordinate
 from LabExT.Movement.Polygons import SingleModeFiber
@@ -86,11 +87,9 @@ VALID_AXES_MAPPING = [
 
 class CalibrationTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        from LabExT.Movement.Calibration import Calibration
         self.stage = DummyStage('usb:123456789')
         self.mover = MoverNew(None)
-        self.Calibration = Calibration
-        self.calibration = Calibration(self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.calibration = Calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
 
     def set_valid_axes_rotation(self):
         for chip_axis, direction, stage_axis in VALID_AXES_MAPPING:
@@ -120,14 +119,7 @@ class CalibrationTestCase(unittest.TestCase):
 
 class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
     def setUp(self) -> None:
-        from LabExT.Movement.Calibration import (
-            Calibration,
-            CalibrationError,
-            assert_minimum_state_for_coordinate_system
-        )
 
-        self.Calibration = Calibration
-        self.CalibrationError = CalibrationError
         self.assert_min_state = assert_minimum_state_for_coordinate_system
 
         self.calibration = Mock(spec=Calibration)
@@ -137,7 +129,7 @@ class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
     def test_raises_error_if_coordinate_system_is_not_fixed(self):
         self.calibration.coordinate_system = CoordinateSystem.UNKNOWN
 
-        with self.assertRaises(self.CalibrationError):
+        with self.assertRaises(CalibrationError):
             self.assert_min_state()(self.func)(self.calibration)
 
         self.func.assert_not_called()
@@ -149,7 +141,7 @@ class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
 
         for required_state in required_states:
             self.func.reset_mock()
-            with self.assertRaises(self.CalibrationError):
+            with self.assertRaises(CalibrationError):
                 self.assert_min_state(chip_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_not_called()
@@ -161,7 +153,7 @@ class AssertMinimumStateForCoordinateSystemTest(unittest.TestCase):
 
         for required_state in required_states:
             self.func.reset_mock()
-            with self.assertRaises(self.CalibrationError):
+            with self.assertRaises(CalibrationError):
                 self.assert_min_state(stage_coordinate_system=required_state)(self.func)(self.calibration)
 
             self.func.assert_not_called()
@@ -348,7 +340,6 @@ class DetermineStateTest(CalibrationTestCase):
 class CalibrationTest(CalibrationTestCase):
 
     def test_position_in_stage_coordinate_raises_error_if_unconnected(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -357,7 +348,6 @@ class CalibrationTest(CalibrationTestCase):
                 self.calibration.get_position()
 
     def test_position_in_chip_coordinate_raises_error_if_not_single_point_fixed(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_valid_axes_rotation()
         self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
@@ -418,7 +408,6 @@ class CalibrationTest(CalibrationTestCase):
         get_position_mock.assert_called_once()
 
     def test_move_relative_in_stage_coordinate_raises_error_if_unconnected(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -427,7 +416,6 @@ class CalibrationTest(CalibrationTestCase):
                 self.calibration.move_relative(StageCoordinate(1, 2, 3))
 
     def test_move_relative_in_chip_coordinate_raises_error_if_axes_rotation_invalid(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_invalid_axes_rotation()
         self.assertEqual(self.calibration.state, State.CONNECTED)
@@ -473,7 +461,6 @@ class CalibrationTest(CalibrationTestCase):
         )
 
     def test_move_absolute_in_stage_coordinate_raises_error_if_unconnected(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.disconnect_to_stage()
         self.assertEqual(self.calibration.state, State.UNINITIALIZED)
 
@@ -482,7 +469,6 @@ class CalibrationTest(CalibrationTestCase):
                 self.calibration.move_absolute(StageCoordinate(1, 2, 3))
 
     def test_move_absolute_in_chip_coordinate_raises_error_if_not_single_point_fixed(self):
-        from LabExT.Movement.Calibration import CalibrationError
         self.calibration.connect_to_stage()
         self.set_valid_axes_rotation()
         self.assertEqual(self.calibration.state, State.COORDINATE_SYSTEM_FIXED)
@@ -605,8 +591,7 @@ class CalibrationTest(CalibrationTestCase):
         set_speed_xy_mock.assert_has_calls([call(5000), call(current_speed_xy)])
 
     def test_dump_includes_orientation_and_port(self):
-        from LabExT.Movement.Calibration import Calibration
-        calibration = Calibration(self.mover, self.stage, Orientation.BOTTOM, DevicePort.INPUT)
+        calibration = Calibration(self.stage, Orientation.BOTTOM, DevicePort.INPUT)
         calibration_dump = calibration.dump()
 
         self.assertEqual(calibration_dump["orientation"], "BOTTOM")
@@ -674,7 +659,6 @@ class CalibrationTest(CalibrationTestCase):
 
         
     def test_dump_with_stage_polygon(self):
-        from LabExT.Movement.Calibration import Calibration
         polygon = SingleModeFiber(
             Orientation.LEFT,
             parameters={
@@ -683,7 +667,7 @@ class CalibrationTest(CalibrationTestCase):
                 "Fiber Length": 10e4
             }
         )
-        calibration = Calibration(self.mover, self.stage, Orientation.LEFT, DevicePort.INPUT, stage_polygon=polygon)
+        calibration = Calibration(self.stage, Orientation.LEFT, DevicePort.INPUT, stage_polygon=polygon)
 
         self.assertDictEqual(
             calibration.dump()["stage_polygon"],
@@ -700,7 +684,6 @@ class CalibrationTest(CalibrationTestCase):
 
 
     def test_load_with_axes_rotation(self):
-        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         calibration_data = {
             "orientation": "LEFT",
@@ -712,11 +695,10 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data)
+        restored_calibration = Calibration.load(self.stage, calibration_data)
         self.assertEqual(restored_calibration.state, State.COORDINATE_SYSTEM_FIXED)
 
     def test_load_with_single_point_offset(self):
-        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
@@ -740,11 +722,10 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip=chip)
+        restored_calibration = Calibration.load(self.stage, calibration_data, chip=chip)
         self.assertEqual(restored_calibration.state, State.SINGLE_POINT_FIXED)
 
     def test_load_with_kabsch_rotation(self):
-        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
@@ -795,11 +776,10 @@ class CalibrationTest(CalibrationTestCase):
             ]
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.stage, calibration_data, chip)
         self.assertEqual(restored_calibration.state, State.FULLY_CALIBRATED)
 
     def test_load_with_stage_polygon(self):
-        from LabExT.Movement.Calibration import Calibration
         self.stage.connect()
         chip = Chip(
             name="Dummy Chip",
@@ -827,7 +807,7 @@ class CalibrationTest(CalibrationTestCase):
             }
         }
 
-        restored_calibration = Calibration.load(self.mover, self.stage, calibration_data, chip)
+        restored_calibration = Calibration.load(self.stage, calibration_data, chip)
         
         self.assertIsInstance(restored_calibration.stage_polygon, SingleModeFiber)
         self.assertDictEqual(

--- a/LabExT/Tests/Movement/Coordinate_test.py
+++ b/LabExT/Tests/Movement/Coordinate_test.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY;
+for details see LICENSE file.
+"""
+import unittest
+from typing import Type, List
+
+import numpy as np
+from numpy.typing import NDArray
+from parameterized import parameterized
+
+from LabExT.Movement.Coordinate import Coordinate, StageCoordinate, ChipCoordinate
+
+
+class CoordinateTest(unittest.TestCase):
+
+    list_parameterized = parameterized.expand([
+        ([1, 2, 3, 4], 1, 2, 3),
+        ([1, 2, 3], 1, 2, 3),
+        ([1, 2], 1, 2, 0),
+        ([1], 1, 0, 0),
+        ([], 0, 0, 0)
+    ])
+    array_parameterized = parameterized.expand([
+        (np.array([1, 2, 3, 4]), 1, 2, 3),
+        (np.array([1, 2, 3]), 1, 2, 3),
+        (np.array([1, 2]), 1, 2, 0),
+        (np.array([1]), 1, 0, 0),
+        (np.array([]), 0, 0, 0)
+    ])
+
+    def test_cannot_instantiate_base_class(self):
+        with self.assertRaises(TypeError):
+            Coordinate()
+
+        with self.assertRaises(TypeError):
+            Coordinate.from_list([1, 2, 3])
+
+        with self.assertRaises(TypeError):
+            Coordinate.from_numpy(np.array([1, 2, 3]))
+
+    @parameterized.expand([(np.array([[1]]),), (np.array([[1], [2], [3]]),)])
+    def test_from_numpy_accepts_only_1D_arrays(self, array: NDArray[np.float64]):
+        with self.assertRaises(ValueError):
+            Coordinate.from_numpy(array)
+
+    @parameterized.expand([
+        (StageCoordinate(1, 2, 3), ChipCoordinate(1, 2, 3)),
+        (ChipCoordinate(1, 2, 3), StageCoordinate(1, 2, 3)),
+        (StageCoordinate(1, 2, 3), StageCoordinate(4, 5, 6)),
+        (ChipCoordinate(1, 2, 3), ChipCoordinate(4, 5, 6)),
+    ])
+    def test_unequal_coordinates(self, coord_1: Coordinate, coord_2: Coordinate):
+        self.assertNotEqual(coord_1, coord_2)
+
+    @parameterized.expand([
+        (StageCoordinate(1, 2, 3), StageCoordinate(1, 2, 3)),
+        (ChipCoordinate(1, 2, 3), ChipCoordinate(1, 2, 3)),
+    ])
+    def test_equal_coordinates(self, coord_1: Coordinate, coord_2: Coordinate):
+        self.assertEqual(coord_1, coord_2)
+
+    def assert_build_from_list(
+            self,
+            coordinate_type: Type[Coordinate],
+            _list: List[float],
+            x: float,
+            y: float,
+            z: float
+    ):
+        self._assert_coordinate_with_correct_values(
+            coordinate_type.from_list(_list), x, y, z)
+
+    def assert_build_from_numpy(
+            self,
+            coordinate_type: Type[Coordinate],
+            array: NDArray[np.float64],
+            x: float,
+            y: float,
+            z: float
+    ):
+        self._assert_coordinate_with_correct_values(coordinate_type.from_numpy(array), x, y, z)
+
+    def _assert_coordinate_with_correct_values(self, coordinate: Coordinate, x: float, y: float, z: float):
+        self.assertEqual(coordinate.x, x)
+        self.assertEqual(coordinate.y, y)
+        self.assertEqual(coordinate.z, z)
+
+
+class StageCoordinateTest(CoordinateTest):
+    @CoordinateTest.list_parameterized
+    def test_from_list(self, _list: List[float], x: float, y: float, z: float):
+        self.assert_build_from_list(StageCoordinate, _list, x, y, z)
+
+    @CoordinateTest.array_parameterized
+    def test_from_numpy(self, array: NDArray[np.float64], x: float, y: float, z: float):
+        self.assert_build_from_numpy(StageCoordinate, array, x, y, z)
+
+    def test_to_list(self):
+        self.assertEqual(StageCoordinate(1, 2, 3).to_list(), [1, 2, 3])
+
+    def test_to_numpy(self):
+        self.assertTrue(np.array_equal(StageCoordinate(1, 2, 3).to_numpy(), np.array([1, 2, 3])))
+
+    @parameterized.expand([(ChipCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)])
+    def test_add_with_incompatible_types(self, other):
+        with self.assertRaises(TypeError):
+            StageCoordinate(1, 2, 3) + other
+
+    @parameterized.expand([(ChipCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)])
+    def test_sub_with_incompatible_types(self, other):
+        with self.assertRaises(TypeError):
+            StageCoordinate(1, 2, 3) - other
+
+    def test_add_with_compatible_types(self):
+        _sum = StageCoordinate.from_list([1, 2, 3]) + StageCoordinate.from_list([1, 2, 3])
+        self.assertIsInstance(_sum, StageCoordinate)
+        self.assertEqual(_sum.to_list(), [2, 4, 6])
+
+    def test_sub_with_compatible_types(self):
+        diff = StageCoordinate.from_list([1, 2, 3]) - StageCoordinate.from_list([1, 2, 3])
+        self.assertIsInstance(diff, StageCoordinate)
+        self.assertEqual(diff.to_list(), [0, 0, 0])
+
+    def test_multiplication_with_scalar(self):
+        mult = StageCoordinate(1, 2, 3) * 2
+        self.assertIsInstance(mult, StageCoordinate)
+        self.assertEqual(mult.to_list(), [2, 4, 6])
+
+
+class ChipCoordinateTest(CoordinateTest):
+    @CoordinateTest.list_parameterized
+    def test_from_list(self, _list: List[float], x: float, y: float, z: float):
+        self.assert_build_from_list(ChipCoordinate, _list, x, y, z)
+
+    @CoordinateTest.array_parameterized
+    def test_from_numpy(self, array: NDArray[np.float64], x: float, y: float, z: float):
+        self.assert_build_from_numpy(ChipCoordinate, array, x, y, z)
+
+    def test_to_list(self):
+        self.assertEqual(ChipCoordinate(1, 2, 3).to_list(), [1, 2, 3])
+
+    def test_to_numpy(self):
+        self.assertTrue(np.array_equal(ChipCoordinate(1, 2, 3).to_numpy(), np.array([1, 2, 3])))
+
+    @parameterized.expand([(StageCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)])
+    def test_add_with_incompatible_types(self, other):
+        with self.assertRaises(TypeError):
+            ChipCoordinate(1, 2, 3) + other
+
+    @parameterized.expand([(StageCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)])
+    def test_sub_with_incompatible_types(self, other):
+        with self.assertRaises(TypeError):
+            ChipCoordinate(1, 2, 3) - other
+
+    def test_add_with_compatible_types(self):
+        _sum = ChipCoordinate.from_list([1, 2, 3]) + ChipCoordinate.from_list([1, 2, 3])
+        self.assertIsInstance(_sum, ChipCoordinate)
+        self.assertEqual(_sum.to_list(), [2, 4, 6])
+
+    def test_sub_with_compatible_types(self):
+        diff = ChipCoordinate.from_list([1, 2, 3]) - ChipCoordinate.from_list([1, 2, 3])
+        self.assertIsInstance(diff, ChipCoordinate)
+        self.assertEqual(diff.to_list(), [0, 0, 0])
+
+    def test_multiplication_with_scalar(self):
+        mult = ChipCoordinate(1, 2, 3) * 2
+        self.assertIsInstance(mult, ChipCoordinate)
+        self.assertEqual(mult.to_list(), [2, 4, 6])

--- a/LabExT/Tests/Movement/MoverNew_test.py
+++ b/LabExT/Tests/Movement/MoverNew_test.py
@@ -29,10 +29,8 @@ class AssertConnectedStagesTest(unittest.TestCase):
 
         return super().setUp()
 
-    def test_assert_connected_stages_raises_error_if_no_stage_is_connected(
-            self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+    def test_assert_connected_stages_raises_error_if_no_stage_is_connected(self):
+        self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         self.stage.disconnect()
 
         func = Mock()
@@ -43,10 +41,8 @@ class AssertConnectedStagesTest(unittest.TestCase):
 
         func.assert_not_called()
 
-    def test_assert_connected_stages_calls_function_if_stage_is_connected(
-            self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+    def test_assert_connected_stages_calls_function_if_stage_is_connected(self):
+        self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         self.stage.connect()
 
         func = Mock()
@@ -65,8 +61,7 @@ class AddStageCalibrationTest(unittest.TestCase):
         self.stage = DummyStage('usb:123456789')
         self.stage2 = DummyStage('usb:9887654321')
 
-        with patch.object(MoverNew, "MOVER_SETTINGS_FILE",
-                          return_value="/mocked/mover_settings.json"):
+        with patch.object(MoverNew, "MOVER_SETTINGS_FILE", return_value="/mocked/mover_settings.json"):
             self.mover = MoverNew(None)
 
         return super().setUp()
@@ -74,17 +69,14 @@ class AddStageCalibrationTest(unittest.TestCase):
     def test_default_mover_settings_after_initialization(self):
         self.assertEqual(self.mover._speed_xy, self.mover.DEFAULT_SPEED_XY)
         self.assertEqual(self.mover._speed_z, self.mover.DEFAULT_SPEED_Z)
-        self.assertEqual(
-            self.mover._acceleration_xy,
-            self.mover.DEFAULT_ACCELERATION_XY)
+        self.assertEqual(self.mover._acceleration_xy, self.mover.DEFAULT_ACCELERATION_XY)
         self.assertEqual(self.mover._z_lift, self.mover.DEFAULT_Z_LIFT)
 
     def test_add_stage_calibration_reject_invalid_orientations(self):
         current_calibrations = self.mover.calibrations
 
         with self.assertRaises(ValueError):
-            self.mover.add_stage_calibration(
-                self.stage, 1, DevicePort.INPUT)
+            self.mover.add_stage_calibration(self.stage, 1, DevicePort.INPUT)
 
         self.assertEqual(current_calibrations, self.mover.calibrations)
 
@@ -97,94 +89,74 @@ class AddStageCalibrationTest(unittest.TestCase):
         self.assertEqual(current_calibrations, self.mover.calibrations)
 
     def test_add_stage_calibration_reject_double_orientations(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        valid_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         current_calibrations = self.mover.calibrations
 
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
+        self.assertEqual(current_calibrations[(Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
 
         with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage2, Orientation.LEFT, DevicePort.OUTPUT)
+            self.mover.add_stage_calibration(self.stage2, Orientation.LEFT, DevicePort.OUTPUT)
 
         with self.assertRaises(KeyError):
             self.mover.calibrations[(Orientation.LEFT, DevicePort.OUTPUT)]
 
-        self.assertEqual(
-            "A stage has already been assigned for Left.", str(
-                error_context.exception))
+        self.assertEqual("A stage has already been assigned for Left.", str(error_context.exception))
         self.assertEqual(current_calibrations, self.mover.calibrations)
         self.assertEqual(1, len(self.mover.calibrations))
 
     def test_add_stage_calibration_reject_double_ports(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        valid_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         current_calibrations = self.mover.calibrations
 
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
+        self.assertEqual(current_calibrations[(Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
 
         with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage2, Orientation.RIGHT, DevicePort.INPUT)
+            self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.INPUT)
 
         with self.assertRaises(KeyError):
             self.mover.calibrations[(Orientation.RIGHT, DevicePort.INPUT)]
 
-        self.assertEqual(
-            "A stage has already been assigned for the Input port.", str(
-                error_context.exception))
+        self.assertEqual("A stage has already been assigned for the Input port.", str(error_context.exception))
         self.assertEqual(current_calibrations, self.mover.calibrations)
         self.assertEqual(1, len(self.mover.calibrations))
 
     def test_add_stage_calibration_reject_double_stages(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        valid_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         current_calibrations = self.mover.calibrations
 
-        self.assertEqual(current_calibrations[(
-            Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
+        self.assertEqual(current_calibrations[(Orientation.LEFT, DevicePort.INPUT)], valid_calibration)
 
         with self.assertRaises(MoverError) as error_context:
-            self.mover.add_stage_calibration(
-                self.stage, Orientation.TOP, DevicePort.OUTPUT)
+            self.mover.add_stage_calibration(self.stage, Orientation.TOP, DevicePort.OUTPUT)
 
-        self.assertEqual("Stage {} has already an assignment.".format(
-            str(self.stage)), str(error_context.exception))
+        self.assertEqual(f"Stage {self.stage} has already an assignment.", str(error_context.exception))
         self.assertEqual(current_calibrations, self.mover.calibrations)
         self.assertEqual(1, len(self.mover.calibrations))
 
     def test_active_stage_includes_new_stage(self):
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
 
         self.assertIn(self.stage, self.mover.active_stages)
         self.assertIn(self.stage2, self.mover.active_stages)
 
     def test_left_and_input_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         self.assertEqual(calibration, self.mover.left_calibration)
         self.assertEqual(calibration, self.mover.input_calibration)
 
     def test_right_and_output_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.RIGHT, DevicePort.OUTPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.RIGHT, DevicePort.OUTPUT)
         self.assertEqual(calibration, self.mover.right_calibration)
         self.assertEqual(calibration, self.mover.output_calibration)
 
     def test_top_and_input_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.TOP, DevicePort.INPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.TOP, DevicePort.INPUT)
         self.assertEqual(calibration, self.mover.top_calibration)
         self.assertEqual(calibration, self.mover.input_calibration)
 
     def test_bottom_and_output_calibration_property(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
         self.assertEqual(calibration, self.mover.bottom_calibration)
         self.assertEqual(calibration, self.mover.output_calibration)
 
@@ -193,14 +165,11 @@ class AddStageCalibrationTest(unittest.TestCase):
         self.assertIsNone(self.stage.get_speed_xy())
         self.assertIsNone(self.stage.get_acceleration_xy())
 
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
+        self.mover.add_stage_calibration(self.stage, Orientation.BOTTOM, DevicePort.OUTPUT)
 
         self.assertEqual(self.stage.get_speed_xy(), self.mover._speed_xy)
         self.assertEqual(self.stage.get_speed_z(), self.mover._speed_z)
-        self.assertEqual(
-            self.stage.get_acceleration_xy(),
-            self.mover._acceleration_xy)
+        self.assertEqual(self.stage.get_acceleration_xy(), self.mover._acceleration_xy)
 
 
 class MoverStageSettingsTest(unittest.TestCase):
@@ -215,10 +184,8 @@ class MoverStageSettingsTest(unittest.TestCase):
         with patch.object(MoverNew, "MOVER_SETTINGS_FILE", "/mocked/mover_settings.json"):
             self.mover = MoverNew(None)
 
-        self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
 
         self.stage.connect()
         self.stage2.connect()
@@ -228,28 +195,21 @@ class MoverStageSettingsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as error:
             self.mover.speed_xy = self.mover.SPEED_LOWER_BOUND - 1
 
-        self.assertEqual(
-            "Speed for xy is out of valid range.", str(
-                error.exception))
-        self.assertTrue(all(
-            s.get_speed_xy() == self.mover._speed_xy for s in self.mover.connected_stages))
+        self.assertEqual("Speed for xy is out of valid range.", str(error.exception))
+        self.assertTrue(all(s.get_speed_xy() == self.mover._speed_xy for s in self.mover.connected_stages))
 
     def test_set_speed_xy_raises_error_if_upper_bound_is_violated(self):
         with self.assertRaises(ValueError) as error:
             self.mover.speed_xy = self.mover.SPEED_UPPER_BOUND + 1
 
-        self.assertEqual(
-            "Speed for xy is out of valid range.", str(
-                error.exception))
-        self.assertTrue(all(
-            s.get_speed_xy() == self.mover._speed_xy for s in self.mover.connected_stages))
+        self.assertEqual("Speed for xy is out of valid range.", str(error.exception))
+        self.assertTrue(all(s.get_speed_xy() == self.mover._speed_xy for s in self.mover.connected_stages))
 
     def test_set_speed_xy_for_all_stages(self):
         self.mover.speed_xy = 200
 
         self.assertEqual(self.mover._speed_xy, 200)
-        self.assertTrue(
-            all(s.get_speed_xy() == 200 for s in self.mover.connected_stages))
+        self.assertTrue(all(s.get_speed_xy() == 200 for s in self.mover.connected_stages))
 
     def test_get_speed_xy(self):
         self.mover.speed_xy = 200
@@ -267,28 +227,21 @@ class MoverStageSettingsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as error:
             self.mover.speed_z = self.mover.SPEED_LOWER_BOUND - 1
 
-        self.assertEqual(
-            "Speed for z is out of valid range.", str(
-                error.exception))
-        self.assertTrue(
-            all(s.get_speed_z() == self.mover._speed_z for s in self.mover.connected_stages))
+        self.assertEqual("Speed for z is out of valid range.", str(error.exception))
+        self.assertTrue(all(s.get_speed_z() == self.mover._speed_z for s in self.mover.connected_stages))
 
     def test_set_speed_z_raises_error_if_upper_bound_is_violated(self):
         with self.assertRaises(ValueError) as error:
             self.mover.speed_z = self.mover.SPEED_UPPER_BOUND + 1
 
-        self.assertEqual(
-            "Speed for z is out of valid range.", str(
-                error.exception))
-        self.assertTrue(
-            all(s.get_speed_z() == self.mover._speed_z for s in self.mover.connected_stages))
+        self.assertEqual("Speed for z is out of valid range.", str(error.exception))
+        self.assertTrue(all(s.get_speed_z() == self.mover._speed_z for s in self.mover.connected_stages))
 
     def test_set_speed_z_for_all_stages(self):
         self.mover.speed_z = 200
 
         self.assertEqual(self.mover._speed_z, 200)
-        self.assertTrue(
-            all(s.get_speed_z() == 200 for s in self.mover.connected_stages))
+        self.assertTrue(all(s.get_speed_z() == 200 for s in self.mover.connected_stages))
 
     def test_get_speed_z(self):
         self.mover.speed_z = 200
@@ -306,28 +259,25 @@ class MoverStageSettingsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as error:
             self.mover.acceleration_xy = self.mover.ACCELERATION_LOWER_BOUND - 1
 
-        self.assertEqual(
-            "Acceleration for xy is out of valid range.", str(
-                error.exception))
-        self.assertTrue(all(s.get_acceleration_xy(
-        ) == self.mover._acceleration_xy for s in self.mover.connected_stages))
+        self.assertEqual("Acceleration for xy is out of valid range.", str(error.exception))
+        self.assertTrue(
+            all(s.get_acceleration_xy() == self.mover._acceleration_xy for s in self.mover.connected_stages)
+        )
 
     def test_set_acceleration_xy_raises_error_if_upper_bound_is_violated(self):
         with self.assertRaises(ValueError) as error:
             self.mover.acceleration_xy = self.mover.ACCELERATION_UPPER_BOUND + 1
 
-        self.assertEqual(
-            "Acceleration for xy is out of valid range.", str(
-                error.exception))
-        self.assertTrue(all(s.get_acceleration_xy(
-        ) == self.mover._acceleration_xy for s in self.mover.connected_stages))
+        self.assertEqual("Acceleration for xy is out of valid range.", str(error.exception))
+        self.assertTrue(
+            all(s.get_acceleration_xy() == self.mover._acceleration_xy for s in self.mover.connected_stages)
+        )
 
     def test_set_acceleration_xy_for_all_stages(self):
         self.mover.acceleration_xy = 200
 
         self.assertEqual(self.mover._acceleration_xy, 200)
-        self.assertTrue(all(s.get_acceleration_xy() ==
-                        200 for s in self.mover.connected_stages))
+        self.assertTrue(all(s.get_acceleration_xy() == 200 for s in self.mover.connected_stages))
 
     def test_get_acceleration_xy(self):
         self.mover.acceleration_xy = 200
@@ -350,8 +300,7 @@ class MoverStageSettingsTest(unittest.TestCase):
 
         self.assertEqual(self.mover.z_lift, 50)
 
-    @patch.object(MoverNew, "MOVER_SETTINGS_FILE",
-                  "/mocked/mover_settings.json")
+    @patch.object(MoverNew, "MOVER_SETTINGS_FILE", "/mocked/mover_settings.json")
     def test_dump_settings(self):
         self.mover.speed_xy = 1000
         self.mover.speed_z = 50
@@ -364,28 +313,27 @@ class MoverStageSettingsTest(unittest.TestCase):
         m.assert_called_once_with('/mocked/mover_settings.json', 'w')
 
         file_pointer = m()
-        file_pointer.write.assert_has_calls(
-            [
-                call('{'),
-                call('"speed_xy"'),
-                call(': '),
-                call('1000'),
-                call(', '),
-                call('"speed_z"'),
-                call(': '),
-                call('50'),
-                call(', '),
-                call('"acceleration_xy"'),
-                call(': '),
-                call('200'),
-                call(', '),
-                call('"z_lift"'),
-                call(': '),
-                call('24.5'),
-                call('}')])
+        file_pointer.write.assert_has_calls([
+            call('{'),
+            call('"speed_xy"'),
+            call(': '),
+            call('1000'),
+            call(', '),
+            call('"speed_z"'),
+            call(': '),
+            call('50'),
+            call(', '),
+            call('"acceleration_xy"'),
+            call(': '),
+            call('200'),
+            call(', '),
+            call('"z_lift"'),
+            call(': '),
+            call('24.5'),
+            call('}')
+        ])
 
-    @patch.object(MoverNew, "MOVER_SETTINGS_FILE",
-                  "/mocked/mover_settings.json")
+    @patch.object(MoverNew, "MOVER_SETTINGS_FILE", "/mocked/mover_settings.json")
     @patch('os.path.exists')
     def test_load_settings(self, mock_exists):
         settings = json.dumps({
@@ -418,42 +366,33 @@ class CanMoveRelativelyTest(unittest.TestCase):
         self.assertFalse(self.mover.can_move_relatively)
 
     def test_with_one_valid_calibration(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         calibration.connect_to_stage()
 
-        self.assertTrue(
-            calibration._axes_rotation.is_valid)
+        self.assertTrue(calibration._axes_rotation.is_valid)
 
         self.assertTrue(self.mover.can_move_relatively)
 
     def test_with_one_invalid_calibration(self):
-        calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         calibration.connect_to_stage()
 
         calibration.update_axes_rotation(Axis.X, Direction.NEGATIVE, Axis.Y)
-        self.assertFalse(
-            calibration._axes_rotation.is_valid)
+        self.assertFalse(calibration._axes_rotation.is_valid)
 
         self.assertFalse(self.mover.can_move_relatively)
 
     def test_with_one_valid_and_one_invalid_calibration(self):
-        valid_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
+        valid_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
         valid_calibration.connect_to_stage()
 
-        self.assertTrue(
-            valid_calibration._axes_rotation.is_valid)
+        self.assertTrue(valid_calibration._axes_rotation.is_valid)
 
-        invalid_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        invalid_calibration = self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
         invalid_calibration.connect_to_stage()
 
-        invalid_calibration.update_axes_rotation(
-            Axis.X, Direction.NEGATIVE, Axis.Y)
-        self.assertFalse(
-            invalid_calibration._axes_rotation.is_valid)
+        invalid_calibration.update_axes_rotation(Axis.X, Direction.NEGATIVE, Axis.Y)
+        self.assertFalse(invalid_calibration._axes_rotation.is_valid)
 
         self.assertFalse(self.mover.can_move_relatively)
 
@@ -466,17 +405,14 @@ class RelativeMovementTest(unittest.TestCase):
 
         self.mover = MoverNew(None)
 
-        self.left_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.right_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.left_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.right_calibration = self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
 
         self.left_calibration.connect_to_stage()
         self.right_calibration.connect_to_stage()
 
     def test_raises_error_if_axes_rotation_in_valid(self):
-        self.left_calibration.update_axes_rotation(
-            Axis.X, Direction.NEGATIVE, Axis.Y)
+        self.left_calibration.update_axes_rotation(Axis.X, Direction.NEGATIVE, Axis.Y)
         self.assertFalse(self.left_calibration._axes_rotation.is_valid)
 
         movement_command = {Orientation.LEFT: ChipCoordinate(1, 2, 3)}
@@ -497,41 +433,35 @@ class RelativeMovementTest(unittest.TestCase):
 
     @patch.object(DummyStage, "move_relative")
     def test_move_relative_with_ordering(self, move_relative_mock):
-        self.left_calibration.update_axes_rotation(
-            Axis.X, Direction.NEGATIVE, Axis.Z)
-        self.left_calibration.update_axes_rotation(
-            Axis.Y, Direction.POSITIVE, Axis.X)
-        self.left_calibration.update_axes_rotation(
-            Axis.Z, Direction.NEGATIVE, Axis.Y)
+        self.left_calibration.update_axes_rotation(Axis.X, Direction.NEGATIVE, Axis.Z)
+        self.left_calibration.update_axes_rotation(Axis.Y, Direction.POSITIVE, Axis.X)
+        self.left_calibration.update_axes_rotation(Axis.Z, Direction.NEGATIVE, Axis.Y)
 
         self.assertTrue(self.left_calibration._axes_rotation.is_valid)
 
-        self.right_calibration.update_axes_rotation(
-            Axis.X, Direction.POSITIVE, Axis.Y)
-        self.right_calibration.update_axes_rotation(
-            Axis.Y, Direction.POSITIVE, Axis.Z)
-        self.right_calibration.update_axes_rotation(
-            Axis.Z, Direction.NEGATIVE, Axis.X)
+        self.right_calibration.update_axes_rotation(Axis.X, Direction.POSITIVE, Axis.Y)
+        self.right_calibration.update_axes_rotation(Axis.Y, Direction.POSITIVE, Axis.Z)
+        self.right_calibration.update_axes_rotation(Axis.Z, Direction.NEGATIVE, Axis.X)
 
         self.assertTrue(self.right_calibration._axes_rotation.is_valid)
 
         left_requested_offset = ChipCoordinate(42, 8, -17)
         right_requested_offset = ChipCoordinate(72, -42, 31)
 
-        expected_left_offset = self.left_calibration._axes_rotation.chip_to_stage(
-            left_requested_offset)
-        expected_right_offset = self.right_calibration._axes_rotation.chip_to_stage(
-            right_requested_offset)
+        expected_left_offset = self.left_calibration._axes_rotation.chip_to_stage(left_requested_offset)
+        expected_right_offset = self.right_calibration._axes_rotation.chip_to_stage(right_requested_offset)
 
         requested_ordering = [
             Orientation.BOTTOM,
             Orientation.RIGHT,
             Orientation.TOP,
-            Orientation.LEFT]
+            Orientation.LEFT
+        ]
 
         self.mover.move_relative(
             {Orientation.LEFT: left_requested_offset, Orientation.RIGHT: right_requested_offset},
-            requested_ordering)
+            requested_ordering
+        )
 
         move_relative_mock.assert_has_calls(
             [
@@ -546,7 +476,8 @@ class RelativeMovementTest(unittest.TestCase):
                     z=expected_left_offset.z,
                     wait_for_stopping=True),
             ],
-            any_order=False)
+            any_order=False
+        )
 
 
 class CoordinateSystemControlTest(unittest.TestCase):
@@ -556,31 +487,24 @@ class CoordinateSystemControlTest(unittest.TestCase):
 
         self.mover = MoverNew(None)
 
-        self.left_calibration = self.mover.add_stage_calibration(
-            self.stage, Orientation.LEFT, DevicePort.INPUT)
-        self.right_calibration = self.mover.add_stage_calibration(
-            self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
+        self.left_calibration = self.mover.add_stage_calibration(self.stage, Orientation.LEFT, DevicePort.INPUT)
+        self.right_calibration = self.mover.add_stage_calibration(self.stage2, Orientation.RIGHT, DevicePort.OUTPUT)
 
         self.left_calibration.connect_to_stage()
         self.right_calibration.connect_to_stage()
 
-    @parameterized.expand([(CoordinateSystem.CHIP,),
-                          (CoordinateSystem.STAGE,), (CoordinateSystem.UNKNOWN,)])
+    @parameterized.expand([(CoordinateSystem.CHIP,), (CoordinateSystem.STAGE,), (CoordinateSystem.UNKNOWN,)])
     def test_set_valid_coordinate_system(self, valid_system):
 
         left_calibration_prior = self.left_calibration.coordinate_system
         right_calibration_prior = self.right_calibration.coordinate_system
 
         with self.mover.set_stages_coordinate_system(valid_system):
-            self.assertEqual(
-                self.left_calibration.coordinate_system, valid_system)
-            self.assertEqual(
-                self.right_calibration.coordinate_system, valid_system)
+            self.assertEqual(self.left_calibration.coordinate_system, valid_system)
+            self.assertEqual(self.right_calibration.coordinate_system, valid_system)
 
-        self.assertEqual(
-            self.left_calibration.coordinate_system, left_calibration_prior)
-        self.assertEqual(
-            self.right_calibration.coordinate_system, right_calibration_prior)
+        self.assertEqual(self.left_calibration.coordinate_system, left_calibration_prior)
+        self.assertEqual(self.right_calibration.coordinate_system, right_calibration_prior)
 
     def test_set_valid_coordinate_system_with_block_error(self):
         func = Mock(side_effect=RuntimeError)
@@ -592,37 +516,23 @@ class CoordinateSystemControlTest(unittest.TestCase):
             with self.mover.set_stages_coordinate_system(CoordinateSystem.CHIP):
                 func()
 
-        self.assertEqual(
-            self.left_calibration.coordinate_system, left_calibration_prior)
-        self.assertEqual(
-            self.right_calibration.coordinate_system, right_calibration_prior)
+        self.assertEqual(self.left_calibration.coordinate_system, left_calibration_prior)
+        self.assertEqual(self.right_calibration.coordinate_system, right_calibration_prior)
 
     def test_set_nested_coordinate_system(self):
         self.left_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
         self.right_calibration.set_coordinate_system(CoordinateSystem.UNKNOWN)
 
         with self.mover.set_stages_coordinate_system(CoordinateSystem.CHIP):
-            self.assertEqual(
-                self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
-            self.assertEqual(
-                self.right_calibration.coordinate_system,
-                CoordinateSystem.CHIP)
+            self.assertEqual(self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
+            self.assertEqual(self.right_calibration.coordinate_system, CoordinateSystem.CHIP)
 
             with self.mover.set_stages_coordinate_system(CoordinateSystem.STAGE):
-                self.assertEqual(
-                    self.left_calibration.coordinate_system,
-                    CoordinateSystem.STAGE)
-                self.assertEqual(
-                    self.right_calibration.coordinate_system,
-                    CoordinateSystem.STAGE)
+                self.assertEqual(self.left_calibration.coordinate_system, CoordinateSystem.STAGE)
+                self.assertEqual(self.right_calibration.coordinate_system, CoordinateSystem.STAGE)
 
-            self.assertEqual(
-                self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
-            self.assertEqual(
-                self.right_calibration.coordinate_system,
-                CoordinateSystem.CHIP)
+            self.assertEqual(self.left_calibration.coordinate_system, CoordinateSystem.CHIP)
+            self.assertEqual(self.right_calibration.coordinate_system, CoordinateSystem.CHIP)
 
-        self.assertEqual(
-            self.left_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
-        self.assertEqual(
-            self.right_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
+        self.assertEqual(self.left_calibration.coordinate_system, CoordinateSystem.UNKNOWN)
+        self.assertEqual(self.right_calibration.coordinate_system, CoordinateSystem.UNKNOWN)

--- a/LabExT/Tests/Movement/PathPlanning_test.py
+++ b/LabExT/Tests/Movement/PathPlanning_test.py
@@ -12,7 +12,7 @@ from parameterized import parameterized
 
 from LabExT.Movement.config import Orientation
 from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.PathPlanning import SingleModeFiber, StagePolygon
+from LabExT.Movement.Polygons import SingleModeFiber, StagePolygon
 
 
 class SingleModeFiberTest(TestCase):

--- a/LabExT/Tests/Movement/Transformations_test.py
+++ b/LabExT/Tests/Movement/Transformations_test.py
@@ -6,203 +6,31 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY;
 for details see LICENSE file.
 """
 
-from typing import List, Type
+from typing import List
 import unittest
 from unittest.mock import Mock
 import numpy as np
+from numpy.typing import NDArray
 from numpy.testing import assert_array_equal
-from random import seed, uniform
+from random import uniform
 from parameterized import parameterized
 from itertools import product, combinations, permutations
 from scipy.spatial.transform import Rotation
 from LabExT.Movement.Calibration import Calibration
 
 from LabExT.Movement.config import Direction, Axis
-from LabExT.Movement.Transformations import Coordinate, ChipCoordinate, KabschRotation,\
-    StageCoordinate, CoordinatePairing, SinglePointOffset, AxesRotation, Transformation, TransformationError,\
-    assert_valid_transformation, rigid_transform_with_orientation_preservation
+from LabExT.Movement.Transformations import (KabschRotation, CoordinatePairing, SinglePointOffset, AxesRotation,
+                                             Transformation, TransformationError, assert_valid_transformation,
+                                             rigid_transform_with_orientation_preservation)
 from LabExT.Tests.Utils import get_calibrations_from_file
+from ...Movement.Coordinate import StageCoordinate, ChipCoordinate
 from ...Wafer.Chip import Chip
 from LabExT.Wafer.Device import Device
 
 
-POSSIBLE_AXIS_ROTATIONS = list(product(
-    permutations(Axis), product(
-        Direction, repeat=3)))
+POSSIBLE_AXIS_ROTATIONS = list(product(permutations(Axis), product(Direction, repeat=3)))
 
 VACHERIN_ROTATION, VACHERIN_STAGE_COORDS, VACHERIN_CHIP_COORDS = get_calibrations_from_file("vacherin.json", "left")
-
-class CoordinateTest(unittest.TestCase):
-
-    list_parameterized = parameterized.expand([
-        ([1, 2, 3, 4], 1, 2, 3),
-        ([1, 2, 3], 1, 2, 3),
-        ([1, 2], 1, 2, 0),
-        ([1], 1, 0, 0),
-        ([], 0, 0, 0)])
-    array_parameterized = parameterized.expand([
-        (np.array([1, 2, 3, 4]), 1, 2, 3),
-        (np.array([1, 2, 3]), 1, 2, 3),
-        (np.array([1, 2]), 1, 2, 0),
-        (np.array([1]), 1, 0, 0),
-        (np.array([]), 0, 0, 0)])
-
-    def test_cannot_instantiate_base_class(self):
-        with self.assertRaises(TypeError):
-            Coordinate()
-
-        with self.assertRaises(TypeError):
-            Coordinate.from_list([1, 2, 3])
-
-        with self.assertRaises(TypeError):
-            Coordinate.from_numpy(np.array([1, 2, 3]))
-
-    @parameterized.expand([
-        (np.array([[1]]),), (np.array([[1], [2], [3]]),)
-    ])
-    def test_from_numpy_accepts_only_1D_arrays(self, array):
-        with self.assertRaises(ValueError):
-            Coordinate.from_numpy(array)
-
-    @parameterized.expand([
-        (StageCoordinate(1, 2, 3), ChipCoordinate(1, 2, 3)),
-        (ChipCoordinate(1, 2, 3), StageCoordinate(1, 2, 3)),
-        (StageCoordinate(1, 2, 3), StageCoordinate(4, 5, 6)),
-        (ChipCoordinate(1, 2, 3), ChipCoordinate(4, 5, 6)),
-    ])
-    def test_unequal_coordinates(self, coord_1, coord_2):
-        self.assertNotEqual(coord_1, coord_2)
-
-    @parameterized.expand([
-        (StageCoordinate(1, 2, 3), StageCoordinate(1, 2, 3)),
-        (ChipCoordinate(1, 2, 3), ChipCoordinate(1, 2, 3)),
-    ])
-    def test_equal_coordinates(self, coord_1, coord_2):
-        self.assertEqual(coord_1, coord_2)
-
-    def assert_build_from_list(
-            self,
-            coordinate_type: Coordinate,
-            list,
-            x,
-            y,
-            z):
-        self._assert_coordinate_with_correct_values(
-            coordinate_type.from_list(list), x, y, z)
-
-    def assert_build_from_numpy(
-            self,
-            coordinate_type: Coordinate,
-            array,
-            x,
-            y,
-            z):
-        self._assert_coordinate_with_correct_values(
-            coordinate_type.from_numpy(array), x, y, z)
-
-    def _assert_coordinate_with_correct_values(
-            self, coordinate: Type[Coordinate], x, y, z):
-        self.assertEqual(coordinate.x, x)
-        self.assertEqual(coordinate.y, y)
-        self.assertEqual(coordinate.z, z)
-
-
-class StageCoordinateTest(CoordinateTest):
-    @CoordinateTest.list_parameterized
-    def test_from_list(self, list, x, y, z):
-        self.assert_build_from_list(StageCoordinate, list, x, y, z)
-
-    @CoordinateTest.array_parameterized
-    def test_from_numpy(self, array, x, y, z):
-        self.assert_build_from_numpy(StageCoordinate, array, x, y, z)
-
-    def test_to_list(self):
-        self.assertEqual(StageCoordinate(1, 2, 3).to_list(), [1, 2, 3])
-
-    def test_to_numpy(self):
-        self.assertTrue(np.array_equal(
-            StageCoordinate(1, 2, 3).to_numpy(), np.array([1, 2, 3])
-        ))
-
-    @parameterized.expand([
-        (ChipCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)
-    ])
-    def test_add_with_incompatible_types(self, other):
-        with self.assertRaises(TypeError):
-            StageCoordinate(1, 2, 3) + other
-
-    @parameterized.expand([
-        (ChipCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)
-    ])
-    def test_sub_with_incompatible_types(self, other):
-        with self.assertRaises(TypeError):
-            StageCoordinate(1, 2, 3) - other
-
-    def test_add_with_compatible_types(self):
-        sum = StageCoordinate.from_list(
-            [1, 2, 3]) + StageCoordinate.from_list([1, 2, 3])
-        self.assertIsInstance(sum, StageCoordinate)
-        self.assertEqual(sum.to_list(), [2, 4, 6])
-
-    def test_sub_with_compatible_types(self):
-        diff = StageCoordinate.from_list(
-            [1, 2, 3]) - StageCoordinate.from_list([1, 2, 3])
-        self.assertIsInstance(diff, StageCoordinate)
-        self.assertEqual(diff.to_list(), [0, 0, 0])
-
-    def test_multiplication_with_scalar(self):
-        mult = StageCoordinate(1, 2, 3) * 2
-        self.assertIsInstance(mult, StageCoordinate)
-        self.assertEqual(mult.to_list(), [2, 4, 6])
-
-
-class ChipCoordinateTest(CoordinateTest):
-    @CoordinateTest.list_parameterized
-    def test_from_list(self, list, x, y, z):
-        self.assert_build_from_list(ChipCoordinate, list, x, y, z)
-
-    @CoordinateTest.array_parameterized
-    def test_from_numpy(self, array, x, y, z):
-        self.assert_build_from_numpy(ChipCoordinate, array, x, y, z)
-
-    def test_to_list(self):
-        self.assertEqual(ChipCoordinate(1, 2, 3).to_list(), [1, 2, 3])
-
-    def test_to_numpy(self):
-        self.assertTrue(np.array_equal(
-            ChipCoordinate(1, 2, 3).to_numpy(), np.array([1, 2, 3])
-        ))
-
-    @parameterized.expand([
-        (StageCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)
-    ])
-    def test_add_with_incompatible_types(self, other):
-        with self.assertRaises(TypeError):
-            ChipCoordinate(1, 2, 3) + other
-
-    @parameterized.expand([
-        (StageCoordinate(1, 2, 3),), ([1, 2, 3],), (np.array([1, 2, 3]),)
-    ])
-    def test_sub_with_incompatible_types(self, other):
-        with self.assertRaises(TypeError):
-            ChipCoordinate(1, 2, 3) - other
-
-    def test_add_with_compatible_types(self):
-        sum = ChipCoordinate.from_list(
-            [1, 2, 3]) + ChipCoordinate.from_list([1, 2, 3])
-        self.assertIsInstance(sum, ChipCoordinate)
-        self.assertEqual(sum.to_list(), [2, 4, 6])
-
-    def test_sub_with_compatible_types(self):
-        diff = ChipCoordinate.from_list(
-            [1, 2, 3]) - ChipCoordinate.from_list([1, 2, 3])
-        self.assertIsInstance(diff, ChipCoordinate)
-        self.assertEqual(diff.to_list(), [0, 0, 0])
-
-    def test_multiplication_with_scalar(self):
-        mult = ChipCoordinate(1, 2, 3) * 2
-        self.assertIsInstance(mult, ChipCoordinate)
-        self.assertEqual(mult.to_list(), [2, 4, 6])
 
 
 class CoordinatePairingTest(unittest.TestCase):
@@ -212,7 +40,8 @@ class CoordinatePairingTest(unittest.TestCase):
             calibration=Mock(),
             stage_coordinate=StageCoordinate(7,8,9),
             device=self.device,
-            chip_coordinate=ChipCoordinate(1,2,3))
+            chip_coordinate=ChipCoordinate(1,2,3)
+        )
 
     def test_dump_with_device(self):
         pairing_data = self.pairing.dump(include_device_id=True)
@@ -220,19 +49,22 @@ class CoordinatePairingTest(unittest.TestCase):
         self.assertDictEqual(pairing_data, {
             "stage_coordinate": [7,8,9],
             "chip_coordinate": [1,2,3],
-            "device_id": '1'})
+            "device_id": '1'
+        })
 
     def test_dump_without_device(self):
         pairing_data = self.pairing.dump(include_device_id=False)
 
         self.assertDictEqual(pairing_data, {
             "stage_coordinate": [7,8,9],
-            "chip_coordinate": [1,2,3]})
+            "chip_coordinate": [1,2,3]
+        })
 
     def test_load(self):
         pairing_data = {
             "stage_coordinate": [4,2,1],
-            "chip_coordinate": [6,5,9]}
+            "chip_coordinate": [6,5,9]
+        }
 
         calibration = Mock()
         pairing = CoordinatePairing.load(pairing_data, self.device, calibration)
@@ -289,25 +121,17 @@ class AxesRotationTest(unittest.TestCase):
         self.rotation.update(stage_axis, direction, chip_axis)
         self.assertTrue(self.rotation.is_valid)
 
-        chip_axis_unit = ChipCoordinate.from_list(
-            [1 if axis == chip_axis else 0 for axis in Axis])
-        stage_axis_unit = StageCoordinate.from_list(
-            [1 if axis == stage_axis else 0 for axis in Axis])
+        chip_axis_unit = ChipCoordinate.from_list([1 if axis == chip_axis else 0 for axis in Axis])
+        stage_axis_unit = StageCoordinate.from_list([1 if axis == stage_axis else 0 for axis in Axis])
 
-        self.assertEqual(
-            self.rotation.chip_to_stage(chip_axis_unit),
-            stage_axis_unit * direction.value)
-        self.assertEqual(
-            self.rotation.stage_to_chip(stage_axis_unit),
-            chip_axis_unit * direction.value)
+        self.assertEqual(self.rotation.chip_to_stage(chip_axis_unit), stage_axis_unit * direction.value)
+        self.assertEqual(self.rotation.stage_to_chip(stage_axis_unit), chip_axis_unit * direction.value)
 
     @parameterized.expand(zip(
         POSSIBLE_AXIS_ROTATIONS,
-        [np.array(d) * np.array(p) for p in permutations([1,2,3]) for d in product([-1,1],repeat=3)]))
-    def test_possible_axes_assignments(
-            self,
-            stage_axes_mapping,
-            expected_chip_coordinate):
+        [np.array(d) * np.array(p) for p in permutations([1,2,3]) for d in product([-1,1],repeat=3)]
+    ))
+    def test_possible_axes_assignments(self, stage_axes_mapping, expected_chip_coordinate):
         stage_axes, direction = stage_axes_mapping
         for idx, chip_axis in enumerate(Axis):
             self.rotation.update(chip_axis, direction[idx], stage_axes[idx])
@@ -334,7 +158,8 @@ class AxesRotationTest(unittest.TestCase):
                 'X': ('NEGATIVE', 'Y'),
                 'Y': ('POSITIVE', 'Z'),
                 'Z': ('NEGATIVE', 'X')
-            })
+            }
+        )
 
     def test_load_invalid_mapping(self):
         # Z Axis get assigned twice
@@ -410,20 +235,17 @@ class SinglePointOffsetTest(unittest.TestCase):
             self.rotation.update(chip_axis, directions[idx], stage_axes[idx])
 
         chip_coordinate = ChipCoordinate.from_list([-1550, 1120, 0])
-        stage_coordinate = StageCoordinate.from_list(
-            [23236.35, -7888.67, 18956.06])
+        stage_coordinate = StageCoordinate.from_list([23236.35, -7888.67, 18956.06])
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=stage_coordinate,
             device=Mock(),
-            chip_coordinate=chip_coordinate))
+            chip_coordinate=chip_coordinate)
+        )
 
-        self.assertEqual(
-            self.transformation.chip_to_stage(chip_coordinate),
-            stage_coordinate)
-        self.assertEqual(self.transformation.stage_to_chip(
-            stage_coordinate), chip_coordinate)
+        self.assertEqual(self.transformation.chip_to_stage(chip_coordinate), stage_coordinate)
+        self.assertEqual(self.transformation.stage_to_chip(stage_coordinate), chip_coordinate)
 
     @parameterized.expand([
         (-1050, 570, 0),
@@ -431,43 +253,43 @@ class SinglePointOffsetTest(unittest.TestCase):
         (1046.25, -1337.5, 0),
         (-50, 1120, 0)
     ])
-    def test_against_kabsch_rotation(self, chip_x, chip_y, chip_z):
+    def test_against_kabsch_rotation(self, chip_x: float, chip_y: float, chip_z: float):
         self.rotation.matrix = VACHERIN_ROTATION
 
         stage_offset = VACHERIN_STAGE_COORDS.mean(axis=0)
         chip_offset = VACHERIN_CHIP_COORDS.mean(axis=0)
-        kabsch, _ = Rotation.align_vectors(
-            VACHERIN_CHIP_COORDS - chip_offset, VACHERIN_STAGE_COORDS - stage_offset)
+        kabsch, _ = Rotation.align_vectors(VACHERIN_CHIP_COORDS - chip_offset, VACHERIN_STAGE_COORDS - stage_offset)
 
         device_coordinate = ChipCoordinate(chip_x, chip_y, chip_z)
 
-        expected_stage_coordinate = kabsch.apply(
-            device_coordinate.to_numpy()) + stage_offset
+        expected_stage_coordinate = kabsch.apply(device_coordinate.to_numpy()) + stage_offset
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate(*VACHERIN_STAGE_COORDS[0]),
             device=None,
-            chip_coordinate=ChipCoordinate(*VACHERIN_CHIP_COORDS[0])))
+            chip_coordinate=ChipCoordinate(*VACHERIN_CHIP_COORDS[0]))
+        )
 
         self.assertTrue(np.allclose(
             expected_stage_coordinate,
             self.transformation.chip_to_stage(device_coordinate).to_numpy(),
             rtol=1,
-            atol=1))
+            atol=1
+        ))
 
     
     def test_dump(self):
         chip_coordinate = ChipCoordinate.from_list([-1550, 1120, 0])
-        stage_coordinate = StageCoordinate.from_list(
-             [23236.35, -7888.67, 18956.06])
+        stage_coordinate = StageCoordinate.from_list([23236.35, -7888.67, 18956.06])
 
         device = Mock()
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=stage_coordinate,
             device=device,
-            chip_coordinate=chip_coordinate))   
+            chip_coordinate=chip_coordinate
+        ))
 
         self.assertDictEqual(self.transformation.dump(), {
             "stage_coordinate": [23236.35, -7888.67, 18956.06],
@@ -476,42 +298,50 @@ class SinglePointOffsetTest(unittest.TestCase):
         })
 
     def test_load(self):
-        chip = Chip("Test Chip", devices=[
-            Device(1, "test device", in_position=[19,293.03,1029.02], out_position=[1,1])
-        ], path="/example/path", _serialize_to_disk=False)
+        chip = Chip(
+            "Test Chip",
+            devices=[Device("1", "test device", in_position=[19,293.03,1029.02], out_position=[1,1])],
+            path="/example/path",
+            _serialize_to_disk=False
+        )
         stored_format = {
             "stage_coordinate": [19,293.03,1029.02],
             "chip_coordinate": [110203,29342,0],
-            'device_id': 1
+            'device_id': "1"
         }
 
         transformation = SinglePointOffset.load(stored_format, chip, self.rotation)
 
         assert_array_equal(
             transformation.stage_offset.to_numpy(),
-            np.array([110203,29342,0]) - np.array([19,293.03,1029.02]))
+            np.array([110203,29342,0]) - np.array([19,293.03,1029.02])
+        )
 
     def test_dump_and_load(self):
-        chip = Chip("Test Chip", devices=[
-            Device(1, "test device", in_position=[0,0], out_position=[1,1])
-        ], path="/example/path", _serialize_to_disk=False)
+        chip = Chip(
+            "Test Chip",
+            devices=[Device("1", "test device", in_position=[0,0], out_position=[1,1])],
+            path="/example/path",
+            _serialize_to_disk=False
+        )
 
         chip_coordinate = ChipCoordinate.from_list([-1550, 1120, 0])
-        stage_coordinate = StageCoordinate.from_list(
-            [23236.35, -7888.67, 18956.06])
+        stage_coordinate = StageCoordinate.from_list([23236.35, -7888.67, 18956.06])
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=stage_coordinate,
-            device=chip.devices.get(1),
-            chip_coordinate=chip_coordinate))
+            device=chip.devices.get("1"),
+            chip_coordinate=chip_coordinate)
+        )
 
         current_offset = self.transformation.stage_offset.to_numpy()
 
         from_stored_offset = SinglePointOffset.load(
             self.transformation.dump(),
             chip,
-            self.transformation.axes_rotation)
+            self.transformation.axes_rotation
+        )
 
         assert_array_equal(current_offset, from_stored_offset.stage_offset.to_numpy())
 
@@ -537,7 +367,8 @@ class RigidTransformationTest(unittest.TestCase):
 
         R_ret, t_ret, R_inv_ret, t_inv_ret = rigid_transform_with_orientation_preservation(
             S=start_dataset,
-            T=target_dataset)
+            T=target_dataset
+        )
 
         target_dataset_ret = R_ret @ start_dataset + t_ret
         start_dataset_ret = R_inv_ret @ target_dataset + t_inv_ret
@@ -583,7 +414,8 @@ class KabschRotationTest(unittest.TestCase):
             calibration=self.calibration,
             stage_coordinate=StageCoordinate(1,2,3),
             device=device,
-            chip_coordinate=ChipCoordinate(4,5,6))
+            chip_coordinate=ChipCoordinate(4,5,6)
+        )
 
         self.transformation.update(pairing)
         self.assertIn(pairing, self.transformation.pairings)
@@ -592,15 +424,27 @@ class KabschRotationTest(unittest.TestCase):
             calibration=self.calibration,
             stage_coordinate=StageCoordinate(7,8,9),
             device=device,
-            chip_coordinate=ChipCoordinate(8,7,6))
+            chip_coordinate=ChipCoordinate(8,7,6)
+        )
 
         with self.assertRaises(ValueError):
             self.transformation.update(pairing_2)
 
         self.assertNotIn(pairing_2, self.transformation.pairings)
 
-    @parameterized.expand([(np.delete(VACHERIN_STAGE_COORDS, (i), axis=0), np.delete(VACHERIN_CHIP_COORDS, (i), axis=0), VACHERIN_STAGE_COORDS[i,:], VACHERIN_CHIP_COORDS[i,:]) for i in range(0,4)])
-    def test_transformation_estimates_fourth_variable(self, stage_coordinates, chip_coordinates, test_stage_coordinate, test_chip_coordinate):
+    @parameterized.expand([
+        (np.delete(VACHERIN_STAGE_COORDS, i, axis=0),
+         np.delete(VACHERIN_CHIP_COORDS, i, axis=0),
+         VACHERIN_STAGE_COORDS[i,:],
+         VACHERIN_CHIP_COORDS[i,:]) for i in range(0,4)
+    ])
+    def test_transformation_estimates_fourth_variable(
+            self,
+            stage_coordinates,
+            chip_coordinates,
+            test_stage_coordinate,
+            test_chip_coordinate
+    ):
         for stage_coord, chip_coord in zip(stage_coordinates, chip_coordinates):
             pairing = CoordinatePairing(
                 calibration=Mock(),
@@ -629,79 +473,93 @@ class KabschRotationTest(unittest.TestCase):
                 calibration=Mock(),
                 stage_coordinate=StageCoordinate.from_numpy(stage_coord),
                 device=Mock(),
-                chip_coordinate=ChipCoordinate.from_numpy(chip_coord)))
+                chip_coordinate=ChipCoordinate.from_numpy(chip_coord)
+            ))
 
         chip_coordinate = ChipCoordinate(1,2,3)
         stage_coordinate = StageCoordinate(4,5,6)
 
         self.assertTrue(np.allclose(
             self.transformation.stage_to_chip(self.transformation.chip_to_stage(chip_coordinate)).to_numpy(),
-            chip_coordinate.to_numpy()))
+            chip_coordinate.to_numpy()
+        ))
         self.assertTrue(np.allclose(
             self.transformation.chip_to_stage(self.transformation.stage_to_chip(stage_coordinate)).to_numpy(),
-            stage_coordinate.to_numpy()))
+            stage_coordinate.to_numpy()
+        ))
 
     def test_dump(self):
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([23236.35, -7888.67, 18956.06]),
-            device=Device(1, "example type", in_position=[0,0], out_position=[1,1]),
-            chip_coordinate=ChipCoordinate.from_list([-1550.0, 1120.0, 0.0])))
+            device=Device("1", "example type", in_position=[0,0], out_position=[1,1]),
+            chip_coordinate=ChipCoordinate.from_list([-1550.0, 1120.0, 0.0])
+        ))
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([23744.6, -9172.55, 18956.1]),
-            device=Device(2, "example type", in_position=[0,0], out_position=[1,1]),
-            chip_coordinate=ChipCoordinate.from_list([-1050.0, -160.0, 0.0])))
+            device=Device("2", "example type", in_position=[0,0], out_position=[1,1]),
+            chip_coordinate=ChipCoordinate.from_list([-1050.0, -160.0, 0.0])
+        ))
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([25846.07, -10348.82, 18955.11]),
-            device=Device(3, "example type", in_position=[0,0], out_position=[1,1]),
-            chip_coordinate=ChipCoordinate.from_list([1046.25, -1337.5, 0.0])))
+            device=Device("3", "example type", in_position=[0,0], out_position=[1,1]),
+            chip_coordinate=ChipCoordinate.from_list([1046.25, -1337.5, 0.0])
+        ))
 
         self.assertListEqual(self.transformation.dump(), [
             {
                 'stage_coordinate': [23236.35, -7888.67, 18956.06],
                 'chip_coordinate': [-1550.0, 1120.0, 0.0],
-                'device_id': 1
+                'device_id': "1"
             },
             {
                 'stage_coordinate': [23744.6, -9172.55, 18956.1],
                 'chip_coordinate': [-1050.0, -160.0, 0.0],
-                'device_id': 2
+                'device_id': "2"
             }, 
             {
                 'stage_coordinate': [25846.07, -10348.82, 18955.11],
                 'chip_coordinate': [1046.25, -1337.5, 0.0],
-                'device_id': 3
-            }])
+                'device_id': "3"
+            }
+        ])
 
 
     def test_load_and_dump(self):
-        chip = Chip("Test Chip", devices=[
-            Device(1, "example device", in_position=[0,0], out_position=[1,1]),
-            Device(2, "example device", in_position=[0,0], out_position=[1,1]),
-            Device(3, "example device", in_position=[0,0], out_position=[1,1]),
-        ], path="/example/path", _serialize_to_disk=False)
+        chip = Chip(
+            "Test Chip",
+            devices=[
+                Device("1", "example device", in_position=[0,0], out_position=[1,1]),
+                Device("2", "example device", in_position=[0,0], out_position=[1,1]),
+                Device("3", "example device", in_position=[0,0], out_position=[1,1]),
+            ],
+            path="/example/path",
+            _serialize_to_disk=False
+        )
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([23236.35, -7888.67, 18956.06]),
-            device=chip.devices.get(1),
-            chip_coordinate=ChipCoordinate.from_list([-1550.0, 1120.0, 0.0])))
+            device=chip.devices.get("1"),
+            chip_coordinate=ChipCoordinate.from_list([-1550.0, 1120.0, 0.0])
+        ))
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([23744.6, -9172.55, 18956.1]),
-            device=chip.devices.get(2),
-            chip_coordinate=ChipCoordinate.from_list([-1050.0, -160.0, 0.0])))
+            device=chip.devices.get("2"),
+            chip_coordinate=ChipCoordinate.from_list([-1050.0, -160.0, 0.0])
+        ))
 
         self.transformation.update(CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([25846.07, -10348.82, 18955.11]),
-            device=chip.devices.get(3),
-            chip_coordinate=ChipCoordinate.from_list([1046.25, -1337.5, 0.0])))
-
+            device=chip.devices.get("3"),
+            chip_coordinate=ChipCoordinate.from_list([1046.25, -1337.5, 0.0])
+        ))
 
         current_rotation_to_chip = self.transformation.rotation_to_chip
         current_translation_to_chip = self.transformation.translation_to_chip
@@ -709,9 +567,7 @@ class KabschRotationTest(unittest.TestCase):
         current_rotation_to_stage = self.transformation.rotation_to_stage
         current_translation_to_stage = self.transformation.translation_to_stage
 
-        restored_rotation = KabschRotation.load(
-            self.transformation.dump(), chip, self.transformation.axes_rotation)
-
+        restored_rotation = KabschRotation.load(self.transformation.dump(), chip, self.transformation.axes_rotation)
 
         assert_array_equal(current_rotation_to_chip, restored_rotation.rotation_to_chip)
         assert_array_equal(current_translation_to_chip, restored_rotation.translation_to_chip)
@@ -720,19 +576,21 @@ class KabschRotationTest(unittest.TestCase):
 
 
 
-class KabschOrientationPerservationTest(unittest.TestCase):
+class KabschOrientationPreservationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
         stage_coords = [
             StageCoordinate(*[17232.05, 258.53, 9674.18]),
             StageCoordinate(*[17229.81, 807.78, 9676.27]),
-            StageCoordinate(*[20582.50, -2968.97, 9694.711])]
+            StageCoordinate(*[20582.50, -2968.97, 9694.711])
+        ]
 
         chip_coords = [
             ChipCoordinate(*[-1050.00, 570, 0]),
             ChipCoordinate(*[-1050.00, 1120, 0]),
-            ChipCoordinate(*[2295.00, -2650, 0])]
+            ChipCoordinate(*[2295.00, -2650, 0])
+        ]
 
         cls.axes_rotation_matrix = np.array([
             [1,0,0],
@@ -759,7 +617,8 @@ class KabschOrientationPerservationTest(unittest.TestCase):
         np.testing.assert_allclose(
             kabsch_stage_x_unit, user_stage_x_unit.to_numpy(),
             rtol=1e-5,
-            atol=1)
+            atol=1
+        )
 
     def test_y_unit_direction(self):
         chip_y_unit = [0,1,0]
@@ -770,7 +629,8 @@ class KabschOrientationPerservationTest(unittest.TestCase):
         np.testing.assert_allclose(
             kabsch_stage_y_unit, user_stage_y_unit.to_numpy(),
             rtol=1e-5,
-            atol=1)
+            atol=1
+        )
 
     def test_z_unit_direction(self):
         chip_z_unit = [0,0,1]
@@ -781,52 +641,58 @@ class KabschOrientationPerservationTest(unittest.TestCase):
         np.testing.assert_allclose(
             kabsch_stage_z_unit, user_stage_z_unit.to_numpy(),
             rtol=1e-5,
-            atol=1)
+            atol=1
+        )
 
 
 
-class KabschOrientationPerservationRandomTest(unittest.TestCase):
+class KabschOrientationPreservationRandomTest(unittest.TestCase):
 
     CHIP_LIMIT = [-5000, 5000]
     STAGE_LIMIT = [-30000, 30000]
 
     def create_pairings(
         self,
-        axes_rotation: Type[AxesRotation],
-        noise=np.array([0,0,0]),
-        number_of_pairings=3
+        axes_rotation: AxesRotation,
+        noise: NDArray[np.float64] = np.array([0,0,0]),
+        number_of_pairings: int = 3
     ) -> List[CoordinatePairing]:
+
         pairings = []
         init_pairing = CoordinatePairing(
             calibration=Mock(),
             stage_coordinate=StageCoordinate.from_list([
                 uniform(self.STAGE_LIMIT[0], self.STAGE_LIMIT[1]),
                 uniform(self.STAGE_LIMIT[0], self.STAGE_LIMIT[1]),
-                uniform(self.STAGE_LIMIT[0], self.STAGE_LIMIT[1])]),
+                uniform(self.STAGE_LIMIT[0], self.STAGE_LIMIT[1])
+            ]),
             device=Mock(),
             chip_coordinate=ChipCoordinate.from_list([
                 uniform(self.CHIP_LIMIT[0], self.CHIP_LIMIT[1]),
                 uniform(self.CHIP_LIMIT[0], self.CHIP_LIMIT[1]),
-                0]))
+                0
+            ])
+        )
 
         pairings.append(init_pairing)
 
-        stage_offset = axes_rotation.chip_to_stage(
-            init_pairing.chip_coordinate) - init_pairing.stage_coordinate + StageCoordinate.from_numpy(noise)
+        stage_offset = (axes_rotation.chip_to_stage(init_pairing.chip_coordinate) - init_pairing.stage_coordinate +
+                        StageCoordinate.from_numpy(noise))
 
         for _ in range(1, number_of_pairings):
             new_chip_coord = StageCoordinate.from_list([
                 uniform(self.CHIP_LIMIT[0], self.CHIP_LIMIT[1]),
                 uniform(self.CHIP_LIMIT[0], self.CHIP_LIMIT[1]),
-                0])
-            new_stage_coord = axes_rotation.chip_to_stage(
-                new_chip_coord) - stage_offset
+                0
+            ])
+            new_stage_coord = axes_rotation.chip_to_stage(new_chip_coord) - stage_offset
             
             pairings.append(CoordinatePairing(
                 calibration=Mock(),
                 stage_coordinate=new_stage_coord,
                 device=Mock(),
-                chip_coordinate=new_chip_coord))
+                chip_coordinate=new_chip_coord)
+            )
 
         return pairings
 
@@ -852,18 +718,18 @@ class KabschOrientationPerservationRandomTest(unittest.TestCase):
         ground_truth = axes_rotation.matrix @ x_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ x_unit_vector
         self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
-            "X-Unit Vector orientation not perserved!")
+            "X-Unit Vector orientation not preserved!")
 
         # Test y unit
         y_unit_vector = np.array([0,1,0])
         ground_truth = axes_rotation.matrix @ y_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ y_unit_vector
         self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
-            "Y-Unit Vector orientation not perserved!")
+            "Y-Unit Vector orientation not preserved!")
 
         # Test x unit
         z_unit_vector = np.array([0,0,1])
         ground_truth = axes_rotation.matrix @ z_unit_vector
         kabsch_transformed_vector = kabsch_rotation.rotation_to_stage @ z_unit_vector
         self.assertGreater(ground_truth.dot(kabsch_transformed_vector), 0, 
-            "Z-Unit Vector orientation not perserved!")
+            "Z-Unit Vector orientation not preserved!")

--- a/LabExT/View/Controls/CoordinateWidget.py
+++ b/LabExT/View/Controls/CoordinateWidget.py
@@ -5,8 +5,7 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from typing import Type
-from tkinter import LEFT, SUNKEN, Frame, Label
+from tkinter import LEFT, SUNKEN, Frame, Label, Tk
 
 from LabExT.Movement.config import Axis, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
@@ -18,10 +17,9 @@ class CoordinateWidget(Frame):
     Simple Widget to display a coordinate
     """
 
-    def __init__(self, master, coordinate: Type[Coordinate]):
-        super(CoordinateWidget, self).__init__(master)
+    def __init__(self, parent: Tk, coordinate: Coordinate) -> None:
+        super().__init__(parent)
         self._coordinate = coordinate
-
         self.__setup__()
 
     def __setup__(self):
@@ -36,13 +34,13 @@ class CoordinateWidget(Frame):
             ).pack(side=LEFT, ipadx=5, padx=(0, 5))
 
     @property
-    def coordinate(self):
-        self._coordinate
+    def coordinate(self) -> Coordinate:
+        return self._coordinate
 
     @coordinate.setter
-    def coordinate(self, coordinate):
+    def coordinate(self, coordinate: Coordinate) -> None:
         """
-        Rerenders the the frame to display
+        Rerenders the frame to display
         """
         self._coordinate = coordinate
 
@@ -60,16 +58,15 @@ class StagePositionWidget(CoordinateWidget):
 
     REFRESHING_RATE = 1000  # [ms]
 
-    def __init__(self, parent, calibration: Type[Calibration]):
+    def __init__(self, parent: Tk, calibration: Calibration) -> None:
         self.calibration = calibration
 
         with self.calibration.perform_in_system(CoordinateSystem.STAGE):
             super().__init__(parent, self.calibration.get_position())
 
-        self._update_pos_job = self.after(
-            self.REFRESHING_RATE, self._refresh_position)
+        self._update_pos_job = self.after(self.REFRESHING_RATE, self._refresh_position)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """
         Deconstructor.
 
@@ -78,7 +75,7 @@ class StagePositionWidget(CoordinateWidget):
         if self._update_pos_job:
             self.after_cancel(self._update_pos_job)
 
-    def _refresh_position(self):
+    def _refresh_position(self) -> None:
         """
         Refreshes Stage Position.
         Kills update job, if an error occurred.
@@ -90,5 +87,4 @@ class StagePositionWidget(CoordinateWidget):
             self.after_cancel(self._update_pos_job)
             raise RuntimeError(exc)
 
-        self._update_pos_job = self.after(
-            self.REFRESHING_RATE, self._refresh_position)
+        self._update_pos_job = self.after(self.REFRESHING_RATE, self._refresh_position)

--- a/LabExT/View/Controls/CoordinateWidget.py
+++ b/LabExT/View/Controls/CoordinateWidget.py
@@ -10,7 +10,7 @@ from tkinter import LEFT, SUNKEN, Frame, Label
 
 from LabExT.Movement.config import Axis, CoordinateSystem
 from LabExT.Movement.Calibration import Calibration
-from LabExT.Movement.Transformations import Coordinate
+from LabExT.Movement.Coordinate import Coordinate
 
 
 class CoordinateWidget(Frame):

--- a/LabExT/View/Controls/CustomTable.py
+++ b/LabExT/View/Controls/CustomTable.py
@@ -5,9 +5,10 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from tkinter import Tk
+from tkinter import Tk, Frame
 from typing import List, Literal, Any, Union
 
+from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.CustomTtkWidgets import CustomTreeview, CustomScrollbar
 
 
@@ -16,7 +17,7 @@ class CustomTable:
     """
 
     def __init__(self,
-                 parent: Tk,
+                 parent: Union[Tk, Frame, CustomFrame],
                  column_headers: List[str],
                  rows: List[tuple],
                  col_width: int = 20,

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -5,8 +5,8 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y
-from typing import Callable, Type
+from tkinter import Frame, Toplevel, Button, Label, messagebox, LEFT, RIGHT, TOP, X, BOTH, DISABLED, FLAT, NORMAL, Y, Tk
+from typing import Callable, TYPE_CHECKING, Optional, Union
 from LabExT.Utils import run_with_wait_window
 from LabExT.View.Controls.CustomFrame import CustomFrame
 from LabExT.View.Controls.DeviceTable import DeviceTable
@@ -16,7 +16,13 @@ from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.MoverNew import MoverNew
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Movement.config import CoordinateSystem
+from LabExT.View.Controls.Wizard import Wizard
 from LabExT.Wafer.Chip import Chip
+
+if TYPE_CHECKING:
+    from LabExT.ExperimentManager import ExperimentManager
+else:
+    ExperimentManager = None
 
 
 class CoordinatePairingsWindow(Toplevel):
@@ -26,19 +32,20 @@ class CoordinatePairingsWindow(Toplevel):
 
     def __init__(
             self,
-            master,
-            mover: Type[MoverNew],
-            chip: Type[Chip],
-            on_finish: Type[Callable],
-            experiment_manager=None,
+            parent: Union[Tk, Wizard],
+            mover: MoverNew,
+            chip: Chip,
+            on_finish: Callable,
+            experiment_manager: Optional[ExperimentManager] = None,
             with_input_stage: bool = True,
-            with_output_stage: bool = True) -> None:
+            with_output_stage: bool = True
+    ) -> None:
         """
         Constructor for new CoordinatePairing Window.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -59,10 +66,10 @@ class CoordinatePairingsWindow(Toplevel):
             If input or output calibration are undefined but requested by user.
             If chip is None.
         """
-        super(CoordinatePairingsWindow, self).__init__(master)
+        super().__init__(parent)
 
-        self.chip: Type[Chip] = chip
-        self.mover: Type[MoverNew] = mover
+        self.chip = chip
+        self.mover = mover
         self.experiment_manager = experiment_manager
 
         self.on_finish = on_finish
@@ -73,12 +80,10 @@ class CoordinatePairingsWindow(Toplevel):
             raise ValueError("Cannot create pairing without chip imported. ")
 
         if self.with_input_stage and self.mover.input_calibration is None:
-            raise ValueError(
-                "No input stage defined, but requested by user to create a pairing.")
+            raise ValueError("No input stage defined, but requested by user to create a pairing.")
 
         if self.with_output_stage and self.mover.output_calibration is None:
-            raise ValueError(
-                "No input stage defined, but requested by user to create a pairing.")
+            raise ValueError("No input stage defined, but requested by user to create a pairing.")
 
         self._device = None
 
@@ -91,11 +96,7 @@ class CoordinatePairingsWindow(Toplevel):
         self._main_frame = Frame(self, borderwidth=0, relief=FLAT)
         self._main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
 
-        self._buttons_frame = Frame(
-            self,
-            borderwidth=0,
-            highlightthickness=0,
-            takefocus=0)
+        self._buttons_frame = Frame(self, borderwidth=0, highlightthickness=0, takefocus=0)
         self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
 
         hint = "Press Finish when you have reached an optimal coupling and want to save the pairings."
@@ -107,9 +108,9 @@ class CoordinatePairingsWindow(Toplevel):
             text="Save and Close",
             width=15,
             state=DISABLED,
-            command=self.finish)
-        self._finish_button.pack(
-            side=RIGHT, fill=Y, expand=0)
+            command=self.finish
+        )
+        self._finish_button.pack(side=RIGHT, fill=Y, expand=0)
 
         self.__setup__()
 
@@ -130,18 +131,10 @@ class CoordinatePairingsWindow(Toplevel):
             self._device_table = DeviceTable(frame, self.chip)
             self._device_table.pack(side=TOP, fill=X, expand=True)
 
-            self._select_device_button = Button(
-                frame,
-                text="Select marked device",
-                command=self._on_device_selection
-            )
+            self._select_device_button = Button(frame, text="Select marked device", command=self._on_device_selection)
             self._select_device_button.pack(side=LEFT, pady=2)
         else:
-            Label(
-                frame,
-                text=self._device.id,
-                font='Helvetica 12 bold'
-            ).pack(side=LEFT, fill=X)
+            Label(frame, text=self._device.id, font='Helvetica 12 bold').pack(side=LEFT, fill=X)
 
             self._clear_device_button = Button(
                 frame,
@@ -157,14 +150,10 @@ class CoordinatePairingsWindow(Toplevel):
         step_hint.pack(side=TOP, fill=X)
 
         if self.with_input_stage:
-            self._calibration_pairing_widget(
-                frame, self.mover.input_calibration).pack(
-                side=TOP, fill=X)
+            self._calibration_pairing_widget(frame, self.mover.input_calibration).pack(side=TOP, fill=X)
 
         if self.with_output_stage:
-            self._calibration_pairing_widget(
-                frame, self.mover.output_calibration).pack(
-                side=TOP, fill=X)
+            self._calibration_pairing_widget(frame, self.mover.output_calibration).pack(side=TOP, fill=X)
 
         if self.experiment_manager:
             shortcuts_frame = CustomFrame(self._main_frame)
@@ -173,16 +162,16 @@ class CoordinatePairingsWindow(Toplevel):
             search_for_peak_button = Button(
                 shortcuts_frame,
                 text="Perform Search for Peak...",
-                command=self.experiment_manager.main_window.open_peak_searcher)
-            search_for_peak_button.pack(
-                side=RIGHT, fill=Y, pady=5, expand=0)
+                command=self.experiment_manager.main_window.open_peak_searcher
+            )
+            search_for_peak_button.pack(side=RIGHT, fill=Y, pady=5, expand=0)
 
             live_viewer_button = Button(
                 shortcuts_frame,
                 text="Open Live Viewer...",
-                command=self.experiment_manager.main_window.open_live_viewer)
-            live_viewer_button.pack(
-                side=RIGHT, fill=Y, pady=5, expand=0)
+                command=self.experiment_manager.main_window.open_live_viewer
+            )
+            live_viewer_button.pack(side=RIGHT, fill=Y, pady=5, expand=0)
 
     def __reload__(self) -> None:
         """
@@ -205,10 +194,7 @@ class CoordinatePairingsWindow(Toplevel):
         Destroys the window.
         """
         if self._device is None:
-            messagebox.showwarning(
-                'Device Needed',
-                'Please select a device to create a pairing.',
-                parent=self)
+            messagebox.showwarning('Device Needed', 'Please select a device to create a pairing.', parent=self)
             return
 
         pairings = []
@@ -243,14 +229,10 @@ class CoordinatePairingsWindow(Toplevel):
         """
         self._device = self._device_table.get_selected_device()
         if self._device is None:
-            messagebox.showwarning(
-                'Selection Needed',
-                'Please select one device.',
-                parent=self)
+            messagebox.showwarning('Selection Needed', 'Please select one device.', parent=self)
             return
 
         self._ask_user_move_to_device()
-
         self.__reload__()
 
     def _on_device_selection_clear(self) -> None:
@@ -274,37 +256,38 @@ class CoordinatePairingsWindow(Toplevel):
             return
 
         run_with_wait_window(
-            self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(self._device))
+            self,
+            description=f"Move to device {self._device.id}",
+            function=lambda: self.mover.move_to_device(self._device)
+        )
     #
     #   Helpers
     #
 
-    def _get_pairing(
-            self,
-            calibration: Type[Calibration]) -> Type[CoordinatePairing]:
+    def _get_pairing(self, calibration: Calibration) -> Optional[CoordinatePairing]:
         """
         Builds and returns a new coordinate pairing for the given calibration.
-
         Returns None if calibration is None.
         """
         if calibration is None:
-            return
+            return None
 
         if calibration.is_input_stage:
             chip_coord = self._device.input_coordinate
         elif calibration.is_output_stage:
             chip_coord = self._device.output_coordinate
+        else:
+            raise ValueError("Device port not assigned to calibration.")
 
         with calibration.perform_in_system(CoordinateSystem.STAGE):
             return CoordinatePairing(
                 calibration,
                 calibration.get_position(),
                 self._device,
-                chip_coord)
+                chip_coord
+            )
 
-    def _calibration_pairing_widget(
-            self, parent, calibration) -> Type[CustomFrame]:
+    def _calibration_pairing_widget(self, parent: Tk, calibration: Calibration) -> CustomFrame:
         """
         Builds and returns a frame to display the current pairing state.
         """
@@ -313,32 +296,22 @@ class CoordinatePairingsWindow(Toplevel):
         pairing_frame.pack(side=TOP, fill=X, pady=5)
 
         if self._device:
-            Label(
-                pairing_frame,
-                text="Chip coordinate:"
-            ).pack(side=LEFT)
+            Label(pairing_frame, text="Chip coordinate:").pack(side=LEFT)
 
             CoordinateWidget(
                 pairing_frame,
                 coordinate=self._device.input_coordinate if calibration.is_input_stage else self._device.output_coordinate
             ).pack(side=LEFT)
 
-            Label(
-                pairing_frame,
-                text="will be paired with Stage coordinate:"
-            ).pack(side=LEFT)
+            Label(pairing_frame, text="will be paired with Stage coordinate:").pack(side=LEFT)
 
             StagePositionWidget(pairing_frame, calibration).pack(side=LEFT)
         else:
-            Label(
-                pairing_frame,
-                text="No device selected",
-                foreground="#FF3333"
-            ).pack(side=LEFT)
+            Label(pairing_frame, text="No device selected", foreground="#FF3333").pack(side=LEFT)
 
         return pairing_frame
 
-    def _get_coupling_hint(self):
+    def _get_coupling_hint(self) -> str:
         """
         Displays a coupling hint depending on the given calibrations.
         """
@@ -354,3 +327,5 @@ class CoordinatePairingsWindow(Toplevel):
         if self.with_output_stage:
             return "You have selected one stages to create a pairing:\n" \
                    f"{self.mover.output_calibration} must be moved to the output port"
+
+        return ""

--- a/LabExT/View/Movement/CoordinatePairingsWindow.py
+++ b/LabExT/View/Movement/CoordinatePairingsWindow.py
@@ -275,8 +275,7 @@ class CoordinatePairingsWindow(Toplevel):
 
         run_with_wait_window(
             self, description="Move to device {}".format(
-                self._device.id), function=lambda: self.mover.move_to_device(
-                self.chip, self._device))
+                self._device.id), function=lambda: self.mover.move_to_device(self._device))
     #
     #   Helpers
     #

--- a/LabExT/View/Movement/LoadStoredCalibrationWindow.py
+++ b/LabExT/View/Movement/LoadStoredCalibrationWindow.py
@@ -6,8 +6,8 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 """
 import logging
 
-from tkinter import Frame, Label, OptionMenu, StringVar, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y, LEFT
-from typing import Type
+from tkinter import Frame, Label, OptionMenu, StringVar, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y, \
+    LEFT, Tk
 
 from LabExT.Utils import run_with_wait_window
 from LabExT.Movement.MoverNew import MoverNew
@@ -19,19 +19,13 @@ class LoadStoredCalibrationWindow(Toplevel):
     """
 
     ASSIGNMENT_MENU_PLACEHOLDER = "-- unused --"
-
     MENU_OPTION_TEMPLATE = "Stage-ID: {id} - Port: {port}"
 
-    def __init__(
-        self,
-        master,
-        mover: Type[MoverNew],
-        calibration_settings: dict
-    ) -> None:
+    def __init__(self, parent: Tk, mover: MoverNew, calibration_settings: dict) -> None:
         """
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -43,14 +37,13 @@ class LoadStoredCalibrationWindow(Toplevel):
         RuntimeError
             If calibrations could not be restored.
         """
-        super(LoadStoredCalibrationWindow, self).__init__(master)
+        super().__init__(parent)
 
         self.logger = logging.getLogger()
 
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
         self.calibration_settings = calibration_settings
-        self.stored_calibrations = self.calibration_settings.get(
-            "calibrations", {})
+        self.stored_calibrations = self.calibration_settings.get("calibrations", {})
 
         self.calibrations_vars = {}
         self.menu_options = [
@@ -65,18 +58,14 @@ class LoadStoredCalibrationWindow(Toplevel):
 
         self.__setup__()
 
-    def __setup__(self):
+    def __setup__(self) -> None:
         """
         Builds window to restore calibrations.
         """
         main_frame = Frame(self, borderwidth=0, relief=FLAT)
         main_frame.pack(side=TOP, fill=BOTH, expand=True, padx=10)
 
-        buttons_frame = Frame(
-            self,
-            borderwidth=0,
-            highlightthickness=0,
-            takefocus=0)
+        buttons_frame = Frame(self, borderwidth=0, highlightthickness=0, takefocus=0)
         buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
 
         stage_assignment_frame = CustomFrame(main_frame)
@@ -87,29 +76,22 @@ class LoadStoredCalibrationWindow(Toplevel):
             available_stage_frame = Frame(stage_assignment_frame)
             available_stage_frame.pack(side=TOP, fill=X, pady=2)
 
-            Label(
-                available_stage_frame, text=str(avail_stage), anchor="w"
-            ).pack(side=LEFT, fill=X, padx=(0, 10))
+            Label(available_stage_frame, text=str(avail_stage), anchor="w").pack(side=LEFT, fill=X, padx=(0, 10))
 
             stored_stage = next(
                 (c for c in self.stored_calibrations if c["stage_identifier"] == avail_stage.identifier),
-                None)
+                None
+            )
             calibration_var = StringVar(
                 main_frame,
-                self.MENU_OPTION_TEMPLATE.format(
-                    id=stored_stage["stage_identifier"], port=stored_stage["device_port"]
-                ) if stored_stage else self.ASSIGNMENT_MENU_PLACEHOLDER)
+                self.MENU_OPTION_TEMPLATE.format(id=stored_stage["stage_identifier"], port=stored_stage["device_port"])
+                if stored_stage else self.ASSIGNMENT_MENU_PLACEHOLDER
+            )
 
-            OptionMenu(
-                available_stage_frame,
-                calibration_var,
-                *self.menu_options
-            ).pack(side=RIGHT, padx=5)
+            OptionMenu(available_stage_frame, calibration_var, *self.menu_options).pack(side=RIGHT, padx=5)
             self.calibrations_vars[avail_stage] = calibration_var
 
-            Label(
-                available_stage_frame, text="Calibrations:"
-            ).pack(side=RIGHT, fill=X, padx=5)
+            Label(available_stage_frame, text="Calibrations:").pack(side=RIGHT, fill=X, padx=5)
 
         Button(
             buttons_frame,
@@ -118,19 +100,18 @@ class LoadStoredCalibrationWindow(Toplevel):
             command=self.apply_calibrations
         ).pack(side=RIGHT, fill=Y, expand=0)
 
-    def apply_calibrations(self):
+    def apply_calibrations(self) -> None:
         """
         Callback, when user wants to apply the calibrations
         """
         assignment = self._resolve_calibrations()
-        if any(
-                c["stage_identifier"] != s.identifier for s,
-                c in assignment.items()):
+        if any(c["stage_identifier"] != s.identifier for s, c in assignment.items()):
             if not messagebox.askyesno(
                 "Caution: Different stage identifiers",
-                "CONFIRMATION REQUIRED: Some calibrations were assigned to a stage with a different identifier than the one used to create the calibration. "
-                "Incorrectly assigned calibrations cannot be guaranteed to work. Are you sure you want to apply these assignments?",
-                    parent=self):
+                "CONFIRMATION REQUIRED: Some calibrations were assigned to a stage with a different identifier than "
+                "the one used to create the calibration. Incorrectly assigned calibrations cannot be guaranteed to work. "
+                "Are you sure you want to apply these assignments?",
+                parent=self):
                 return
 
         # Reset calibrations
@@ -139,28 +120,18 @@ class LoadStoredCalibrationWindow(Toplevel):
         # Apply calibrations
         for stage, stored_calibration in assignment.items():
             try:
-                calibration = self.mover.restore_stage_calibration(
-                    stage, stored_calibration)
+                calibration = self.mover.restore_stage_calibration(stage, stored_calibration)
             except Exception as err:
-                messagebox.showerror(
-                    "Error",
-                    f"Failed to restored calibration: {err}",
-                    parent=self)
+                messagebox.showerror("Error", f"Failed to restored calibration: {err}", parent=self)
                 self.mover.reset_calibrations()
                 return
 
-            run_with_wait_window(
-                self,
-                f"Connecting to stage {stage}",
-                lambda: calibration.connect_to_stage())
+            run_with_wait_window(self, f"Connecting to stage {stage}", lambda: calibration.connect_to_stage())
 
         # Store calibrations to disk
         self.mover.dump_calibrations()
 
-        messagebox.showinfo(
-            "Success",
-            f"Successfully restored {len(assignment)} calibration(s)",
-            parent=self)
+        messagebox.showinfo("Success", f"Successfully restored {len(assignment)} calibration(s)", parent=self)
         self.destroy()
 
     def _resolve_calibrations(self) -> dict:

--- a/LabExT/View/Movement/MoveStagesDeviceWindow.py
+++ b/LabExT/View/Movement/MoveStagesDeviceWindow.py
@@ -5,8 +5,7 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y
-from typing import Type
+from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y, Tk
 from LabExT.Utils import run_with_wait_window
 
 from LabExT.Movement.MoverNew import MoverNew
@@ -19,18 +18,13 @@ class MoveStagesDeviceWindow(Toplevel):
     Window to move stages to device
     """
 
-    def __init__(
-        self,
-        master,
-        mover: Type[MoverNew],
-        chip: Type[Chip]
-    ) -> None:
+    def __init__(self, parent: Tk, mover: MoverNew, chip: Chip) -> None:
         """
         Constructor for new move to device Window.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -43,19 +37,20 @@ class MoveStagesDeviceWindow(Toplevel):
             If mover cannot move absolutely
             If chip is None.
         """
-        self.mover: Type[MoverNew] = mover
-        self.chip: Type[Chip] = chip
+        self.mover = mover
+        self.chip = chip
 
         if not self.mover.can_move_absolutely:
             raise RuntimeError(
-                f"Cannot perform absolute movement, not all active stages are calibrated correctly. "
+                "Cannot perform absolute movement, not all active stages are calibrated correctly. "
                 "Note for each stage a coordinate transformation must be defined.")
 
         if self.chip is None:
             raise RuntimeError(
-                "'No chip file imported before moving to device. Cannot move to device without chip file present.")
+                "'No chip file imported before moving to device. Cannot move to device without chip file present."
+            )
 
-        super(MoveStagesDeviceWindow, self).__init__(master)
+        super().__init__(parent)
 
         # Set up window
         self.title("Move Stages to Device")
@@ -70,47 +65,41 @@ class MoveStagesDeviceWindow(Toplevel):
                f"The stages are z-lifted by {self.mover.z_lift:.0f}nm before the lateral movement and lowered again afterwards.\n"
         Label(self._main_frame, text=hint).pack(side=TOP, fill=X)
 
-        self._buttons_frame = Frame(
-            self,
-            borderwidth=0,
-            highlightthickness=0,
-            takefocus=0)
+        self._buttons_frame = Frame(self, borderwidth=0, highlightthickness=0, takefocus=0)
         self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
 
         self._execute_button = Button(
             self._buttons_frame,
             text="Execute Movement",
             width=15,
-            command=self.execute_movement)
-        self._execute_button.pack(
-            side=RIGHT, fill=Y, expand=0)
+            command=self.execute_movement
+        )
+        self._execute_button.pack(side=RIGHT, fill=Y, expand=0)
 
         self._device_table = DeviceTable(self._main_frame, self.chip)
         self._device_table.pack(side=TOP, fill=X)
 
-    def execute_movement(self):
+    def execute_movement(self) -> None:
         """
         Callback, when user wants to execute the movement.
         """
         selected_device = self._device_table.get_selected_device()
         if selected_device is None:
-            messagebox.showwarning(
-                'Selection Needed',
-                'Please select one device.',
-                parent=self)
+            messagebox.showwarning('Selection Needed', 'Please select one device.', parent=self)
             return
 
         if self._confirm_movement(selected_device):
             run_with_wait_window(
                 self,
                 f"Moving to Device {selected_device.id}",
-                lambda: self.mover.move_to_device(selected_device))
+                lambda: self.mover.move_to_device(selected_device)
+            )
 
-    def _confirm_movement(self, device: Type[Device]) -> bool:
+    def _confirm_movement(self, device: Device) -> bool:
         """
         Asks the user to confirm the movement.
         """
-        message = f"By proceeding the stages will be moved to device {device.id}\n"\
-            "Do you want to proceed?"
+        message = (f"By proceeding the stages will be moved to device {device.id}\n"
+                   f"Do you want to proceed?")
 
         return messagebox.askokcancel("Confirm Movement", message, parent=self)

--- a/LabExT/View/Movement/MoveStagesDeviceWindow.py
+++ b/LabExT/View/Movement/MoveStagesDeviceWindow.py
@@ -104,7 +104,7 @@ class MoveStagesDeviceWindow(Toplevel):
             run_with_wait_window(
                 self,
                 f"Moving to Device {selected_device.id}",
-                lambda: self.mover.move_to_device(self.chip, selected_device))
+                lambda: self.mover.move_to_device(selected_device))
 
     def _confirm_movement(self, device: Type[Device]) -> bool:
         """

--- a/LabExT/View/Movement/MoveStagesRelativeWindow.py
+++ b/LabExT/View/Movement/MoveStagesRelativeWindow.py
@@ -5,10 +5,11 @@ LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
-from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y
-from typing import Type
-from LabExT.Movement.Transformations import ChipCoordinate
-from LabExT.Movement.config import Axis
+from tkinter import Frame, Label, Toplevel, Button, messagebox, RIGHT, TOP, X, BOTH, FLAT, Y, Tk
+from typing import Dict
+
+from LabExT.Movement.Coordinate import ChipCoordinate
+from LabExT.Movement.config import Axis, Orientation
 from LabExT.Utils import run_with_wait_window
 
 from LabExT.Movement.MoverNew import MoverNew
@@ -20,17 +21,13 @@ class MoveStagesRelativeWindow(Toplevel):
     Window to move stages relative in chip coordinates
     """
 
-    def __init__(
-        self,
-        master,
-        mover: Type[MoverNew]
-    ) -> None:
+    def __init__(self, parent: Tk, mover: MoverNew) -> None:
         """
         Constructor for new CoordinatePairing Window.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -41,14 +38,15 @@ class MoveStagesRelativeWindow(Toplevel):
             If input or output calibration are undefined but requested by user.
             If chip is None.
         """
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
 
         if not self.mover.can_move_relatively:
             raise RuntimeError(
-                f"Cannot perform relative movement, not all active stages are calibrated correctly. "
-                "Note for each stage the coordinate system must be fixed.")
+                "Cannot perform relative movement, not all active stages are calibrated correctly. "
+                "Note for each stage the coordinate system must be fixed."
+            )
 
-        super(MoveStagesRelativeWindow, self).__init__(master)
+        super().__init__(parent)
 
         self.parameters = {}
 
@@ -66,27 +64,22 @@ class MoveStagesRelativeWindow(Toplevel):
                "The stages will move one after each other in the order: top, right, bottom, left"
         Label(self._main_frame, text=hint).pack(side=TOP, fill=X)
 
-        self._buttons_frame = Frame(
-            self,
-            borderwidth=0,
-            highlightthickness=0,
-            takefocus=0)
+        self._buttons_frame = Frame(self, borderwidth=0, highlightthickness=0, takefocus=0)
         self._buttons_frame.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
 
         self._execute_button = Button(
             self._buttons_frame,
             text="Execute Movement",
             width=15,
-            command=self.execute_movement)
-        self._execute_button.pack(
-            side=RIGHT, fill=Y, expand=0)
+            command=self.execute_movement
+        )
+        self._execute_button.pack(side=RIGHT, fill=Y, expand=0)
 
         self.parameter_tables = {}
         for calibration in self.mover.calibrations.values():
             movement_params = {}
             for axis in Axis:
-                movement_params[axis] = ConfigParameter(
-                    self, unit='um', parameter_type='number_float')
+                movement_params[axis] = ConfigParameter(self, unit='um', parameter_type='number_float')
 
             parameter_table = ParameterTable(self._main_frame)
             parameter_table.pack(side=TOP, fill=X, expand=0, padx=10, pady=10)
@@ -96,27 +89,25 @@ class MoveStagesRelativeWindow(Toplevel):
             self.parameter_tables[calibration] = parameter_table
             self.parameters[calibration] = movement_params
 
-    def execute_movement(self):
+    def execute_movement(self) -> None:
         """
         Callback, when user wants to execute the movement.
         """
-        movement_commands = {}
+        movement_commands: Dict[Orientation, ChipCoordinate] = {}
         for calibration, params in self.parameters.items():
             requested_offset = ChipCoordinate(
                 x=float(params[Axis.X].value),
                 y=float(params[Axis.Y].value),
-                z=float(params[Axis.Z].value))
+                z=float(params[Axis.Z].value)
+            )
 
             if not requested_offset.is_zero:
                 movement_commands[calibration.orientation] = requested_offset
 
         if self._confirm_movement(movement_commands):
-            run_with_wait_window(
-                self,
-                "Moving stages relatively",
-                lambda: self.mover.move_relative(movement_commands))
+            run_with_wait_window(self, "Moving stages relatively", lambda: self.mover.move_relative(movement_commands))
 
-    def _confirm_movement(self, movement_commands) -> bool:
+    def _confirm_movement(self, movement_commands: Dict[Orientation, ChipCoordinate]) -> bool:
         """
         Asks the user to confirm the movement.
         """

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -11,7 +11,7 @@ from itertools import product
 from tkinter import W, Label, Button, messagebox, StringVar, OptionMenu, Frame, Button, Label, DoubleVar, Entry, BooleanVar, Checkbutton, DISABLED, NORMAL, LEFT, RIGHT, TOP, X
 from typing import Type, List
 from bidict import bidict
-from LabExT.Movement.PathPlanning import SingleModeFiber, StagePolygon
+from LabExT.Movement.Polygons import SingleModeFiber, StagePolygon
 
 from LabExT.Utils import run_with_wait_window, try_to_lift_window
 from LabExT.View.Movement.CoordinatePairingsWindow import CoordinatePairingsWindow

--- a/LabExT/View/Movement/MovementWizard.py
+++ b/LabExT/View/Movement/MovementWizard.py
@@ -8,9 +8,11 @@ This program is free software and comes with ABSOLUTELY NO WARRANTY; for details
 from logging import getLogger
 from functools import partial
 from itertools import product
-from tkinter import W, Label, Button, messagebox, StringVar, OptionMenu, Frame, Button, Label, DoubleVar, Entry, BooleanVar, Checkbutton, DISABLED, NORMAL, LEFT, RIGHT, TOP, X
-from typing import Type, List
+from tkinter import (W, messagebox, StringVar, OptionMenu, Frame, Button, Label, DoubleVar, Entry, BooleanVar,
+                     Checkbutton, DISABLED, NORMAL, LEFT, RIGHT, TOP, X, Tk)
+from typing import List, Optional, TYPE_CHECKING, TypeVar, Callable
 from bidict import bidict
+
 from LabExT.Movement.Polygons import SingleModeFiber, StagePolygon
 
 from LabExT.Utils import run_with_wait_window, try_to_lift_window
@@ -23,11 +25,19 @@ from LabExT.View.Controls.ParameterTable import ParameterTable
 from LabExT.Measurements.MeasAPI.Measparam import MeasParamAuto
 
 from LabExT.Movement.config import Orientation, DevicePort, Axis, Direction
-from LabExT.Movement.Stage import Stage, StageError
-from LabExT.Movement.MoverNew import MoverError, MoverNew, Stage
+from LabExT.Movement.Stage import StageError, Stage
+from LabExT.Movement.MoverNew import MoverError, MoverNew
 from LabExT.Movement.Transformations import CoordinatePairing
 from LabExT.Movement.Calibration import Calibration
 from LabExT.Wafer.Chip import Chip
+
+if TYPE_CHECKING:
+    from LabExT.ExperimentManager import ExperimentManager
+else:
+    ExperimentManager = None
+
+
+T = TypeVar("T")
 
 
 class StageWizard(Wizard):
@@ -35,13 +45,13 @@ class StageWizard(Wizard):
     Wizard to load stage drivers and connect to stages.
     """
 
-    def __init__(self, master, mover, experiment_manager=None):
+    def __init__(self, parent: Tk, mover: MoverNew, experiment_manager: Optional[ExperimentManager] = None) -> None:
         """
         Constructor for new Stage Wizard.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -49,7 +59,7 @@ class StageWizard(Wizard):
             Optional instance of the current experiment manager
         """
         super().__init__(
-            master,
+            parent,
             width=1100,
             height=800,
             on_finish=self.finish,
@@ -59,7 +69,7 @@ class StageWizard(Wizard):
             finish_button_label="Finish Setup",
         )
         self.title("Configure Mover")
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
 
         self.experiment_manager = experiment_manager
 
@@ -79,7 +89,8 @@ class StageWizard(Wizard):
             if messagebox.askokcancel(
                 "Proceed?",
                 "You have already created stages. If you continue, they will be reset, including the calibrations. Proceed?",
-                    parent=self):
+                parent=self
+            ):
                 self.mover.reset_calibrations()
             else:
                 return False
@@ -88,11 +99,12 @@ class StageWizard(Wizard):
         for stage, assignment in self.stage_assignment_step.assignment.items():
             orientation, port = assignment
 
-            polygon_cls, polygon_cls_cfg = self.stage_assignment_step.polygon_cfg.get(stage, (
-                self.stage_assignment_step.DEFAULT_POLYGON,
-                self.stage_assignment_step.DEFAULT_POLYGON.get_default_parameters()))
-            stage_polygon = polygon_cls(
-                orientation, parameters=polygon_cls_cfg)
+            polygon_cls, polygon_cls_cfg = self.stage_assignment_step.polygon_cfg.get(
+                stage,
+                (self.stage_assignment_step.DEFAULT_POLYGON,
+                 self.stage_assignment_step.DEFAULT_POLYGON.get_default_parameters())
+            )
+            stage_polygon = polygon_cls(orientation, parameters=polygon_cls_cfg)
 
             try:
                 run_with_wait_window(
@@ -102,26 +114,26 @@ class StageWizard(Wizard):
                         stage=stage,
                         orientation=orientation,
                         port=port,
-                        stage_polygon=stage_polygon))
+                        stage_polygon=stage_polygon)
+                )
             except (ValueError, MoverError, StageError) as e:
                 self.mover.reset_calibrations()
-                messagebox.showerror(
-                    "Error",
-                    f"Connecting to stages failed: {e}",
-                    parent=self)
+                messagebox.showerror("Error", f"Connecting to stages failed: {e}", parent=self)
                 return False
 
         if not self.experiment_manager:
             messagebox.showinfo(
                 "Stage Setup completed.",
                 f"Successfully connected to {len(self.stage_assignment_step.assignment)} stage(s).",
-                parent=self)
+                parent=self
+            )
         else:
             if messagebox.askyesnocancel(
                 "Stage Setup completed.",
                 f"Successfully connected to {len(self.stage_assignment_step.assignment)} stage(s)."
                 "Do you want to calibrate the stages now?",
-                    parent=self):
+                parent=self
+            ):
                 self.destroy()
 
                 self.experiment_manager.main_window.open_stage_calibration()
@@ -134,24 +146,24 @@ class MoverWizard(Wizard):
     Wizard to configure the mover
     """
 
-    def __init__(self, master, mover):
+    def __init__(self, parent: Tk, mover: MoverNew) -> None:
         """
         Constructor for new Mover Wizard.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
         """
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
 
         if not self.mover.has_connected_stages:
             raise RuntimeError("No connected stages. Cannot configure mover.")
 
         super().__init__(
-            master,
+            parent,
             width=1100,
             height=800,
             on_finish=self.finish,
@@ -166,26 +178,29 @@ class MoverWizard(Wizard):
         self.configure_mover_step = ConfigureMoverStep(self, self.mover)
         self.current_step = self.configure_mover_step
 
-    def finish(self):
+    def finish(self) -> bool:
         speed_xy = self._get_safe_value(
             self.configure_mover_step.xy_speed_var,
             float,
-            self.mover.DEFAULT_SPEED_XY)
+            self.mover.DEFAULT_SPEED_XY
+        )
         speed_z = self._get_safe_value(
             self.configure_mover_step.z_speed_var,
             float,
-            self.mover.DEFAULT_SPEED_Z)
+            self.mover.DEFAULT_SPEED_Z
+        )
         acceleration_xy = self._get_safe_value(
             self.configure_mover_step.xy_acceleration_var,
             float,
-            self.mover.DEFAULT_ACCELERATION_XY)
+            self.mover.DEFAULT_ACCELERATION_XY
+        )
         z_lift = self._get_safe_value(
             self.configure_mover_step.z_lift_var,
             float,
-            self.mover.DEFAULT_Z_LIFT)
+            self.mover.DEFAULT_Z_LIFT
+        )
 
-        if self._warn_user_about_zero_speed(
-                speed_xy) and self._warn_user_about_zero_speed(speed_z):
+        if self._warn_user_about_zero_speed(speed_xy) and self._warn_user_about_zero_speed(speed_z):
             try:
                 self.mover.speed_xy = speed_xy
                 self.mover.speed_z = speed_z
@@ -193,21 +208,16 @@ class MoverWizard(Wizard):
                 self.mover.z_lift = z_lift
 
                 self.mover.dump_settings()
-
-                messagebox.showinfo(
-                    "Mover Setup completed.",
-                    f"Successfully configured mover.",
-                    parent=self)
-
+                messagebox.showinfo("Mover Setup completed.", "Successfully configured mover.", parent=self)
                 return True
+
             except Exception as e:
-                messagebox.showerror(
-                    message=f"Could not setup stages. Reason: {e}",
-                    parent=self)
+                messagebox.showerror(message=f"Could not setup stages. Reason: {e}", parent=self)
 
         return False
 
-    def _warn_user_about_zero_speed(self, speed) -> bool:
+    @staticmethod
+    def _warn_user_about_zero_speed(speed: float) -> bool:
         """
         Warns user when settings speed to zero.
         Returns True if speed is not zero or user wants to set speed to zero.
@@ -220,11 +230,8 @@ class MoverWizard(Wizard):
 
         return True
 
-    def _get_safe_value(
-            self,
-            var: Type[DoubleVar],
-            to_type: type,
-            default=None):
+    @staticmethod
+    def _get_safe_value(var: DoubleVar, to_type: Callable[..., T], default: Optional[T] = None) -> T:
         """
         Returns the value of a tkinter entry and cast it to a specified type.
         If casting or retrieving fails, it returns a default value.
@@ -242,17 +249,17 @@ class CalibrationWizard(Wizard):
 
     def __init__(
         self,
-        master,
-        mover,
-        chip=None,
-        experiment_manager=None
+        parent: Tk,
+        mover: MoverNew,
+        chip: Optional[Chip] = None,
+        experiment_manager: Optional[ExperimentManager] = None
     ) -> None:
         """
         Constructor for new Mover Wizard.
 
         Parameters
         ----------
-        master : Tk
+        parent : Tk
             Tk instance of the master toplevel
         mover : Mover
             Instance of the current mover.
@@ -262,16 +269,15 @@ class CalibrationWizard(Wizard):
         experiment_manager : ExperimentManager = None
             Optional instance of the current experiment manager
         """
-        self.mover: Type[MoverNew] = mover
-        self.chip: Type[Chip] = chip
+        self.mover = mover
+        self.chip = chip
         self.experiment_manager = experiment_manager
 
         if len(self.mover.calibrations) == 0:
-            raise RuntimeError(
-                "Calibration not possible without connected stages.")
+            raise RuntimeError("Calibration not possible without connected stages.")
 
         super().__init__(
-            master,
+            parent,
             width=1100,
             height=800,
             on_finish=self.finish,
@@ -283,25 +289,21 @@ class CalibrationWizard(Wizard):
         self.title("Configure Mover")
 
         self.calibrate_axes_step = AxesCalibrationStep(self, self.mover)
-        self.coordinate_pairing_step = CoordinatePairingStep(
-            self, self.mover, self.chip)
+        self.coordinate_pairing_step = CoordinatePairingStep(self, self.mover, self.chip)
 
         self.calibrate_axes_step.next_step = self.coordinate_pairing_step
         self.coordinate_pairing_step.previous_step = self.calibrate_axes_step
 
         self.current_step = self.calibrate_axes_step
 
-    def finish(self):
+    def finish(self) -> bool:
         """
         Callback when user wants to finish the calibration.
         """
         try:
             self.mover.dump_calibrations()
         except Exception as err:
-            messagebox.showerror(
-                "Error",
-                f"Could not store calibration settings to disk: {err}",
-                parent=self)
+            messagebox.showerror("Error", f"Could not store calibration settings to disk: {err}", parent=self)
             return False
 
         return True
@@ -312,24 +314,21 @@ class StageDriverStep(Step):
     Wizard Step to load stage drivers.
     """
 
-    def __init__(self, wizard, mover) -> None:
+    def __init__(self, wizard: StageWizard, mover: MoverNew) -> None:
         """
         Constructor for new Wizard step for loading drivers.
 
         Parameters
         ----------
-        master : Tk
-            Tk instance of the master toplevel
+        wizard : Tk
+            Tk instance of the wizard toplevel
         mover : Mover
             Instance of the current mover.
         """
-        super().__init__(
-            wizard,
-            self.build,
-            title="Driver Settings")
-        self.mover: Type[MoverNew] = mover
+        super().__init__(wizard, self.build, title="Driver Settings")
+        self.mover = mover
 
-    def build(self, frame: Type[CustomFrame]) -> None:
+    def build(self, frame: CustomFrame) -> None:
         """
         Builds step to load stage drivers.
 
@@ -340,35 +339,29 @@ class StageDriverStep(Step):
         """
         frame.title = "Load Stage Drivers"
 
+        # noinspection PyTypeChecker
         Label(
             frame,
-            text="Below you can see all Stage classes available in LabExT.\nSo that all stages can be found correctly in the following step, make sure that the drivers for each class are loaded."
+            text="Below you can see all Stage classes available in LabExT.\n"
+                 "So that all stages can be found correctly in the following step, "
+                 "make sure that the drivers for each class are loaded."
         ).pack(side=TOP, fill=X)
 
         if not self.mover.stage_classes:
-            Label(
-                frame,
-                text="No stage classes found!",
-                foreground="#FF3333").pack(
-                side=TOP,
-                fill=X)
+            Label(frame, text="No stage classes found!", foreground="#FF3333").pack(side=TOP, fill=X)
 
         for stage_name, stage_cls in self.mover.stage_classes.items():
             stage_driver_frame = Frame(frame)
             stage_driver_frame.pack(side=TOP, fill=X, pady=2)
 
-            Label(
-                stage_driver_frame,
-                text=f"[{stage_cls.__name__}] {stage_cls.description}"
-            ).pack(side=LEFT, fill=X)
+            Label(stage_driver_frame, text=f"[{stage_cls.__name__}] {stage_cls.description}").pack(side=LEFT, fill=X)
 
             stage_driver_load = Button(
                 stage_driver_frame,
                 text="Load Driver",
                 state=NORMAL if stage_cls.driver_specifiable else DISABLED,
-                command=partial(
-                    stage_cls.load_driver,
-                    parent=self.wizard))
+                command=partial(stage_cls.load_driver, parent=self.wizard)
+            )
             stage_driver_load.pack(side=RIGHT)
 
             stage_driver_status = Label(
@@ -384,45 +377,37 @@ class StageAssignmentStep(Step):
     Wizard Step to assign and connect stages.
     """
 
-    POLYGON_OPTIONS = {
-        pg.__name__: pg for pg in StagePolygon.find_polygon_classes()}
+    POLYGON_OPTIONS = {pg.__name__: pg for pg in StagePolygon.find_polygon_classes()}
 
     ASSIGNMENT_MENU_PLACEHOLDER = "-- unused --"
 
     DEFAULT_POLYGON = SingleModeFiber
-    DEFAULT_ASSIGNMENT = (
-        ASSIGNMENT_MENU_PLACEHOLDER,
-        DevicePort.INPUT)
+    DEFAULT_ASSIGNMENT = (ASSIGNMENT_MENU_PLACEHOLDER, DevicePort.INPUT)
 
-    def __init__(self, wizard, mover) -> None:
+    def __init__(self, wizard: StageWizard, mover: MoverNew) -> None:
         """
         Constructor for new Wizard step for assigning stages.
 
         Parameters
         ----------
-        master : Tk
-            Tk instance of the master toplevel
-        mover : Mover
+        wizard : Tk
+            Tk instance of the Wizard toplevel
+        mover : MoverNew
             Instance of the current mover.
         """
-        super().__init__(
-            wizard,
-            self.build,
-            on_reload=self.on_reload,
-            title="Stage Connection")
-        self.mover: Type[MoverNew] = mover
+        super().__init__(wizard, self.build, on_reload=self.on_reload, title="Stage Connection")
+        self.mover = mover
 
-        self.assignment = {
-            c.stage: (o, p)
-            for (o, p), c in self.mover.calibrations.items()}
+        self.assignment = {c.stage: (o, p) for (o, p), c in self.mover.calibrations.items()}
         self.polygon_cfg = {
             c.stage: (c.stage_polygon.__class__, c.stage_polygon.parameters)
-            for c in self.mover.calibrations.values()}
+            for c in self.mover.calibrations.values()
+        }
 
         self.orientation_vars, self.port_vars, self.polygon_vars = self._build_assignment_variables()
         self._stage_polygon_parameter_tables = {}
 
-    def build(self, frame: Type[CustomFrame]) -> None:
+    def build(self, frame: CustomFrame) -> None:
         """
         Builds step to assign stages.
 
@@ -435,7 +420,8 @@ class StageAssignmentStep(Step):
 
         Label(
             frame,
-            text="Below you can see all the stages found by LabExT.\nIf stages are missing, go back one step and check if all drivers are loaded."
+            text="Below you can see all the stages found by LabExT.\n"
+                 "If stages are missing, go back one step and check if all drivers are loaded."
         ).pack(side=TOP, fill=X)
 
         available_stages_frame = CustomFrame(frame)
@@ -445,16 +431,12 @@ class StageAssignmentStep(Step):
         CustomTable(
             parent=available_stages_frame,
             selectmode='none',
-            column_headers=(
-                'ID', 'Description', 'Stage Class', 'Address', 'Connected'
-            ),
+            column_headers=( 'ID', 'Description', 'Stage Class', 'Address', 'Connected'),
             rows=[
-                (idx,
-                 s.__class__.description,
-                 s.__class__.__name__,
-                 s.address_string,
-                 s.connected)
-                for idx, s in enumerate(self.mover.available_stages)])
+                (idx, s.__class__.description, s.__class__.__name__, s.address_string, s.connected)
+                for idx, s in enumerate(self.mover.available_stages)
+            ]
+        )
 
         stage_assignment_frame = CustomFrame(frame)
         stage_assignment_frame.title = "Assign Stages"
@@ -464,9 +446,7 @@ class StageAssignmentStep(Step):
             available_stage_frame = Frame(stage_assignment_frame)
             available_stage_frame.pack(side=TOP, fill=X, pady=2)
 
-            Label(
-                available_stage_frame, text=str(avail_stage), anchor="w"
-            ).pack(side=LEFT, fill=X, padx=(0, 10))
+            Label(available_stage_frame, text=str(avail_stage), anchor="w").pack(side=LEFT, fill=X, padx=(0, 10))
 
             polygon_menu = OptionMenu(
                 available_stage_frame,
@@ -475,12 +455,12 @@ class StageAssignmentStep(Step):
             )
             polygon_menu.pack(side=RIGHT, padx=5)
 
-            polygon_menu.config(state=DISABLED if self.orientation_vars[avail_stage].get(
-            ) == self.ASSIGNMENT_MENU_PLACEHOLDER else NORMAL)
+            polygon_menu.config(
+                state=DISABLED if self.orientation_vars[avail_stage].get() == self.ASSIGNMENT_MENU_PLACEHOLDER
+                else NORMAL
+            )
 
-            Label(
-                available_stage_frame, text="Stage type:"
-            ).pack(side=RIGHT, fill=X, padx=5)
+            Label(available_stage_frame, text="Stage type:").pack(side=RIGHT, fill=X, padx=5)
 
             port_menu = OptionMenu(
                 available_stage_frame,
@@ -489,12 +469,12 @@ class StageAssignmentStep(Step):
             )
             port_menu.pack(side=RIGHT, padx=5)
 
-            port_menu.config(state=DISABLED if self.orientation_vars[avail_stage].get(
-            ) == self.ASSIGNMENT_MENU_PLACEHOLDER else NORMAL)
+            port_menu.config(
+                state=DISABLED if self.orientation_vars[avail_stage].get() == self.ASSIGNMENT_MENU_PLACEHOLDER
+                else NORMAL
+            )
 
-            Label(
-                available_stage_frame, text="Device Port:"
-            ).pack(side=RIGHT, fill=X, padx=5)
+            Label(available_stage_frame, text="Device Port:").pack(side=RIGHT, fill=X, padx=5)
 
             OptionMenu(
                 available_stage_frame,
@@ -502,28 +482,23 @@ class StageAssignmentStep(Step):
                 *([self.ASSIGNMENT_MENU_PLACEHOLDER] + list(Orientation))
             ).pack(side=RIGHT, padx=5)
 
-            Label(
-                available_stage_frame, text="Stage Orientation:"
-            ).pack(side=RIGHT, fill=X, padx=5)
+            Label(available_stage_frame, text="Stage Orientation:").pack(side=RIGHT, fill=X, padx=5)
 
             # Enable configuration if orientation is selected
-            if self.orientation_vars[avail_stage].get(
-            ) != self.ASSIGNMENT_MENU_PLACEHOLDER:
+            if self.orientation_vars[avail_stage].get() != self.ASSIGNMENT_MENU_PLACEHOLDER:
                 polygon_cfg_frame = Frame(stage_assignment_frame)
                 polygon_cfg_frame.pack(side=TOP, fill=X)
 
                 polygon_cls, polygon_cls_cfg = self.polygon_cfg.get(
-                    avail_stage, (self.DEFAULT_POLYGON, self.DEFAULT_POLYGON.get_default_parameters()))
-                polygon_params = {
-                    l: MeasParamAuto(
-                        value=v) for l,
-                    v in polygon_cls_cfg.items()}
+                    avail_stage,
+                    (self.DEFAULT_POLYGON, self.DEFAULT_POLYGON.get_default_parameters())
+                )
+                polygon_params = {l: MeasParamAuto(value=v) for l, v in polygon_cls_cfg.items()}
 
                 polygon_cfg_table = ParameterTable(polygon_cfg_frame)
                 polygon_cfg_table.title = f"Configure Polygon: {polygon_cls.__name__}"
                 polygon_cfg_table.parameter_source = polygon_params
-                polygon_cfg_table.pack(
-                    side=TOP, fill=X, expand=0, padx=2, pady=2)
+                polygon_cfg_table.pack(side=TOP, fill=X, expand=0, padx=2, pady=2)
 
                 self._stage_polygon_parameter_tables[avail_stage] = polygon_cfg_table
 
@@ -543,8 +518,7 @@ class StageAssignmentStep(Step):
         ports_orientations = len(ports) != len(set(ports))
         if double_orientations or ports_orientations:
             self.finish_step_enabled = False
-            self.wizard.set_error(
-                "Please do not assign a orientation or device port twice.")
+            self.wizard.set_error("Please do not assign a orientation or device port twice.")
             return
 
         self.finish_step_enabled = True
@@ -573,9 +547,7 @@ class StageAssignmentStep(Step):
             polygon_cls_cfg = polygon_cls.get_default_parameters()
 
         self.polygon_cfg[stage] = (polygon_cls, polygon_cls_cfg)
-        self.assignment[stage] = (
-            Orientation[orientation.upper()],
-            DevicePort[port.upper()])
+        self.assignment[stage] = (Orientation[orientation.upper()], DevicePort[port.upper()])
 
         self.wizard.__reload__()
 
@@ -593,60 +565,43 @@ class StageAssignmentStep(Step):
 
     def _build_assignment_variables(self) -> tuple:
         """
-        Builds and returns Tkinter variables for orrientation and port selection.
+        Builds and returns Tkinter variables for orientation and port selection.
         """
         orientation_vars = {}
         port_vars = {}
         polygon_vars = {}
 
-        for stage in self.mover.available_stages:
-            orientation, port = self.assignment.get(
-                stage, self.DEFAULT_ASSIGNMENT)
-            polygon_cls, _ = self.polygon_cfg.get(
-                stage, (self.DEFAULT_POLYGON, {}))
+        for _stage in self.mover.available_stages:
+            orientation, port = self.assignment.get(_stage, self.DEFAULT_ASSIGNMENT)
+            polygon_cls, _ = self.polygon_cfg.get(_stage, (self.DEFAULT_POLYGON, {}))
 
             port_var = StringVar(self.wizard, port)
-            port_var.trace(
-                W, lambda *_, stage=stage: self.change_assignment(stage))
+            port_var.trace(W, lambda *_, stage=_stage: self.change_assignment(stage))
 
             orientation_var = StringVar(self.wizard, orientation)
-            orientation_var.trace(
-                W, lambda *_, stage=stage: self.change_assignment(stage))
+            orientation_var.trace(W, lambda *_, stage=_stage: self.change_assignment(stage))
 
             polygon_var = StringVar(self.wizard, polygon_cls.__name__)
-            polygon_var.trace(
-                W, lambda *_, stage=stage: self.change_assignment(stage))
+            polygon_var.trace(W, lambda *_, stage=_stage: self.change_assignment(stage))
 
-            orientation_vars[stage] = orientation_var
-            port_vars[stage] = port_var
-            polygon_vars[stage] = polygon_var
+            orientation_vars[_stage] = orientation_var
+            port_vars[_stage] = port_var
+            polygon_vars[_stage] = polygon_var
 
         return orientation_vars, port_vars, polygon_vars
 
 
 class ConfigureMoverStep(Step):
-    def __init__(self, wizard, mover) -> None:
-        super().__init__(
-            wizard,
-            self.build,
-            finish_step_enabled=True,
-            title="Stage Configuration")
-        self.mover: Type[MoverNew] = mover
+    def __init__(self, wizard: MoverWizard, mover: MoverNew) -> None:
+        super().__init__(wizard, self.build, finish_step_enabled=True, title="Stage Configuration")
+        self.mover = mover
 
-        self.xy_speed_var = DoubleVar(
-            self.wizard,
-            self.mover.speed_xy if self.mover._speed_xy else self.mover.DEFAULT_SPEED_XY)
-        self.z_speed_var = DoubleVar(
-            self.wizard,
-            self.mover.speed_z if self.mover._speed_z else self.mover.DEFAULT_SPEED_Z)
-        self.xy_acceleration_var = DoubleVar(
-            self.wizard,
-            self.mover.acceleration_xy if self.mover._acceleration_xy else self.mover.DEFAULT_ACCELERATION_XY)
-        self.z_lift_var = DoubleVar(
-            self.wizard,
-            self.mover.z_lift if self.mover._z_lift else self.mover.DEFAULT_Z_LIFT)
+        self.xy_speed_var = DoubleVar(self.wizard, self.mover.speed_xy)
+        self.z_speed_var = DoubleVar(self.wizard, self.mover.speed_z)
+        self.xy_acceleration_var = DoubleVar(self.wizard, self.mover.acceleration_xy)
+        self.z_lift_var = DoubleVar(self.wizard, self.mover.z_lift)
 
-    def build(self, frame: Type[CustomFrame]):
+    def build(self, frame: CustomFrame) -> None:
         """
         Builds step to configure stages.
         """
@@ -664,7 +619,8 @@ class ConfigureMoverStep(Step):
         Label(
             stage_properties_frame,
             anchor="w",
-            text="Speed Hint: A value of 0 (default) deactivates the speed control feature. The stage will move as fast as possible!"
+            text="Speed Hint: A value of 0 (default) deactivates the speed control feature. "
+                 "The stage will move as fast as possible!"
         ).pack(side=TOP, fill=X)
         Label(
             stage_properties_frame,
@@ -675,41 +631,40 @@ class ConfigureMoverStep(Step):
         self._build_entry_with_label(
             stage_properties_frame,
             self.xy_speed_var,
-            label="Movement speed xy direction (valid range: {}...{:.0e}um/s):".format(
-                self.mover.SPEED_LOWER_BOUND,
-                self.mover.SPEED_UPPER_BOUND),
-            unit="[um/s]")
-
+            label=f"Movement speed xy direction (valid range: {self.mover.SPEED_LOWER_BOUND}..."
+                  f"{self.mover.SPEED_UPPER_BOUND:.0e} um/s):",
+            unit="[um/s]"
+        )
         self._build_entry_with_label(
             stage_properties_frame,
             self.z_speed_var,
-            label="Movement speed z direction (valid range: {}...{:.0e}um/s):".format(
-                self.mover.SPEED_LOWER_BOUND,
-                self.mover.SPEED_UPPER_BOUND),
-            unit="[um/s]")
-
+            label=f"Movement speed z direction (valid range: {self.mover.SPEED_LOWER_BOUND}..."
+                  f"{self.mover.SPEED_UPPER_BOUND:.0e} um/s):",
+            unit="[um/s]"
+        )
         self._build_entry_with_label(
             stage_properties_frame,
             self.xy_acceleration_var,
-            label="Movement acceleration xy direction (valid range: {}...{:.0e}um/s^2):".format(
-                self.mover.ACCELERATION_LOWER_BOUND,
-                self.mover.ACCELERATION_UPPER_BOUND),
-            unit="[um/s^2]")
-
+            label=f"Movement acceleration xy direction (valid range: {self.mover.ACCELERATION_LOWER_BOUND}..."
+                  f"{self.mover.ACCELERATION_UPPER_BOUND:.0e} um/s^2):",
+            unit="[um/s^2]"
+        )
         self._build_entry_with_label(
             stage_properties_frame,
             self.z_lift_var,
             label="Z channel up-movement during xy movement:",
-            unit="[um]")
+            unit="[um]"
+        )
 
+    @staticmethod
     def _build_entry_with_label(
-            self,
-            parent,
-            var: Type[DoubleVar],
+            parent: CustomFrame,
+            var: DoubleVar,
             label: str = None,
-            unit: str = None) -> None:
+            unit: str = None
+    ) -> None:
         """
-        Builds an tkinter entry with label and unit.
+        Builds a tkinter entry with label and unit.
         """
         entry_frame = Frame(parent)
         entry_frame.pack(side=TOP, fill=X, pady=2)
@@ -725,17 +680,16 @@ class AxesCalibrationStep(Step):
     Wizard Step to calibrate stage axes.
     """
 
-    STAGE_AXIS_OPTIONS = bidict({o: " ".join(map(str, o))
-                                for o in product(Direction, Axis)})
+    STAGE_AXIS_OPTIONS = bidict({o: " ".join(map(str, o)) for o in product(Direction, Axis)})
 
-    def __init__(self, wizard, mover) -> None:
+    def __init__(self, wizard: CalibrationWizard, mover: MoverNew) -> None:
         """
         Constructor for new Wizard step for calibrating stage axes.
 
         Parameters
         ----------
-        master : Tk
-            Tk instance of the master toplevel
+        wizard : Tk
+            Tk instance of the Wizard toplevel
         mover : Mover
             Instance of the current mover.
         """
@@ -745,38 +699,32 @@ class AxesCalibrationStep(Step):
             on_reload=self.on_reload,
             on_next=self.on_next,
             title="Stage Axes Calibration")
-        self.mover: Type[MoverNew] = mover
+        self.mover = mover
         self.logger = getLogger()
 
         self.axes_mapping_vars = self._build_axes_mapping_vars()
 
-    def _build_axes_mapping_vars(self):
+    def _build_axes_mapping_vars(self) -> dict:
         """
         Builds and returns Tkinter variables for axes calibration.
         """
-        vars = {}
-        for calibration in self.mover.calibrations.values():
+        values = {}
+        for _calibration in self.mover.calibrations.values():
             # Get current mapping
             _current_mapping = {}
-            if calibration._axes_rotation and calibration._axes_rotation.is_valid:
-                _current_mapping = calibration._axes_rotation.mapping
+            if _calibration.axes_rotation and _calibration.axes_rotation.is_valid:
+                _current_mapping = _calibration.axes_rotation.mapping
 
-            for chip_axis in Axis:
-                _current_value = _current_mapping.get(
-                    chip_axis, (Direction.POSITIVE, chip_axis))
+            for _chip_axis in Axis:
+                _current_value = _current_mapping.get(_chip_axis, (Direction.POSITIVE, _chip_axis))
                 str_var = StringVar(self.wizard, _current_value)
-                str_var.trace(
-                    W,
-                    lambda *_,
-                    calibration=calibration,
-                    chip_axis=chip_axis: self.calibrate_axis(
-                        calibration,
-                        chip_axis))
-                vars.setdefault(calibration, {})[chip_axis] = str_var
+                str_var.trace(W, lambda *_, calibration=_calibration,
+                                        chip_axis=_chip_axis: self.calibrate_axis(calibration, chip_axis))
+                values.setdefault(_calibration, {})[_chip_axis] = str_var
 
-        return vars
+        return values
 
-    def build(self, frame: Type[CustomFrame]):
+    def build(self, frame: CustomFrame) -> None:
         """
         Builds step to calibrate axes.
 
@@ -789,26 +737,25 @@ class AxesCalibrationStep(Step):
 
         Label(
             frame,
-            text="In order for each stage to move relative to the chip coordinates, the direction of each axis of each stage must be defined. \n Postive Y-Axis: North of chip, Positive X-Axis: East of chip, Positive Z-Axis: Lift stage"
+            text="In order for each stage to move relative to the chip coordinates, "
+                 "the direction of each axis of each stage must be defined.\n"
+                 "Positive Y-Axis: North of chip, Positive X-Axis: East of chip, Positive Z-Axis: Lift stage"
         ).pack(side=TOP, fill=X)
 
-        for calibration in self.mover.calibrations.values():
+        for cal in self.mover.calibrations.values():
             stage_calibration_frame = CustomFrame(frame)
-            stage_calibration_frame.title = str(calibration)
+            stage_calibration_frame.title = str(cal)
             stage_calibration_frame.pack(side=TOP, fill=X, pady=2)
 
             for chip_axis in Axis:
                 chip_axis_frame = Frame(stage_calibration_frame)
                 chip_axis_frame.pack(side=TOP, fill=X)
 
-                Label(
-                    chip_axis_frame,
-                    text="Positive {}-Chip-axis points to ".format(chip_axis.name)
-                ).pack(side=LEFT)
+                Label(chip_axis_frame, text=f"Positive {chip_axis.name}-Chip-axis points to ").pack(side=LEFT)
 
                 OptionMenu(
                     chip_axis_frame,
-                    self.axes_mapping_vars[calibration][chip_axis],
+                    self.axes_mapping_vars[cal][chip_axis],
                     *self.STAGE_AXIS_OPTIONS.values(),
                 ).pack(side=LEFT)
 
@@ -816,13 +763,11 @@ class AxesCalibrationStep(Step):
 
                 wiggle_button = Button(
                     chip_axis_frame,
-                    text="Wiggle {}-Axis".format(
-                        chip_axis.name),
+                    text="Wiggle {}-Axis".format(chip_axis.name),
                     command=lambda axis=chip_axis,
-                    calibration=calibration: self.wiggle_axis(
-                        calibration,
-                        axis),
-                    state=NORMAL if calibration._axes_rotation.is_valid else DISABLED)
+                    calibration=cal: self.wiggle_axis(calibration, axis),
+                    state=NORMAL if cal.axes_rotation.is_valid else DISABLED
+                )
                 wiggle_button.pack(side=RIGHT)
 
     def on_reload(self) -> None:
@@ -830,7 +775,7 @@ class AxesCalibrationStep(Step):
         Callback, when coordinate system fixation step gets reloaded.
         Checks, if the current assignment is valid.
         """
-        if all(c._axes_rotation.is_valid for c in self.mover.calibrations.values()):
+        if all(cal.axes_rotation.is_valid for cal in self.mover.calibrations.values()):
             self.next_step_enabled = True
             self.wizard.set_error("")
         else:
@@ -844,16 +789,13 @@ class AxesCalibrationStep(Step):
         """
         try:
             self.mover.dump_axes_rotations()
-        except Exception as err:
-            messagebox.showerror(
-                "Error",
-                f"Failed to store axes rotation to file: {err}",
-                parent=self.wizard)
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to store axes rotation to file: {e}", parent=self.wizard)
             return False
 
         return True
 
-    def calibrate_axis(self, calibration: Type[Calibration], chip_axis: Axis):
+    def calibrate_axis(self, calibration: Calibration, chip_axis: Axis) -> None:
         """
         Callback, when user wants to change the axis rotation of a calibration.
         """
@@ -863,7 +805,7 @@ class AxesCalibrationStep(Step):
         calibration.update_axes_rotation(chip_axis, direction, stage_axis)
         self.wizard.__reload__()
 
-    def wiggle_axis(self, calibration: Type[Calibration], chip_axis: Axis):
+    def wiggle_axis(self, calibration: Calibration, chip_axis: Axis) -> None:
         """
         Callback, when user wants to wiggle an axis.
 
@@ -881,17 +823,15 @@ class AxesCalibrationStep(Step):
             run_with_wait_window(
                 self.wizard,
                 f"Wiggle {chip_axis} of {calibration}",
-                lambda: calibration.wiggle_axis(chip_axis))
+                lambda: calibration.wiggle_axis(chip_axis)
+            )
         except RuntimeError as e:
             self.logger.log(f"Wiggling {chip_axis} failed: {e}")
-            messagebox.showerror(
-                "Error"
-                f"Wiggling {chip_axis} failed: {e}",
-                parent=self.wizard)
+            messagebox.showerror("Error", f"Wiggling {chip_axis} failed: {e}", parent=self.wizard)
 
-    def _confirm_wiggle(self, axis) -> bool:
+    def _confirm_wiggle(self, axis: Axis) -> bool:
         """
-        Confirms with user if wiggeling is allowed.
+        Confirms with user if wiggling is allowed.
         """
         message = 'By proceeding this button will move the stage along the {} direction. \n\n'.format(axis) \
                   + 'Please make sure it has enough travel range(+-5mm) to avoid collision. \n\n' \
@@ -908,15 +848,15 @@ class CoordinatePairingStep(Step):
     Wizard Step to fully calibrate stages.
     """
 
-    def __init__(self, wizard, mover, chip) -> None:
+    def __init__(self, wizard: CalibrationWizard, mover: MoverNew, chip: Chip) -> None:
         """
         Constructor for new Wizard step for fully calibrate stages.
 
         Parameters
         ----------
-        master : Tk
-            Tk instance of the master toplevel
-        mover : Mover
+        wizard : Tk
+            Wizard instance of the wizard toplevel
+        mover : MoverNew
             Instance of the current mover.
         chip : Chip
             Instance of the current chip.
@@ -926,14 +866,14 @@ class CoordinatePairingStep(Step):
             self.build,
             finish_step_enabled=True,
             on_reload=self.on_reload,
-            title="Stage Configuration")
-        self.mover: Type[MoverNew] = mover
-        self.chip: Type[Chip] = chip
+            title="Stage Configuration"
+        )
+        self.mover = mover
+        self.chip = chip
+        self.experiment_manager = wizard.experiment_manager
 
-        self._use_input_stage_var = BooleanVar(
-            self.wizard, self.mover.has_input_calibration)
-        self._use_output_stage_var = BooleanVar(
-            self.wizard, self.mover.has_output_calibration)
+        self._use_input_stage_var = BooleanVar(self.wizard, self.mover.has_input_calibration)
+        self._use_output_stage_var = BooleanVar(self.wizard, self.mover.has_output_calibration)
         self._full_calibration_new_pairing_button = None
 
         self._coordinate_pairing_table = None
@@ -946,19 +886,17 @@ class CoordinatePairingStep(Step):
         Returns a list of current pairings.
         """
         pairings = []
-        for calibration in self.mover.calibrations.values():
-            _kabsch_rotation = calibration._kabsch_rotation
-            if _kabsch_rotation and _kabsch_rotation.is_valid:
-                pairings += _kabsch_rotation.pairings
+        for cal in self.mover.calibrations.values():
+            if cal.kabsch_rotation and cal.kabsch_rotation.is_valid:
+                pairings += cal.kabsch_rotation.pairings
 
-            _single_point_offset = calibration._single_point_offset
-            if _single_point_offset and _single_point_offset.is_valid:
-                if _single_point_offset.pairing not in pairings:
-                    pairings.append(_single_point_offset.pairing)
+            if cal.single_point_offset and cal.single_point_offset.is_valid:
+                if cal.single_point_offset.pairing not in pairings:
+                    pairings.append(cal.single_point_offset.pairing)
 
         return pairings
 
-    def build(self, frame: Type[CustomFrame]):
+    def build(self, frame: CustomFrame) -> None:
         """
         Builds step to fully calibrate axes.
 
@@ -971,10 +909,10 @@ class CoordinatePairingStep(Step):
 
         Label(
             frame,
-            text="To move the stages absolutely in chip coordinates, define at least 3 stage-chip-coordinate pairings to calculate the rotation. \n" +
-            "Note: After the first coordinate pairing, the stages can be moved approximatively absolute in chip coordinates.").pack(
-            side=TOP,
-            fill=X)
+            text="To move the stages absolutely in chip coordinates, define at least 3 stage-chip-coordinate pairings "
+                 "to calculate the rotation. \nNote: After the first coordinate pairing, "
+                 "the stages can be moved approximatively absolute in chip coordinates."
+        ).pack(side=TOP, fill=X)
 
         # Render frame to for current chip
         chip_frame = CustomFrame(frame)
@@ -983,10 +921,9 @@ class CoordinatePairingStep(Step):
 
         Label(
             chip_frame,
-            text="The calibration is calculated using several coordinate pairs consisting of chip and stage coordinates. \n"
-            "The following chip is used for calibration:").pack(
-            side=TOP,
-            fill=X)
+            text="The calibration is calculated using several coordinate pairs consisting of chip "
+                 "and stage coordinates. \nThe following chip is used for calibration:"
+        ).pack(side=TOP, fill=X)
 
         if self.chip:
             Label(
@@ -995,17 +932,8 @@ class CoordinatePairingStep(Step):
                 foreground='#4BB543'
             ).pack(side=LEFT, fill=X)
         else:
-            Label(
-                chip_frame,
-                text="No Chip imported!",
-                foreground='#FF3333'
-            ).pack(side=LEFT, fill=X)
-
-            Button(
-                chip_frame,
-                text="Import Chip",
-                command=self._on_chip_import
-            ).pack(side=RIGHT)
+            Label(chip_frame, text="No Chip imported!", foreground='#FF3333').pack(side=LEFT, fill=X)
+            Button(chip_frame, text="Import Chip", command=self._on_chip_import).pack(side=RIGHT)
 
         # Render table with all defined pairings
         pairings_frame = CustomFrame(frame)
@@ -1018,19 +946,15 @@ class CoordinatePairingStep(Step):
         self._coordinate_pairing_table = CustomTable(
             parent=pairings_table_frame,
             selectmode='extended',
-            column_headers=(
-                'ID',
-                'Stage',
-                'Stage Cooridnate',
-                'Device',
-                'Chip Coordinate'),
+            column_headers=['ID', 'Stage', 'Stage Coordinate', 'Device', 'Chip Coordinate'],
             rows=[(
                 str(idx),
                 str(p.calibration),
                 str(p.stage_coordinate),
                 str(p.device.short_str),
                 str(p.chip_coordinate)
-            ) for idx, p in enumerate(self.pairings)])
+            ) for idx, p in enumerate(self.pairings)]
+        )
 
         Button(
             pairings_frame,
@@ -1056,43 +980,26 @@ class CoordinatePairingStep(Step):
             stage_calibration_frame.pack(side=TOP, fill=X, pady=2)
 
             # SINGLE POINT STATE
+            Label(stage_calibration_frame, text="Single Point Fixation:").grid(row=0, column=0, padx=2, pady=2, sticky=W)
             Label(
                 stage_calibration_frame,
-                text="Single Point Fixation:"
-            ).grid(row=0, column=0, padx=2, pady=2, sticky=W)
-            Label(
-                stage_calibration_frame,
-                text=calibration._single_point_offset,
-                foreground='#4BB543' if calibration._single_point_offset.is_valid else "#FF3333",
-            ).grid(
-                row=0,
-                column=1,
-                padx=2,
-                pady=2,
-                sticky=W)
+                text=str(calibration.single_point_offset),
+                foreground='#4BB543' if calibration.single_point_offset.is_valid else "#FF3333",
+            ).grid(row=0, column=1, padx=2, pady=2, sticky=W)
 
             # GLOBAL STATE
+            Label(stage_calibration_frame, text="Global Transformation:").grid(row=1, column=0, padx=2, pady=2, sticky=W)
             Label(
                 stage_calibration_frame,
-                text="Global Transformation:"
-            ).grid(row=1, column=0, padx=2, pady=2, sticky=W)
-            Label(
-                stage_calibration_frame,
-                text=calibration._kabsch_rotation,
-                foreground='#4BB543' if calibration._kabsch_rotation.is_valid else "#FF3333",
-            ).grid(
-                row=1,
-                column=1,
-                padx=2,
-                pady=2,
-                sticky=W)
+                text=str(calibration.kabsch_rotation),
+                foreground='#4BB543' if calibration.kabsch_rotation.is_valid else "#FF3333",
+            ).grid( row=1, column=1, padx=2, pady=2, sticky=W)
 
-            if calibration._kabsch_rotation.is_valid:
-                rad, deg, per = calibration._kabsch_rotation.get_z_plane_angles()
+            if calibration.kabsch_rotation.is_valid:
+                rad, deg, per = calibration.kabsch_rotation.get_z_plane_angles()
                 Label(
                     stage_calibration_frame,
-                    text="Angle between XY Plane: "
-                    "{:.2f} rad - {:.2f}° - {:.2f}%".format(rad, deg, per)
+                    text=f"Angle between XY Plane: {rad:.2f} rad - {deg:.2f}° - {per:.2f}%"
                 ).grid(row=2, column=1, padx=2, pady=2, sticky=W)
 
         # FRAME FOR NEW PAIRING
@@ -1122,10 +1029,9 @@ class CoordinatePairingStep(Step):
             command=self._new_coordinate_pairing)
         self._full_calibration_new_pairing_button.pack(side=RIGHT)
 
-    def on_reload(self):
+    def on_reload(self) -> None:
         """
-        Callback, when wizard step gets reloaded.
-        Checks, if the all transformations are vald.
+        Callback, when wizard step gets reloaded. Checks, if all the transformations are valid.
         """
         if not self.chip:
             self.next_step_enabled = False
@@ -1133,26 +1039,23 @@ class CoordinatePairingStep(Step):
             self.wizard.set_error("Please import a chip to calibrate stages.")
             return
 
-        if not all(
-                c._single_point_offset.is_valid for c in self.mover.calibrations.values()):
+        if not all(c.single_point_offset.is_valid for c in self.mover.calibrations.values()):
             self.next_step_enabled = False
             self.finish_step_enabled = False
             self.wizard.set_error("Please fix for each stage a single point.")
             return
 
-        if not all(
-                c._kabsch_rotation.is_valid for c in self.mover.calibrations.values()):
+        if not all(c.kabsch_rotation.is_valid for c in self.mover.calibrations.values()):
             self.next_step_enabled = False
             self.finish_step_enabled = True
-            self.wizard.set_error(
-                "Please define for each stage at least three points to calibrate the stages globally.")
+            self.wizard.set_error("Please define for each stage at least three points to calibrate the stages globally.")
             return
 
         self.finish_step_enabled = True
         self.next_step_enabled = True
         self.wizard.set_error("")
 
-    def _reset_all_pairings(self):
+    def _reset_all_pairings(self) -> None:
         """
         Resets all pairings if the user confirms before.
         """
@@ -1163,7 +1066,8 @@ class CoordinatePairingStep(Step):
             "Reset all pairings",
             f"Are you sure to delete all {len(self.pairings)} coordinate pairs? "
             "This step cannot be undone.",
-                parent=self.wizard):
+            parent=self.wizard
+        ):
             return
 
         for calibration in self.mover.calibrations.values():
@@ -1171,10 +1075,9 @@ class CoordinatePairingStep(Step):
             calibration.reset_kabsch_rotation()
 
         self.pairings = []
-
         self.wizard.__reload__()
 
-    def _remove_pairings(self):
+    def _remove_pairings(self) -> None:
         """
         Removes all selected pairings.
         """
@@ -1186,11 +1089,11 @@ class CoordinatePairingStep(Step):
             messagebox.showerror(
                 "No pairings selected",
                 "No pairings were selected for deletion.",
-                parent=self.wizard)
+                parent=self.wizard
+            )
             return
 
-        whitelisted_pairings = [
-            p for p in self.pairings if p not in blacklisted_pairings]
+        whitelisted_pairings = [p for p in self.pairings if p not in blacklisted_pairings]
 
         # Reset all
         for calibration in self.mover.calibrations.values():
@@ -1215,8 +1118,7 @@ class CoordinatePairingStep(Step):
         for iid in checked_iids:
             pairing_idx = self._coordinate_pairing_table._tree.set(iid, 0)
             try:
-                selected_pairings.append(
-                    self.pairings[int(pairing_idx)])
+                selected_pairings.append(self.pairings[int(pairing_idx)])
             except (IndexError, ValueError):
                 continue
 
@@ -1226,7 +1128,7 @@ class CoordinatePairingStep(Step):
         """
         Creates a window to create a coordinate pairing.
         """
-        if self._check_for_exisiting_coordinate_window():
+        if self._check_for_existing_coordinate_window():
             return
 
         with_input_stage = self._use_input_stage_var.get()
@@ -1237,7 +1139,8 @@ class CoordinatePairingStep(Step):
                 "No Stages selected",
                 "No stages have been selected with which to create a coordinate pairing. "
                 "At least one stage must be selected.",
-                parent=self.wizard)
+                parent=self.wizard
+            )
             return
 
         try:
@@ -1245,22 +1148,19 @@ class CoordinatePairingStep(Step):
                 self.wizard,
                 self.mover,
                 self.chip,
-                experiment_manager=self.wizard.experiment_manager,
+                experiment_manager=self.experiment_manager,
                 on_finish=self._save_coordinate_pairing,
                 with_input_stage=with_input_stage,
                 with_output_stage=with_output_stage)
         except Exception as e:
-            messagebox.showerror(
-                "Error",
-                "Could not initiate a new coordinate pairing: {}".format(e),
-                parent=self.wizard)
+            messagebox.showerror("Error", f"Could not initiate a new coordinate pairing: {e}", parent=self.wizard)
 
     def _save_coordinate_pairing(self, pairings: List[CoordinatePairing]):
         """
         Delegates the list of pairings to the responsible calibrations.
         """
         for p in pairings:
-            if not p.calibration._single_point_offset.is_valid:
+            if not p.calibration.single_point_offset.is_valid:
                 p.calibration.update_single_point_offset(p)
 
             p.calibration.update_kabsch_rotation(p)
@@ -1268,19 +1168,20 @@ class CoordinatePairingStep(Step):
 
         self.wizard.__reload__()
 
-    def _check_for_exisiting_coordinate_window(self) -> bool:
+    def _check_for_existing_coordinate_window(self) -> bool:
         """
         Ensures that only one window exists to create a new coordinate pair.
-        Returns True if there is a exsiting window.
+        Returns True if there is an existing window.
         """
-        if self._coordinate_pairing_window is None or not try_to_lift_window(
-                self._coordinate_pairing_window):
+        if self._coordinate_pairing_window is None or not try_to_lift_window(self._coordinate_pairing_window):
             return False
 
         if not messagebox.askyesno(
             "New Coordinate-Pairing",
-            "You have an incomplete creation of a coordinate pair. Click Yes if you want to continue it or No if you want to create the new one.",
-                parent=self._coordinate_pairing_window):
+            "You have an incomplete creation of a coordinate pair. "
+            "Click Yes if you want to continue it or No if you want to create the new one.",
+            parent=self._coordinate_pairing_window
+        ):
             self._coordinate_pairing_window.cancel()
             self._coordinate_pairing_window = None
             return False
@@ -1291,10 +1192,10 @@ class CoordinatePairingStep(Step):
         """
         Callback, when user wants to import a chip
         """
-        if not self.wizard.experiment_manager:
+        if not self.experiment_manager:
             return
 
-        self.wizard.experiment_manager.main_window.open_import_chip()
-        self.chip = self.wizard.experiment_manager.chip
+        self.experiment_manager.main_window.open_import_chip()
+        self.chip = self.experiment_manager.chip
 
         self.wizard.__reload__()


### PR DESCRIPTION
Essentially, this is a rather big clean up and introduction of proper type annotations in the Movement and its related modules. No features are added nor any operating principle has changed. 

- Introduced type annotations wherever possible
- Corrected the wrong use of typing's `Type`. In almost every case we actually want to have an instance of a class and not the class object itself. This has lead to all sorts of warnings by type checkers.
- Separated `Polygons` and `Coordinates` into their own modules. 
- `Calibration` is now decoupled from `MoverNew`. We still have to inject the `update_main_model` method for now. 
- All unit tests have been adjusted. Though to verify proper operation a real movement/calibration test was done in the lab.